### PR TITLE
refactor(unit): Use a unit_prefix cfg opt to control systemd naming

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -32,8 +32,8 @@ type Agent struct {
 	peers map[string][]string
 }
 
-func New(registry *registry.Registry, events *registry.EventStream, machine *machine.Machine, ttl string) *Agent {
-	mgr := unit.NewSystemdManager(machine)
+func New(registry *registry.Registry, events *registry.EventStream, machine *machine.Machine, ttl string, unitPrefix string) *Agent {
+	mgr := unit.NewSystemdManager(machine, unitPrefix)
 
 	if ttl == "" {
 		ttl = DefaultServiceTTL

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	PublicIP    string   `toml:"public_ip"`
 	Verbosity   int      `toml:"verbosity"`
 	RawMetadata string   `toml:"metadata"`
+	UnitPrefix  string   `toml:"unit_prefix"`
 }
 
 func NewConfig() *Config {

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,7 @@ func New(cfg config.Config) *Server {
 	es := registry.NewEventStream(r)
 	es.Open()
 
-	a := agent.New(r, es, m, "")
+	a := agent.New(r, es, m, "", cfg.UnitPrefix)
 	e := engine.New(r, es, m)
 
 	return &Server{a, e, m, r, es}
@@ -43,7 +43,7 @@ func (self *Server) Configure(cfg *config.Config) {
 	if cfg.BootId != self.machine.BootId {
 		self.machine = machine.New(cfg.BootId, cfg.PublicIP, cfg.Metadata())
 		self.agent.Stop()
-		self.agent = agent.New(self.registry, self.events, self.machine, "")
+		self.agent = agent.New(self.registry, self.events, self.machine, "", cfg.UnitPrefix)
 		go self.agent.Run()
 	}
 }

--- a/unit/manager.go
+++ b/unit/manager.go
@@ -23,20 +23,21 @@ const (
 )
 
 type SystemdManager struct {
-	Systemd  *systemdDbus.Conn
-	Target   *SystemdTarget
-	Machine  *machine.Machine
-	unitPath string
-	dbusPath string
+	Systemd    *systemdDbus.Conn
+	Target     *SystemdTarget
+	Machine    *machine.Machine
+	UnitPrefix string
+	unitPath   string
+	dbusPath   string
 }
 
-func NewSystemdManager(machine *machine.Machine) *SystemdManager {
+func NewSystemdManager(machine *machine.Machine, unitPrefix string) *SystemdManager {
 	systemd := systemdDbus.New()
 
 	name := "coreinit-" + machine.BootId + ".target"
 	target := NewSystemdTarget(name)
 
-	mgr := &SystemdManager{systemd, target, machine, defaultSystemdRuntimePath, defaultSystemdDbusPath}
+	mgr := &SystemdManager{systemd, target, machine, unitPrefix, defaultSystemdRuntimePath, defaultSystemdDbusPath}
 
 	mgr.writeUnit(target.Name(), "")
 
@@ -206,9 +207,17 @@ func (m *SystemdManager) getLocalPath(name string) string {
 }
 
 func (m *SystemdManager) addUnitNamePrefix(name string) string {
-	return fmt.Sprintf("%s.%s", m.Machine.BootId, name)
+	if len(m.UnitPrefix) > 0 {
+		return fmt.Sprintf("%s.%s", m.UnitPrefix, name)
+	} else {
+		return name
+	}
 }
 
 func (m *SystemdManager) stripUnitNamePrefix(name string) string {
-	return strings.TrimPrefix(name, fmt.Sprintf("%s.", m.Machine.BootId))
+	if len(m.UnitPrefix) > 0 {
+		return strings.TrimPrefix(name, fmt.Sprintf("%s.", m.UnitPrefix))
+	} else {
+		return name
+	}
 }


### PR DESCRIPTION
The bootid cfg opt no longer affects the prefix of systemd units
placed by coreinit. Use the new unit_prefix opt.
