### PR TITLE
fix(machine): Use IPv4 addr when grabbing default public IP

### DIFF
--- a/machine/machine.go
+++ b/machine/machine.go
@@ -76,5 +76,14 @@ func getLocalIP() string {
 		return ""
 	}
 
-	return strings.SplitN(addrs[0].String(), "/", 2)[0]
+	for _, addr := range addrs {
+		// Attempt to parse the address in CIDR notation
+		// and assert it is IPv4
+		ip, _, err := net.ParseCIDR(addr.String())
+		if err == nil && ip.To4() != nil {
+			return ip.String()
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
This makes the getLocalIP function behave as intended. It finds the first IPv4 address bound to eth0. Before, it would have grabbed the first IPv4 or IPv6 address it found.
