### PR TITLE
fix(etcd): Use strong consistency in etcd watchers

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -24,14 +24,14 @@ func New(cfg config.Config) *Server {
 	m := machine.New(cfg.BootId, cfg.PublicIP, cfg.Metadata())
 
 	regClient := etcd.NewClient(cfg.EtcdServers)
-	regClient.SetConsistency(etcd.WEAK_CONSISTENCY)
+	regClient.SetConsistency(etcd.STRONG_CONSISTENCY)
 	r := registry.New(regClient)
 
 	eb := event.NewEventBus()
 	eb.Listen()
 
 	eventClient := etcd.NewClient(cfg.EtcdServers)
-	eventClient.SetConsistency(etcd.WEAK_CONSISTENCY)
+	eventClient.SetConsistency(etcd.STRONG_CONSISTENCY)
 	es := registry.NewEventStream(eventClient)
 
 	a, err := agent.New(r, eb, m, cfg.AgentTTL, cfg.UnitPrefix)


### PR DESCRIPTION
In the event that fleet is watching an etcd peer that is behind in its log updates, it will receive events as if they happened much later than reality. This is quite common in the event that a new fleet machine is brought online watching an etcd peer on the same machine, which then has to join an established cluster.

Using strong consistency in our etcd watchers means fleet event streams will get events as they happen, only dealing with network latency - not the inherent latency of etcd followers.
