### PR TITLE
Fix #93: Add description to list units

### DIFF
--- a/fleetctl/list_units.go
+++ b/fleetctl/list_units.go
@@ -35,19 +35,19 @@ func listUnitsAction(c *cli.Context) {
 		fmt.Fprintln(out, "UNIT\tLOAD\tACTIVE\tSUB\tDESC\tMACHINE")
 	}
 
-	names := make(map[string]bool, 0)
+	names := make(map[string]string, 0)
 	sortable := make(sort.StringSlice, 0)
 
 	for _, p := range r.GetAllPayloads() {
 		if _, ok := names[p.Name]; !ok {
-			names[p.Name] = true
+			names[p.Name] = p.Description()
 			sortable = append(sortable, p.Name)
 		}
 	}
 
 	for _, j := range r.GetAllJobs() {
 		if _, ok := names[j.Name]; !ok {
-			names[j.Name] = true
+			names[j.Name] = j.Description()
 			sortable = append(sortable, j.Name)
 		}
 	}
@@ -57,13 +57,14 @@ func listUnitsAction(c *cli.Context) {
 	full := c.Bool("full")
 	for _, name := range sortable {
 		state := r.GetJobState(name)
-		printJobState(name, state, full)
+		description := names[name]
+		printJobState(name, description, state, full)
 	}
 
 	out.Flush()
 }
 
-func printJobState(name string, js *job.JobState, full bool) {
+func printJobState(name, description string, js *job.JobState, full bool) {
 	loadState := "-"
 	activeState := "-"
 	subState := "-"
@@ -85,5 +86,5 @@ func printJobState(name string, js *job.JobState, full bool) {
 		}
 	}
 
-	fmt.Fprintf(out, "%s\t%s\t%s\t%s\t-\t%s\n", name, loadState, activeState, subState, mach)
+	fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%s\n", name, loadState, activeState, subState, description, mach)
 }

--- a/job/job.go
+++ b/job/job.go
@@ -29,3 +29,7 @@ func (self *Job) Requirements() map[string][]string {
 		return self.JobRequirements
 	}
 }
+
+func (self *Job) Description() string {
+	return self.Payload.Description()
+}

--- a/job/payload.go
+++ b/job/payload.go
@@ -50,3 +50,7 @@ func (jp *JobPayload) Conflicts() []string {
 		return make([]string, 0)
 	}
 }
+
+func (jp *JobPayload) Description() string {
+	return jp.Unit.Description()
+}

--- a/unit/file.go
+++ b/unit/file.go
@@ -46,6 +46,10 @@ func (self *SystemdUnitFile) Requirements() map[string][]string {
 	return requirements
 }
 
+func (self *SystemdUnitFile) Description() string {
+	return self.GetSection("Unit")["Description"]
+}
+
 func (self *SystemdUnitFile) String() string {
 	var serialized string
 	for section, keyMap := range self.Contents {

--- a/unit/file_test.go
+++ b/unit/file_test.go
@@ -37,3 +37,22 @@ WantedBy=fleet-ping.target
 		t.Fatalf("Install.WantedBy is incorrect")
 	}
 }
+
+func TestDescription(t *testing.T) {
+	contents := `
+[Unit]
+Description = Foo
+
+[Service]
+ExecStart=echo "ping";
+ExecStop=echo "pong";
+
+[Install]
+WantedBy=fleet-ping.target
+`
+
+	unitFile := NewSystemdUnitFile(contents)
+	if unitFile.Description() != "Foo" {
+		t.Fatalf("Unit.Description is incorrect")
+	}
+}


### PR DESCRIPTION
Get the unit description from the systemd unit to show it in the unit listing.
As an alternative implementation, the description could be added as a field to job.Job and job.Payload.

:warning: I have not `fleet` running anywhere yet, so I haven't really tested this. I haven't seen any test for `fleetctl` in the repo either, so I don't know what's your convention about testing the ctl.
