### PR TITLE
fix(fleetctl): Default empty description to hyphen

### DIFF
--- a/fleetctl/list_units.go
+++ b/fleetctl/list_units.go
@@ -70,6 +70,10 @@ func printJobState(name, description string, js *job.JobState, full bool) {
 	subState := "-"
 	mach := "-"
 
+	if description == "" {
+		description = "-"
+	}
+
 	if js != nil {
 		loadState = js.LoadState
 		activeState = js.ActiveState


### PR DESCRIPTION
```
$ ./bin/fleetctl list-units
UNIT            LOAD    ACTIVE  SUB DESC                    MACHINE
longdesc.service    -   -   -   What a long description you have!   -
nodesc.service      -   -   -   -                   -
```
