### PR TITLE
refactor(unit): Use all options provided in unit file

### DIFF
--- a/job/payload.go
+++ b/job/payload.go
@@ -1,6 +1,7 @@
 package job
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -49,4 +50,73 @@ func (jp *JobPayload) Conflicts() []string {
 	} else {
 		return make([]string, 0)
 	}
+}
+
+func (jp *JobPayload) UnmarshalJSON(data []byte) error {
+	var jpm jobPayloadModel
+	err := json.Unmarshal(data, &jpm)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Unable to JSON-deserialize object: %s", err))
+	}
+
+	var opts map[string]map[string][]string
+	if len(jpm.Unit.ContentsV1) > 0 {
+		opts = jpm.Unit.ContentsV1
+	} else {
+		opts = mapUnitContentsV0ToV1(jpm.Unit.ContentsV0)
+	}
+
+	jp.Name = jpm.Name
+	jp.Unit = unit.SystemdUnitFile{Options: opts}
+
+	return nil
+}
+
+func (jp *JobPayload) MarshalJSON() ([]byte, error) {
+	ufm := unitFileModel{
+		ContentsV0: mapUnitContentsV1ToV0(jp.Unit.Options),
+		ContentsV1: jp.Unit.Options,
+	}
+	jpm := jobPayloadModel{Name: jp.Name, Unit: ufm}
+	return json.Marshal(jpm)
+}
+
+// unitFileModel is just used for serialization
+type unitFileModel struct {
+	ContentsV0 map[string]map[string]string   `json:"contents"`
+	ContentsV1 map[string]map[string][]string `json:"contentsV1"`
+}
+
+// jobPayloadModel is just used for serialization
+type jobPayloadModel struct {
+	Name string
+	Unit unitFileModel
+}
+
+// mapUnitContentsV0ToV1 transforms the old unit contents format to the new format
+func mapUnitContentsV0ToV1(contents map[string]map[string]string) map[string]map[string][]string {
+	coerced := make(map[string]map[string][]string, len(contents))
+	for section, options := range contents {
+		coerced[section] = make(map[string][]string, len(options))
+		for key, value := range options {
+			coerced[section][key] = []string{value}
+		}
+	}
+	return coerced
+}
+
+// mapUnitContentsV1ToV0 transforms the units from the new format to the old. This
+// is a lossy operation.
+func mapUnitContentsV1ToV0(contents map[string]map[string][]string) map[string]map[string]string {
+	coerced := make(map[string]map[string]string, len(contents))
+	for section, options := range contents {
+		coerced[section] = make(map[string]string, 0)
+		for key, values := range options {
+			if len(values) == 0 {
+				continue
+			}
+			coerced[section][key] = values[len(values)-1]
+		}
+	}
+	return coerced
 }

--- a/job/payload_test.go
+++ b/job/payload_test.go
@@ -1,6 +1,7 @@
 package job
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/coreos/fleet/unit"
@@ -78,5 +79,65 @@ func TestJobPayloadConflictsNotProvided(t *testing.T) {
 
 	if len(conflicts) > 0 {
 		t.Fatalf("Expected no conflicts, received %v", conflicts)
+	}
+}
+
+func TestMapUnitContentsV0ToV1(t *testing.T) {
+	contents := map[string]map[string]string{
+		"key1": map[string]string{
+			"subkey1": "value1",
+			"subkey2": "value2",
+		},
+		"key2": map[string]string{
+			"subkey3": "value3",
+			"subkey4": "value4",
+		},
+	}
+
+	expected := map[string]map[string][]string{
+		"key1": map[string][]string{
+			"subkey1": []string{"value1"},
+			"subkey2": []string{"value2"},
+		},
+		"key2": map[string][]string{
+			"subkey3": []string{"value3"},
+			"subkey4": []string{"value4"},
+		},
+	}
+
+	actual := mapUnitContentsV0ToV1(contents)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Map func did not produce expected output.\nActual=%v\nExpected=%v", actual, expected)
+	}
+}
+
+func TestMapUnitContentsV1ToV0(t *testing.T) {
+	contents := map[string]map[string][]string{
+		"key1": map[string][]string{
+			"subkey1": []string{"value1", "altvalue1"},
+			"subkey2": []string{"value2"},
+		},
+		"key2": map[string][]string{
+			"subkey3": []string{"value3"},
+			"subkey4": []string{"value4", "altvalue2"},
+		},
+	}
+
+	expected := map[string]map[string]string{
+		"key1": map[string]string{
+			"subkey1": "altvalue1",
+			"subkey2": "value2",
+		},
+		"key2": map[string]string{
+			"subkey3": "value3",
+			"subkey4": "altvalue2",
+		},
+	}
+
+	actual := mapUnitContentsV1ToV0(contents)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Map func did not produce expected output.\nActual=%v\nExpected=%v", actual, expected)
 	}
 }

--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -110,7 +110,7 @@ func (m *SystemdManager) getUnitsByTarget(target *SystemdTarget) []SystemdUnit {
 }
 
 func (m *SystemdManager) StartJob(job *job.Job) {
-	job.Payload.Unit.SetField("Install", "WantedBy", m.Target.Name())
+	job.Payload.Unit.ReplaceField("Install", "WantedBy", m.Target.Name())
 
 	name := m.addUnitNamePrefix(job.Name)
 	m.writeUnit(name, job.Payload.Unit.String())


### PR DESCRIPTION
This requires a new format in a Registry, but it maintains
support for the old format for now.
