### PR TITLE
feat(ssh): ssh detects unit or machine automatically

### DIFF
--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -9,13 +9,14 @@ import (
 	"github.com/coreos/fleet/third_party/github.com/codegangsta/cli"
 
 	"github.com/coreos/fleet/machine"
+	"github.com/coreos/fleet/registry"
 	"github.com/coreos/fleet/ssh"
 )
 
 func newSSHCommand() cli.Command {
 	return cli.Command{
-		Name:	"ssh",
-		Usage:	"Open interactive shell on a machine in the cluster",
+		Name:  "ssh",
+		Usage: "Open interactive shell on a machine in the cluster",
 		Description: `Open an interactive shell on a specific machine in the cluster or on the machine where the specified unit is located.
 
 Open a shell on a machine:
@@ -23,54 +24,45 @@ fleetctl ssh 2444264c-eac2-4eff-a490-32d5e5e4af24
 
 Open a shell from your laptop, to the machine running a specific unit, using a
 cluster member as a bastion host:
-fleetctl --tunnel 10.10.10.10 ssh -u foo.service
+fleetctl --tunnel 10.10.10.10 ssh foo.service
+
+Tip: fleetctl tries to detect whether your first argument is a machine or a unit. To skip this check use the flags "-m" and "-u".
 
 Pro-Tip: Create an alias for --tunnel:
 Add "alias fleetctl=fleetctl --tunnel 10.10.10.10" to your bash profile.
 Now you can run all fleet commands locally.`,
-		Action:	sshAction,
 		Flags: []cli.Flag{
+			cli.StringFlag{"machine, m", "", "Open SSH connection to a specific machine."},
 			cli.StringFlag{"unit, u", "", "Open SSH connection to machine running provided unit."},
 		},
+		Action: sshAction,
 	}
 }
 
 func sshAction(c *cli.Context) {
-	r := getRegistry()
-
-	args := c.Args()
 	unit := c.String("unit")
-	if len(args) == 0 && unit == "" {
-		log.Fatalf("Provide one machine or unit")
+	machine := c.String("machine")
+
+	if unit != "" && machine != "" {
+		log.Fatal("Both flags, machine and unit provided, please specify only one")
 	}
 
+	r := getRegistry()
+	args := c.Args()
 	var addr string
-	if unit == "" {
-		lookup := args[0]
+
+	switch {
+	case machine != "":
+		addr, _ = findAddressInMachineList(r, machine)
+	case unit != "":
+		addr, _ = findAddressInRunningUnits(r, unit)
+	default:
+		addr = globalLookup(r, args)
 		args = args[1:]
-		states := r.GetActiveMachines()
-		var match *machine.MachineState
-		for i, _ := range states {
-			machState := states[i]
-			if !strings.HasPrefix(machState.BootId, lookup) {
-				continue
-			} else if match != nil {
-				log.Fatalf("Found more than one Machine, be more specfic")
-			}
-			match = &machState
-		}
+	}
 
-		if match == nil {
-			log.Fatalf("Could not find provided Machine")
-		}
-
-		addr = fmt.Sprintf("%s:22", match.PublicIP)
-	} else {
-		js := r.GetJobState(unit)
-		if js == nil {
-			log.Fatalf("Requested unit %s does not appear to be running", unit)
-		}
-		addr = fmt.Sprintf("%s:22", js.MachineState.PublicIP)
+	if addr == "" {
+		log.Fatalf("Requested machine could not be found")
 	}
 
 	var err error
@@ -111,4 +103,55 @@ func sshAction(c *cli.Context) {
 			log.Fatalf(err.Error())
 		}
 	}
+}
+
+func globalLookup(r *registry.Registry, args []string) string {
+	if len(args) == 0 {
+		log.Fatalf("Provide one machine or unit")
+	}
+
+	lookup := args[0]
+
+	machineAddr, machineOk := findAddressInMachineList(r, lookup)
+	unitAddr, unitOk := findAddressInRunningUnits(r, lookup)
+
+	switch {
+	case machineOk && unitOk:
+		log.Fatalf("Ambiguous argument, both machine and unit found for `%s`.\nPlease use flag `-m` or `-u` to refine the search", lookup)
+	case machineOk:
+		return machineAddr
+	case unitOk:
+		return unitAddr
+	}
+
+	return ""
+}
+
+func findAddressInMachineList(r *registry.Registry, lookup string) (string, bool) {
+	states := r.GetActiveMachines()
+	var match *machine.MachineState
+
+	for i, _ := range states {
+		machState := states[i]
+		if !strings.HasPrefix(machState.BootId, lookup) {
+			continue
+		} else if match != nil {
+			log.Fatalf("Found more than one Machine, be more specfic")
+		}
+		match = &machState
+	}
+
+	if match == nil {
+		return "", false
+	}
+
+	return fmt.Sprintf("%s:22", match.PublicIP), true
+}
+
+func findAddressInRunningUnits(r *registry.Registry, lookup string) (string, bool) {
+	js := r.GetJobState(lookup)
+	if js == nil {
+		return "", false
+	}
+	return fmt.Sprintf("%s:22", js.MachineState.PublicIP), true
 }


### PR DESCRIPTION
I took a stab to remove the `-u` flag from the ssh command. It checks registered machines first and if it cannot find any with the given lookup name it tries to find a machine for the given service.

Fixes #174
