### PR TITLE
refactor(getRegistry): Remove unused parameter in `getRegistry`.

### DIFF
--- a/fleetctl/cat.go
+++ b/fleetctl/cat.go
@@ -19,7 +19,7 @@ the correct version of a unit is running.`,
 }
 
 func printUnitAction(c *cli.Context) {
-	r := getRegistry(c)
+	r := getRegistry()
 
 	if len(c.Args()) != 1 {
 		fmt.Println("One unit file must be provided.")

--- a/fleetctl/cmd.go
+++ b/fleetctl/cmd.go
@@ -42,7 +42,7 @@ OPTIONS:
 `
 }
 
-func getRegistry(context *cli.Context) *registry.Registry {
+func getRegistry() *registry.Registry {
 	tun := getTunnelFlag()
 	endpoint := getEndpointFlag()
 

--- a/fleetctl/destroy.go
+++ b/fleetctl/destroy.go
@@ -22,7 +22,7 @@ Destroyed units are impossible to start unless re-submitted.`,
 }
 
 func destroyUnitsAction(c *cli.Context) {
-	r := getRegistry(c)
+	r := getRegistry()
 
 	for _, v := range c.Args() {
 		name := path.Base(v)

--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -37,7 +37,7 @@ func journalAction(c *cli.Context) {
 	}
 	jobName := c.Args()[0]
 
-	r := getRegistry(c)
+	r := getRegistry()
 	js := r.GetJobState(jobName)
 
 	if js == nil {

--- a/fleetctl/list_machines.go
+++ b/fleetctl/list_machines.go
@@ -28,7 +28,7 @@ fleetctl list-machines --full`,
 }
 
 func listMachinesAction(c *cli.Context) {
-	r := getRegistry(c)
+	r := getRegistry()
 
 	if !c.Bool("no-legend") {
 		fmt.Fprintln(out, "MACHINE\tIP\tMETADATA")

--- a/fleetctl/list_units.go
+++ b/fleetctl/list_units.go
@@ -29,7 +29,7 @@ fleetctl list-units --full`,
 }
 
 func listUnitsAction(c *cli.Context) {
-	r := getRegistry(c)
+	r := getRegistry()
 
 	if !c.Bool("no-legend") {
 		fmt.Fprintln(out, "UNIT\tLOAD\tACTIVE\tSUB\tDESC\tMACHINE")

--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -36,7 +36,7 @@ Now you can run all fleet commands locally.`,
 }
 
 func sshAction(c *cli.Context) {
-	r := getRegistry(c)
+	r := getRegistry()
 
 	args := c.Args()
 	unit := c.String("unit")

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -38,7 +38,7 @@ fleetctl start --require region=us-east foo.service`,
 
 func startUnitAction(c *cli.Context) {
 	var err error
-	r := getRegistry(c)
+	r := getRegistry()
 
 	payloads := make([]job.JobPayload, len(c.Args()))
 	for i, v := range c.Args() {

--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -31,7 +31,7 @@ fleetctl status myservice/*`,
 }
 
 func statusUnitsAction(c *cli.Context) {
-	r := getRegistry(c)
+	r := getRegistry()
 
 	for i, v := range c.Args() {
 		// This extra newline here to match systemctl status output

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -27,7 +27,7 @@ fleetctl stop myservice/*`,
 }
 
 func stopUnitAction(c *cli.Context) {
-	r := getRegistry(c)
+	r := getRegistry()
 
 	for _, v := range c.Args() {
 		name := path.Base(v)

--- a/fleetctl/submit.go
+++ b/fleetctl/submit.go
@@ -25,7 +25,7 @@ fleetctl submit myservice/*`,
 }
 
 func submitUnitsAction(c *cli.Context) {
-	r := getRegistry(c)
+	r := getRegistry()
 
 	// First, validate each of the provided payloads
 	payloads := make([]job.JobPayload, len(c.Args()))


### PR DESCRIPTION
It looks like `cli.Context` is not used at all inside the `getRegistry` function.
This PR removes that coupling.
