### PR TITLE
refactor(fleetctl): Registry bridge interface.

### DIFF
--- a/fleetctl/cat.go
+++ b/fleetctl/cat.go
@@ -12,20 +12,18 @@ import (
 
 func newCatUnitCommand() cli.Command {
 	return cli.Command{
-		Name:	"cat",
-		Usage:	"Output the contents of a submitted unit",
+		Name:  "cat",
+		Usage: "Output the contents of a submitted unit",
 		Description: `Outputs the unit file that is currently loaded in the cluster. Useful to verify
 the correct version of a unit is running.`,
-		Flags:	[]cli.Flag{
+		Flags: []cli.Flag{
 			cli.BoolFlag{"verify", "Verify unit file signatures using local SSH identities"},
 		},
-		Action:	printUnitAction,
+		Action: printUnitAction,
 	}
 }
 
 func printUnitAction(c *cli.Context) {
-	r := getRegistry()
-
 	toVerify := c.Bool("verify")
 	var sv *sign.SignatureVerifier
 	if toVerify {
@@ -43,7 +41,7 @@ func printUnitAction(c *cli.Context) {
 	}
 
 	name := path.Base(c.Args()[0])
-	payload := r.GetPayload(name)
+	payload := registryCtl.GetPayload(name)
 
 	if payload == nil {
 		fmt.Println("Job not found.")
@@ -51,7 +49,7 @@ func printUnitAction(c *cli.Context) {
 	}
 
 	if toVerify {
-		s := r.GetSignatureSetOfPayload(name)
+		s := registryCtl.GetSignatureSetOfPayload(name)
 		ok, err := sv.VerifyPayload(payload, s)
 		if !ok || err != nil {
 			fmt.Printf("Check of payload %s failed: %v\n", payload.Name, err)

--- a/fleetctl/cmd.go
+++ b/fleetctl/cmd.go
@@ -26,6 +26,7 @@ import (
 
 var out *tabwriter.Writer
 var flagset *flag.FlagSet = flag.NewFlagSet("fleetctl", flag.ExitOnError)
+var registryCtl Registry
 
 func init() {
 	out = new(tabwriter.Writer)
@@ -117,6 +118,7 @@ func main() {
 	gconf, _ := globalconf.NewWithOptions(&opts)
 	gconf.ParseSet("", flagset)
 
+	registryCtl = NewRegistry(getRegistry())
 	app.Run(os.Args)
 }
 

--- a/fleetctl/destroy.go
+++ b/fleetctl/destroy.go
@@ -8,8 +8,8 @@ import (
 
 func newDestroyUnitCommand() cli.Command {
 	return cli.Command{
-		Name:	"destroy",
-		Usage:	"Destroy one or more units in the cluster",
+		Name:  "destroy",
+		Usage: "Destroy one or more units in the cluster",
 		Description: `Completely remove a running or submitted unit from the cluster.
 
 Instructs systemd on the host machine to stop the unit, deferring to systemd
@@ -17,17 +17,15 @@ completely for any custom stop directives (i.e. ExecStop option in the unit
 file).
 
 Destroyed units are impossible to start unless re-submitted.`,
-		Action:	destroyUnitsAction,
+		Action: destroyUnitsAction,
 	}
 }
 
 func destroyUnitsAction(c *cli.Context) {
-	r := getRegistry()
-
 	for _, v := range c.Args() {
 		name := path.Base(v)
-		r.StopJob(name)
-		r.DestroyPayload(name)
-		r.DestroySignatureSetOfPayload(name)
+		registryCtl.StopJob(name)
+		registryCtl.DestroyPayload(name)
+		registryCtl.DestroySignatureSetOfPayload(name)
 	}
 }

--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -13,9 +13,9 @@ import (
 
 func newJournalCommand() cli.Command {
 	return cli.Command{
-		Name:	"journal",
-		Usage:	"Print the journal of a unit in the cluster to stdout",
-		Action:	journalAction,
+		Name:   "journal",
+		Usage:  "Print the journal of a unit in the cluster to stdout",
+		Action: journalAction,
 		Description: `Outputs the journal of a unit by connecting to the machine that the unit
 occupies.
 
@@ -38,8 +38,7 @@ func journalAction(c *cli.Context) {
 	}
 	jobName := c.Args()[0]
 
-	r := getRegistry()
-	js := r.GetJobState(jobName)
+	js := registryCtl.GetJobState(jobName)
 
 	if js == nil {
 		fmt.Printf("%s does not appear to be running\n", jobName)

--- a/fleetctl/list_machines.go
+++ b/fleetctl/list_machines.go
@@ -9,8 +9,8 @@ import (
 
 func newListMachinesCommand() cli.Command {
 	return cli.Command{
-		Name:	"list-machines",
-		Usage:	"Enumerate the current hosts in the cluster",
+		Name:  "list-machines",
+		Usage: "Enumerate the current hosts in the cluster",
 		Description: `Lists all active machines within the cluster. Previously active machines will
 not appear in this list.
 
@@ -19,7 +19,7 @@ fleetctl list-machines --no-legend
 
 Output the list without truncation:
 fleetctl list-machines --full`,
-		Action:	listMachinesAction,
+		Action: listMachinesAction,
 		Flags: []cli.Flag{
 			cli.BoolFlag{"full, l", "Do not ellipsize fields on output"},
 			cli.BoolFlag{"no-legend", "Do not print a legend (column headers)"},
@@ -28,15 +28,13 @@ fleetctl list-machines --full`,
 }
 
 func listMachinesAction(c *cli.Context) {
-	r := getRegistry()
-
 	if !c.Bool("no-legend") {
 		fmt.Fprintln(out, "MACHINE\tIP\tMETADATA")
 	}
 
 	full := c.Bool("full")
 
-	for _, m := range r.GetActiveMachines() {
+	for _, m := range registryCtl.GetActiveMachines() {
 		mach := m.BootId
 		if !full {
 			mach = ellipsize(mach, 8)

--- a/fleetctl/list_units_test.go
+++ b/fleetctl/list_units_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/coreos/fleet/job"
+	"github.com/coreos/fleet/unit"
+)
+
+func newTestRegistryForListUnits(payloads []job.JobPayload, jobs []job.Job) Registry {
+	j := []job.Job{*job.NewJob("pong.service", map[string][]string{}, nil, nil)}
+	p := []job.JobPayload{*job.NewJobPayload("echo.service", *unit.NewSystemdUnitFile("Echo"))}
+
+	if payloads != nil {
+		for _, jp := range payloads {
+			p = append(p, jp)
+		}
+	}
+
+	if jobs != nil {
+		for _, job := range jobs {
+			j = append(j, job)
+		}
+	}
+
+	return TestRegistry{jobs: j, payloads: p}
+}
+
+func TestGetAllJobs(t *testing.T) {
+	registryCtl = newTestRegistryForListUnits(nil, nil)
+
+	names, sortable := findAllUnits(false)
+	if len(names) != 2 {
+		t.Errorf("Expected to find two units: %v\n", names)
+	}
+
+	if sortable[0] != "echo.service" {
+		t.Errorf("Expected to find echo.service as the first name, but it was %s\n", sortable[0])
+	}
+
+	if sortable[1] != "pong.service" {
+		t.Errorf("Expected to find pong.service as the second name, but it was %s\n", sortable[0])
+	}
+}
+
+func TestIgnoreDuplicatedUnits(t *testing.T) {
+	jp := []job.JobPayload{*job.NewJobPayload("echo.service", *unit.NewSystemdUnitFile("Echo"))}
+	registryCtl = newTestRegistryForListUnits(jp, nil)
+
+	names, sortable := findAllUnits(false)
+	if len(names) != 2 {
+		t.Errorf("Expected to find two units: %v\n", names)
+	}
+
+	if sortable[0] != "echo.service" {
+		t.Errorf("Expected to find echo.service as the first name, but it was %s\n", sortable[0])
+	}
+
+	if sortable[1] != "pong.service" {
+		t.Errorf("Expected to find pong.service as the second name, but it was %s\n", sortable[0])
+	}
+}
+
+func TestJobDescription(t *testing.T) {
+	contents := `[Unit]
+Description=PING
+`
+	jp := job.NewJobPayload("ping.service", *unit.NewSystemdUnitFile(contents))
+	j := []job.Job{*job.NewJob("ping.service", map[string][]string{}, jp, nil)}
+	registryCtl = newTestRegistryForListUnits(nil, j)
+
+	names, _ := findAllUnits(false)
+	if len(names) != 3 {
+		t.Errorf("Expected to find three units: %v\n", names)
+	}
+
+	if names["ping.service"] != "PING" {
+		t.Errorf("Expected to have `PING` as a description, but it was %s\n", names["ping.service"])
+	}
+}
+
+func TestPayloadDescription(t *testing.T) {
+	contents := `[Unit]
+Description=PING
+`
+	jp := []job.JobPayload{*job.NewJobPayload("ping.service", *unit.NewSystemdUnitFile(contents))}
+	registryCtl = newTestRegistryForListUnits(jp, nil)
+
+	names, _ := findAllUnits(false)
+	if len(names) != 3 {
+		t.Errorf("Expected to find three units: %v\n", names)
+	}
+
+	if names["ping.service"] != "PING" {
+		t.Errorf("Expected to have `PING` as a description, but it was %s\n", names["ping.service"])
+	}
+}

--- a/fleetctl/registry.go
+++ b/fleetctl/registry.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"github.com/coreos/fleet/job"
+	"github.com/coreos/fleet/machine"
+	"github.com/coreos/fleet/registry"
+	"github.com/coreos/fleet/sign"
+)
+
+type Registry interface {
+	GetActiveMachines() []machine.MachineState
+	GetJobState(name string) *job.JobState
+	GetAllPayloads() []job.JobPayload
+	GetAllJobs() []job.Job
+	GetPayload(name string) *job.JobPayload
+	StopJob(name string)
+	DestroyPayload(name string)
+	CreatePayload(jp *job.JobPayload) error
+	CreateJob(j *job.Job) (err error)
+	CreateSignatureSet(s *sign.SignatureSet) error
+	GetSignatureSetOfPayload(name string) *sign.SignatureSet
+	DestroySignatureSetOfPayload(name string)
+}
+
+type MainRegistry struct {
+	registry *registry.Registry
+}
+
+func NewRegistry(r *registry.Registry) Registry {
+	return MainRegistry{r}
+}
+
+func (m MainRegistry) GetActiveMachines() []machine.MachineState {
+	return m.registry.GetActiveMachines()
+}
+
+func (m MainRegistry) GetJobState(name string) *job.JobState {
+	return m.registry.GetJobState(name)
+}
+
+func (m MainRegistry) GetAllPayloads() []job.JobPayload {
+	return m.registry.GetAllPayloads()
+}
+
+func (m MainRegistry) GetAllJobs() []job.Job {
+	return m.registry.GetAllJobs()
+}
+
+func (m MainRegistry) GetPayload(name string) *job.JobPayload {
+	return m.registry.GetPayload(name)
+}
+
+func (m MainRegistry) StopJob(name string) {
+	m.registry.StopJob(name)
+}
+
+func (m MainRegistry) DestroyPayload(name string) {
+	m.registry.DestroyPayload(name)
+}
+
+func (m MainRegistry) CreatePayload(jp *job.JobPayload) error {
+	return m.registry.CreatePayload(jp)
+}
+
+func (m MainRegistry) CreateJob(j *job.Job) error {
+	return m.registry.CreateJob(j)
+}
+
+func (m MainRegistry) CreateSignatureSet(s *sign.SignatureSet) error {
+	return m.registry.CreateSignatureSet(s)
+}
+
+func (m MainRegistry) GetSignatureSetOfPayload(name string) *sign.SignatureSet {
+	return m.registry.GetSignatureSetOfPayload(name)
+}
+
+func (m MainRegistry) DestroySignatureSetOfPayload(name string) {
+	m.registry.DestroySignatureSetOfPayload(name)
+}

--- a/fleetctl/registry_test.go
+++ b/fleetctl/registry_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"github.com/coreos/fleet/job"
+	"github.com/coreos/fleet/machine"
+	"github.com/coreos/fleet/sign"
+)
+
+type TestRegistry struct {
+	machines  []machine.MachineState
+	jobStates map[string]*job.JobState
+	jobs      []job.Job
+	payloads  []job.JobPayload
+}
+
+func (t TestRegistry) GetActiveMachines() []machine.MachineState {
+	return t.machines
+}
+
+func (t TestRegistry) GetJobState(name string) *job.JobState {
+	return t.jobStates[name]
+}
+
+func (t TestRegistry) GetAllPayloads() []job.JobPayload {
+	return t.payloads
+}
+
+func (t TestRegistry) GetAllJobs() []job.Job {
+	return t.jobs
+}
+
+func (t TestRegistry) GetPayload(name string) *job.JobPayload {
+	return nil
+}
+
+func (t TestRegistry) StopJob(name string) {
+}
+
+func (t TestRegistry) DestroyPayload(name string) {
+}
+
+func (t TestRegistry) CreatePayload(jp *job.JobPayload) error {
+	return nil
+}
+
+func (t TestRegistry) CreateJob(j *job.Job) error {
+	return nil
+}
+
+func (t TestRegistry) CreateSignatureSet(s *sign.SignatureSet) error {
+	return nil
+}
+
+func (t TestRegistry) GetSignatureSetOfPayload(name string) *sign.SignatureSet {
+	return nil
+}
+
+func (t TestRegistry) DestroySignatureSetOfPayload(name string) {
+}

--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -9,7 +10,6 @@ import (
 	"github.com/coreos/fleet/third_party/github.com/codegangsta/cli"
 
 	"github.com/coreos/fleet/machine"
-	"github.com/coreos/fleet/registry"
 	"github.com/coreos/fleet/ssh"
 )
 
@@ -47,25 +47,28 @@ func sshAction(c *cli.Context) {
 		log.Fatal("Both flags, machine and unit provided, please specify only one")
 	}
 
-	r := getRegistry()
 	args := c.Args()
+	var err error
 	var addr string
 
 	switch {
 	case machine != "":
-		addr, _ = findAddressInMachineList(r, machine)
+		addr, _ = findAddressInMachineList(machine)
 	case unit != "":
-		addr, _ = findAddressInRunningUnits(r, unit)
+		addr, _ = findAddressInRunningUnits(unit)
 	default:
-		addr = globalLookup(r, args)
+		addr, err = globalMachineLookup(args)
 		args = args[1:]
+	}
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	if addr == "" {
 		log.Fatalf("Requested machine could not be found")
 	}
 
-	var err error
 	var sshClient *gossh.ClientConn
 	if tun := getTunnelFlag(); tun != "" {
 		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr)
@@ -105,30 +108,30 @@ func sshAction(c *cli.Context) {
 	}
 }
 
-func globalLookup(r *registry.Registry, args []string) string {
+func globalMachineLookup(args []string) (string, error) {
 	if len(args) == 0 {
 		log.Fatalf("Provide one machine or unit")
 	}
 
 	lookup := args[0]
 
-	machineAddr, machineOk := findAddressInMachineList(r, lookup)
-	unitAddr, unitOk := findAddressInRunningUnits(r, lookup)
+	machineAddr, machineOk := findAddressInMachineList(lookup)
+	unitAddr, unitOk := findAddressInRunningUnits(lookup)
 
 	switch {
 	case machineOk && unitOk:
-		log.Fatalf("Ambiguous argument, both machine and unit found for `%s`.\nPlease use flag `-m` or `-u` to refine the search", lookup)
+		return "", errors.New(fmt.Sprintf("Ambiguous argument, both machine and unit found for `%s`.\nPlease use flag `-m` or `-u` to refine the search", lookup))
 	case machineOk:
-		return machineAddr
+		return machineAddr, nil
 	case unitOk:
-		return unitAddr
+		return unitAddr, nil
 	}
 
-	return ""
+	return "", nil
 }
 
-func findAddressInMachineList(r *registry.Registry, lookup string) (string, bool) {
-	states := r.GetActiveMachines()
+func findAddressInMachineList(lookup string) (string, bool) {
+	states := registryCtl.GetActiveMachines()
 	var match *machine.MachineState
 
 	for i, _ := range states {
@@ -148,8 +151,8 @@ func findAddressInMachineList(r *registry.Registry, lookup string) (string, bool
 	return fmt.Sprintf("%s:22", match.PublicIP), true
 }
 
-func findAddressInRunningUnits(r *registry.Registry, lookup string) (string, bool) {
-	js := r.GetJobState(lookup)
+func findAddressInRunningUnits(lookup string) (string, bool) {
+	js := registryCtl.GetJobState(lookup)
 	if js == nil {
 		return "", false
 	}

--- a/fleetctl/ssh_test.go
+++ b/fleetctl/ssh_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/coreos/fleet/job"
+	"github.com/coreos/fleet/machine"
+)
+
+func newTestRegistryForSsh() Registry {
+	m1 := machine.MachineState{"c31e44e1-f858-436e-933e-59c642517860", "1.2.3.4", map[string]string{"ping": "pong"}}
+	m2 := machine.MachineState{"595989bb-cbb7-49ce-8726-722d6e157b4e", "5.6.7.8", map[string]string{"foo": "bar"}}
+	m3 := machine.MachineState{"hello.service", "8.7.6.5", map[string]string{"foo": "bar"}}
+	machines := []machine.MachineState{m1, m2, m3}
+
+	states := map[string]*job.JobState{
+		"j1":            job.NewJobState("loaded", "active", "listening", []string{}, &m1),
+		"j2":            job.NewJobState("loaded", "inactive", "dead", []string{}, &m2),
+		"hello.service": job.NewJobState("loaded", "inactive", "dead", []string{}, &m3),
+	}
+
+	return TestRegistry{machines: machines, jobStates: states}
+}
+
+func TestSshUnknownMachine(t *testing.T) {
+	registryCtl = newTestRegistryForSsh()
+
+	_, ok := findAddressInMachineList("asdf")
+	if ok {
+		t.Error("Expected to not find any machine with the boot id `asdf`")
+	}
+}
+
+func TestSshFindMachine(t *testing.T) {
+	registryCtl = newTestRegistryForSsh()
+
+	ip, _ := findAddressInMachineList("c31e44e1-f858-436e-933e-59c642517860")
+	if ip != "1.2.3.4:22" {
+		t.Errorf("Expected to return the host 1.2.3.4:22, but it was %s", ip)
+	}
+}
+
+func TestSshFindMachineByUnknownJobName(t *testing.T) {
+	registryCtl = newTestRegistryForSsh()
+
+	_, ok := findAddressInRunningUnits("asdf")
+	if ok {
+		t.Error("Expected to not find any machine with the job name `asdf`")
+	}
+}
+
+func TestSshFindMachineByJobName(t *testing.T) {
+	registryCtl = newTestRegistryForSsh()
+
+	ip, _ := findAddressInRunningUnits("j1")
+	if ip != "1.2.3.4:22" {
+		t.Errorf("Expected to return the host 1.2.3.4:22, but it was %s", ip)
+	}
+}
+
+func TestGlobalLookupByUnknownArgument(t *testing.T) {
+	registryCtl = newTestRegistryForSsh()
+
+	ip, err := globalMachineLookup([]string{"asdf"})
+	if err != nil {
+		t.Fatal("Expected to not find any error")
+	}
+
+	if ip != "" {
+		t.Errorf("Expected to not find any host with the argument `asdf`")
+	}
+}
+
+func TestGlobalLookupByBootId(t *testing.T) {
+	registryCtl = newTestRegistryForSsh()
+
+	ip, err := globalMachineLookup([]string{"c31e44e1-f858-436e-933e-59c642517860"})
+	if err != nil {
+		t.Fatal("Expected to not find any error")
+	}
+
+	if ip != "1.2.3.4:22" {
+		t.Errorf("Expected to return the host 1.2.3.4:22, but it was %s", ip)
+	}
+}
+
+func TestGlobalLookupByJobName(t *testing.T) {
+	registryCtl = newTestRegistryForSsh()
+
+	ip, err := globalMachineLookup([]string{"j1"})
+	if err != nil {
+		t.Fatal("Expected to not find any error")
+	}
+
+	if ip != "1.2.3.4:22" {
+		t.Errorf("Expected to return the host 1.2.3.4:22, but it was %s", ip)
+	}
+}
+
+func TestGlobalLookupWithAmbiguousArgument(t *testing.T) {
+	registryCtl = newTestRegistryForSsh()
+
+	_, err := globalMachineLookup([]string{"hello.service"})
+	if err == nil {
+		t.Fatal("Expected to find an error with an ambiguous argument")
+	}
+}

--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -9,14 +9,13 @@ import (
 	gossh "github.com/coreos/fleet/third_party/code.google.com/p/go.crypto/ssh"
 	"github.com/coreos/fleet/third_party/github.com/codegangsta/cli"
 
-	"github.com/coreos/fleet/registry"
 	"github.com/coreos/fleet/ssh"
 )
 
 func newStatusUnitsCommand() cli.Command {
 	return cli.Command{
-		Name:	"status",
-		Usage:	"Output the status of one or more units in the cluster",
+		Name:  "status",
+		Usage: "Output the status of one or more units in the cluster",
 		Description: `Output the status of one or more units currently running in the cluster.
 Supports glob matching of units in the current working directory or matches
 previously started units.
@@ -26,13 +25,11 @@ fleetctl status foo.service
 
 Show status of an entire directory with glob matching:
 fleetctl status myservice/*`,
-		Action:	statusUnitsAction,
+		Action: statusUnitsAction,
 	}
 }
 
 func statusUnitsAction(c *cli.Context) {
-	r := getRegistry()
-
 	for i, v := range c.Args() {
 		// This extra newline here to match systemctl status output
 		if i != 0 {
@@ -40,12 +37,12 @@ func statusUnitsAction(c *cli.Context) {
 		}
 
 		name := path.Base(v)
-		printUnitStatus(c, r, name)
+		printUnitStatus(c, name)
 	}
 }
 
-func printUnitStatus(c *cli.Context, r *registry.Registry, jobName string) {
-	js := r.GetJobState(jobName)
+func printUnitStatus(c *cli.Context, jobName string) {
+	js := registryCtl.GetJobState(jobName)
 
 	if js == nil {
 		fmt.Printf("%s does not appear to be running\n", jobName)

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -8,8 +8,8 @@ import (
 
 func newStopUnitCommand() cli.Command {
 	return cli.Command{
-		Name:	"stop",
-		Usage:	"Halt one or more units in the cluster",
+		Name:  "stop",
+		Usage: "Halt one or more units in the cluster",
 		Description: `Stop one or more units from running in the cluster, but allow them to be
 started again in the future.
 
@@ -22,15 +22,13 @@ fleetctl stop foo.service
 
 Stop an entire directory of units with glob matching:
 fleetctl stop myservice/*`,
-		Action:	stopUnitAction,
+		Action: stopUnitAction,
 	}
 }
 
 func stopUnitAction(c *cli.Context) {
-	r := getRegistry()
-
 	for _, v := range c.Args() {
 		name := path.Base(v)
-		r.StopJob(name)
+		registryCtl.StopJob(name)
 	}
 }

--- a/fleetctl/submit.go
+++ b/fleetctl/submit.go
@@ -11,8 +11,8 @@ import (
 
 func newSubmitUnitCommand() cli.Command {
 	return cli.Command{
-		Name:	"submit",
-		Usage:	"Upload one or more units to the cluster without starting them",
+		Name:  "submit",
+		Usage: "Upload one or more units to the cluster without starting them",
 		Description: `Upload one or more units to the cluster without starting them. Useful
 validating units before they are started.
 
@@ -21,16 +21,14 @@ fleetctl submit foo.service
 
 Submit a directory of units with glob matching:
 fleetctl submit myservice/*`,
-		Flags:	[]cli.Flag{
+		Flags: []cli.Flag{
 			cli.BoolFlag{"sign", "Sign unit file signatures using local SSH identities"},
 		},
-		Action:	submitUnitsAction,
+		Action: submitUnitsAction,
 	}
 }
 
 func submitUnitsAction(c *cli.Context) {
-	r := getRegistry()
-
 	toSign := c.Bool("sign")
 	var sc *sign.SignatureCreator
 	if toSign {
@@ -56,7 +54,7 @@ func submitUnitsAction(c *cli.Context) {
 	// Only after all the provided payloads have been validated
 	// do we push any changes to the Registry
 	for _, payload := range payloads {
-		err := r.CreatePayload(&payload)
+		err := registryCtl.CreatePayload(&payload)
 		if err != nil {
 			fmt.Printf("Creation of payload %s failed: %v\n", payload.Name, err)
 			return
@@ -67,7 +65,7 @@ func submitUnitsAction(c *cli.Context) {
 				fmt.Printf("Creation of sign for payload %s failed: %v\n", payload.Name, err)
 				return
 			}
-			r.CreateSignatureSet(s)
+			registryCtl.CreateSignatureSet(s)
 		}
 	}
 }

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 source ./build
 
 if [ -z "$PKG" ]; then
-    PKG="./agent ./config ./job ./machine ./unit ./registry ./event ./sign ./integration-tests"
+    PKG="./agent ./config ./event ./fleetctl ./job ./machine ./registry ./sign ./unit ./integration-tests"
 fi
 
 # Unit tests


### PR DESCRIPTION
Use an interface between cmd and registry to test commands on isolation.
This allows to decouple the commands from the registry and do some unit testing on them.

I've ported the ssh functions that I wrote to search for machines to this interface and add a bunch of unit tests to demonstrate how it can be more clean.
