### PR TITLE
chore(fleetctl): use fmt.Print() instead of print()

### DIFF
--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -72,9 +72,9 @@ func journalAction(c *cli.Context) {
 			break
 		}
 
-		print(string(bytes))
+		fmt.Print(string(bytes))
 		if !prefix {
-			print("\n")
+			fmt.Print("\n")
 		}
 	}
 }

--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -92,9 +92,9 @@ func sshAction(c *cli.Context) {
 				break
 			}
 
-			print(string(bytes))
+			fmt.Print(string(bytes))
 			if !prefix {
-				print("\n")
+				fmt.Print("\n")
 			}
 		}
 

--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -79,9 +79,9 @@ func printUnitStatus(c *cli.Context, r *registry.Registry, jobName string) {
 			break
 		}
 
-		print(string(bytes))
+		fmt.Print(string(bytes))
 		if !prefix {
-			print("\n")
+			fmt.Print("\n")
 		}
 	}
 }


### PR DESCRIPTION
As http://golang.org/ref/spec#Bootstrapping says, print is documented for
completeness but is not guaranteed to stay in the language.
Replace it with fmt.Print
