### PR TITLE
feat(debug): Add SIGUSR1 handler to dump state info

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -57,6 +58,10 @@ func New(registry *registry.Registry, events *event.EventBus, machine *machine.M
 // Access Agent's machine field
 func (a *Agent) Machine() *machine.Machine {
 	return a.machine
+}
+
+func (a *Agent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct{ State *AgentState }{State: a.state})
 }
 
 // Trigger all async processes the Agent intends to run

--- a/agent/state.go
+++ b/agent/state.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"path"
 	"sync"
 
@@ -47,6 +48,22 @@ func (self *AgentState) Unlock() {
 	log.V(2).Infof("Attempting to unlock AgentState")
 	self.mutex.Unlock()
 	log.V(2).Infof("AgentState unlocked")
+}
+
+func (self *AgentState) MarshalJSON() ([]byte, error) {
+	type ds struct {
+		Offers    map[string]job.JobOffer
+		Conflicts map[string][]string
+		Bids      []string
+		Peers     map[string][]string
+	}
+	data := ds{
+		Offers:    self.offers,
+		Conflicts: self.conflicts,
+		Bids:      self.bids,
+		Peers:     self.peers,
+	}
+	return json.Marshal(data)
 }
 
 // Store a list of conflicts on behalf of a given Job

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"encoding/json"
+
 	"github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
 	log "github.com/coreos/fleet/third_party/github.com/golang/glog"
 
@@ -56,6 +58,10 @@ func New(cfg config.Config) *Server {
 	e := engine.New(r, eb, m)
 
 	return &Server{a, e, m, r, eb, es}
+}
+
+func (self *Server) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct{ Agent *agent.Agent }{Agent: self.agent})
 }
 
 func (self *Server) Run() {


### PR DESCRIPTION
This produces output like this in the log:

Mar 06 00:57:18 localhost fleet[10709]: I0306 00:57:18.044789 10709 fleet.go:90] Dumping server state
Mar 06 00:57:18 localhost fleet[10709]: {"Agent":{"State":{"Offers":{},"Conflicts":{"hello.service":[],"ping.service":[],"pong.service":[]},"Bids":[],"Peers":{"ping.service":["pong.service"]}}}}
Mar 06 00:57:18 localhost fleet[10709]: I0306 00:57:18.045274 10709 fleet.go:105] Finished dumping server state
