### PR TITLE
feat(start): Wait until units have been scheduled before exiting the start command.

### DIFF
--- a/fleetctl/cmd.go
+++ b/fleetctl/cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coreos/fleet/third_party/github.com/rakyll/globalconf"
 
 	"github.com/coreos/fleet/job"
+	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/registry"
 	"github.com/coreos/fleet/ssh"
 	"github.com/coreos/fleet/unit"
@@ -123,18 +124,6 @@ func main() {
 	app.Run(os.Args)
 }
 
-func ellipsize(field string, n int) string {
-	// When ellipsing a field, we want to display the first n
-	// characters. We check for n+3 so we don't inadvertently
-	// make fields with fewer than n+3 characters even longer
-	// by adding unnecessary ellipses.
-	if len(field) > n+3 {
-		return fmt.Sprintf("%s...", field[0:n])
-	} else {
-		return field
-	}
-}
-
 func getJobPayloadFromFile(file string) (*job.JobPayload, error) {
 	out, err := ioutil.ReadFile(file)
 	if err != nil {
@@ -159,4 +148,32 @@ func getTunnelFlag() string {
 
 func getEndpointFlag() string {
 	return (*flagset.Lookup("endpoint")).Value.(flag.Getter).Get().(string)
+}
+
+func machineBootIdLegend(ms machine.MachineState, full bool) string {
+	legend := ms.BootId
+	if !full {
+		legend = ellipsize(legend, 8)
+	}
+	return legend
+}
+
+func machineFullLegend(ms machine.MachineState, full bool) string {
+	legend := machineBootIdLegend(ms, full)
+	if len(ms.PublicIP) > 0 {
+		legend = fmt.Sprintf("%s/%s", legend, ms.PublicIP)
+	}
+	return legend
+}
+
+func ellipsize(field string, n int) string {
+	// When ellipsing a field, we want to display the first n
+	// characters. We check for n+3 so we don't inadvertently
+	// make fields with fewer than n+3 characters even longer
+	// by adding unnecessary ellipses.
+	if len(field) > n+3 {
+		return fmt.Sprintf("%s...", field[0:n])
+	} else {
+		return field
+	}
 }

--- a/fleetctl/cmd_test.go
+++ b/fleetctl/cmd_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/coreos/fleet/machine"
+)
+
+func TestBootIdLegend(t *testing.T) {
+	ms := machine.MachineState{"595989bb-cbb7-49ce-8726-722d6e157b4e", "5.6.7.8", map[string]string{"foo": "bar"}}
+
+	l := machineBootIdLegend(ms, true)
+	if l != "595989bb-cbb7-49ce-8726-722d6e157b4e" {
+		t.Errorf("Expected full bootId, but it was %s\n", l)
+	}
+
+	l = machineBootIdLegend(ms, false)
+	if l != "595989bb..." {
+		t.Errorf("Expected partial bootId, but it was %s\n", l)
+	}
+}
+
+func TestFullLegendWithPublicIP(t *testing.T) {
+	ms := machine.MachineState{"595989bb-cbb7-49ce-8726-722d6e157b4e", "5.6.7.8", map[string]string{"foo": "bar"}}
+
+	l := machineFullLegend(ms, false)
+	if l != "595989bb.../5.6.7.8" {
+		t.Errorf("Expected partial bootId with public IP, but it was %s\n", l)
+	}
+
+	l = machineFullLegend(ms, true)
+	if l != "595989bb-cbb7-49ce-8726-722d6e157b4e/5.6.7.8" {
+		t.Errorf("Expected full bootId with public IP, but it was %s\n", l)
+	}
+}
+
+func TestFullLegendWithoutPublicIP(t *testing.T) {
+	ms := machine.MachineState{"520983A8-FB9C-4A68-B49C-CED5BB2E9D08", "", map[string]string{"foo": "bar"}}
+
+	l := machineFullLegend(ms, false)
+	if l != "520983A8..." {
+		t.Errorf("Expected partial bootId without public IP, but it was %s\n", l)
+	}
+
+	l = machineFullLegend(ms, true)
+	if l != "520983A8-FB9C-4A68-B49C-CED5BB2E9D08" {
+		t.Errorf("Expected full bootId without public IP, but it was %s\n", l)
+	}
+}

--- a/fleetctl/list_machines.go
+++ b/fleetctl/list_machines.go
@@ -35,10 +35,7 @@ func listMachinesAction(c *cli.Context) {
 	full := c.Bool("full")
 
 	for _, m := range registryCtl.GetActiveMachines() {
-		mach := m.BootId
-		if !full {
-			mach = ellipsize(mach, 8)
-		}
+		mach := machineBootIdLegend(m, full)
 
 		ip := m.PublicIP
 		if len(ip) == 0 {

--- a/fleetctl/list_units.go
+++ b/fleetctl/list_units.go
@@ -88,13 +88,7 @@ func printJobState(name, description string, js *job.JobState, full bool) {
 		subState = js.SubState
 
 		if js.MachineState != nil {
-			mach = js.MachineState.BootId
-			if !full {
-				mach = ellipsize(mach, 8)
-			}
-			if len(js.MachineState.PublicIP) > 0 {
-				mach = fmt.Sprintf("%s/%s", mach, js.MachineState.PublicIP)
-			}
+			mach = machineFullLegend(*js.MachineState, full)
 		}
 	}
 

--- a/fleetctl/registry.go
+++ b/fleetctl/registry.go
@@ -20,6 +20,8 @@ type Registry interface {
 	CreateSignatureSet(s *sign.SignatureSet) error
 	GetSignatureSetOfPayload(name string) *sign.SignatureSet
 	DestroySignatureSetOfPayload(name string)
+	GetJobTarget(name string) *machine.MachineState
+	GetMachineState(bootId string) *machine.MachineState
 }
 
 type MainRegistry struct {
@@ -76,4 +78,12 @@ func (m MainRegistry) GetSignatureSetOfPayload(name string) *sign.SignatureSet {
 
 func (m MainRegistry) DestroySignatureSetOfPayload(name string) {
 	m.registry.DestroySignatureSetOfPayload(name)
+}
+
+func (m MainRegistry) GetJobTarget(name string) *machine.MachineState {
+	return m.registry.GetJobTarget(name)
+}
+
+func (m MainRegistry) GetMachineState(bootId string) *machine.MachineState {
+	return m.registry.GetMachineState(bootId)
 }

--- a/fleetctl/registry_test.go
+++ b/fleetctl/registry_test.go
@@ -57,3 +57,20 @@ func (t TestRegistry) GetSignatureSetOfPayload(name string) *sign.SignatureSet {
 
 func (t TestRegistry) DestroySignatureSetOfPayload(name string) {
 }
+
+func (t TestRegistry) GetJobTarget(name string) *machine.MachineState {
+	js := t.jobStates[name]
+	if js != nil {
+		return js.MachineState
+	}
+	return nil
+}
+
+func (t TestRegistry) GetMachineState(bootId string) *machine.MachineState {
+	for _, ms := range t.machines {
+		if ms.BootId == bootId {
+			return &ms
+		}
+	}
+	return nil
+}

--- a/fleetctl/start_test.go
+++ b/fleetctl/start_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/coreos/fleet/job"
+	"github.com/coreos/fleet/machine"
+)
+
+type BlockedTestRegistry struct {
+	EchoAttempts int
+	TestRegistry
+}
+
+func (b BlockedTestRegistry) GetJobTarget(name string) *machine.MachineState {
+	if name == "hello.service" {
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if name == "echo.service" {
+		if b.EchoAttempts != 0 {
+			b.EchoAttempts--
+			return nil
+		}
+	}
+
+	return b.TestRegistry.GetJobTarget(name)
+}
+
+func setupRegistryForStart(echoAttempts int) {
+	m1 := machine.MachineState{"c31e44e1-f858-436e-933e-59c642517860", "1.2.3.4", map[string]string{"ping": "pong"}}
+	m2 := machine.MachineState{"595989bb-cbb7-49ce-8726-722d6e157b4e", "5.6.7.8", map[string]string{"foo": "bar"}}
+	m3 := machine.MachineState{"520983A8-FB9C-4A68-B49C-CED5BB2E9D08", "", map[string]string{"foo": "bar"}}
+
+	js := job.NewJobState("loaded", "active", "listening", []string{}, &m1)
+	js2 := job.NewJobState("loaded", "inactive", "dead", []string{}, &m2)
+	js3 := job.NewJobState("loaded", "inactive", "dead", []string{}, &m2)
+	js4 := job.NewJobState("loaded", "inactive", "dead", []string{}, &m3)
+
+	states := map[string]*job.JobState{"pong.service": js, "hello.service": js2, "echo.service": js3, "private.service": js4}
+	machines := []machine.MachineState{m1, m2, m3}
+
+	registryCtl = BlockedTestRegistry{echoAttempts, TestRegistry{jobStates: states, machines: machines}}
+}
+
+func TestPrintJobStarted(t *testing.T) {
+	setupRegistryForStart(0)
+
+	jobs := map[string]bool{"pong.service": true}
+	b := bytes.NewBufferString("")
+	waitForScheduledUnits(jobs, 1, b)
+
+	if b.String() != "Job pong.service started on c31e44e1.../1.2.3.4\n" {
+		t.Errorf("Found unexpected start output: %s", b.String())
+	}
+}
+
+func TestPrintSeveralJobs(t *testing.T) {
+	setupRegistryForStart(0)
+
+	jobs := map[string]bool{"hello.service": true, "pong.service": true}
+	b := bytes.NewBufferString("")
+	waitForScheduledUnits(jobs, 1, b)
+
+	expected := `Job pong.service started on c31e44e1.../1.2.3.4
+Job hello.service started on 595989bb.../5.6.7.8
+`
+
+	if b.String() != expected {
+		t.Errorf("Found unexpected start output: %s", b.String())
+	}
+}
+
+func TestPrintJobPending(t *testing.T) {
+	setupRegistryForStart(1)
+
+	jobs := map[string]bool{"echo.service": true, "pong.service": true}
+	b := bytes.NewBufferString("")
+	waitForScheduledUnits(jobs, 1, b)
+
+	expected := `Job pong.service started on c31e44e1.../1.2.3.4
+Job echo.service in queue to be scheduled
+`
+
+	if b.String() != expected {
+		t.Errorf("Found unexpected start output: %s", b.String())
+	}
+}
+
+func TestPrintJobWithoutPublicIP(t *testing.T) {
+	setupRegistryForStart(0)
+
+	jobs := map[string]bool{"private.service": true}
+	b := bytes.NewBufferString("")
+	waitForScheduledUnits(jobs, 1, b)
+
+	if b.String() != "Job private.service started on 520983A8...\n" {
+		t.Errorf("Found unexpected start output: %s", b.String())
+	}
+}

--- a/machine/state_test.go
+++ b/machine/state_test.go
@@ -39,5 +39,3 @@ func TestStackStateEmptyTop(t *testing.T) {
 		t.Errorf("Unexpected Metadata %v", stacked.Metadata)
 	}
 }
-
-


### PR DESCRIPTION
This makes the start command to wait until all the untils have been loaded into the cluster.
It attempts to get the status of each unit for 10 seconds, giving up after that.

Fixes #128
