### PR TITLE
fix(docs): replace relative links with absolute links for syncing with coreos.com

### DIFF
--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -11,7 +11,7 @@ Each `fleet` daemon must be configured to talk to the same [etcd cluster][etcd].
 `fleet` requires etcd be of version 0.3.0+.
 
 [etcd]: https://coreos.com/docs/cluster-management/setup/getting-started-with-etcd
-[config]: configuration.md
+[config]: https://github.com/coreos/fleet/blob/master/Documentation/configuration.md
 
 ### systemd
 

--- a/Documentation/remote-access.md
+++ b/Documentation/remote-access.md
@@ -9,7 +9,7 @@ This requires two things:
 
 Authorizing a user's SSH key within a cluster is up to the deployer. See the [deployment doc][d] for help doing this.
 
-[d]: deployment.md
+[d]: https://github.com/coreos/fleet/blob/master/Documentation/deployment.md
 
 Running an ssh-agent is the responsibility of the user. Many unix-based distros conveniently provide the necessary tools on a base install, or in an ssh-related package. For example, Ubuntu provides the `ssh-agent` and `ssh-add` binaries in the `openssh-client` package. If you cannot find the necessary binaries on your system, please consult your distro's documentation.
 

--- a/Documentation/scheduling.md
+++ b/Documentation/scheduling.md
@@ -9,7 +9,7 @@ The Engine simply accepts the first bid that is submitted for a given offer and 
 
 **NOTE:** The current approach of accepting the first bid is only temporary - the Engine will make an effort to fairly schedule across the entire schedule in the near future.
 
-Read more about [fleet's architecture and data model](architecture.md).
+Read more about [fleet's architecture and data model](https://github.com/coreos/fleet/blob/master/Documentation/architecture.md).
 
 ## User-Defined Requirements
 
@@ -40,7 +40,7 @@ $ fleetctl start --require region=us-east-1,region=us-east-2
 This would allow a machine to match just one of the provided values to consider themselves capable of running a job.
 
 A machine is not automatically configured with metadata.
-A deployer may define machine metadata using the `metadata` [config option](configuration.md).
+A deployer may define machine metadata using the `metadata` [config option](https://github.com/coreos/fleet/blob/master/Documentation/configuration.md).
 
 ##### Schedule unit next to another unit
 

--- a/Documentation/security.md
+++ b/Documentation/security.md
@@ -4,7 +4,7 @@
 
 The preview release of fleet doesn't currently perform any authentication or authorization for submitted units. This means that any client that can access your etcd cluster can possibly run arbitrary code on many of your machines very easily.
 
-You should avoid public access to etcd and instead run fleet [from your local laptop](using-the-client.md#get-up-and-running) with the `--tunnel` flag to run commands over an SSH tunnel. You can alias this flag for easier usage: `alias fleetctl=fleetctl --tunnel 10.10.10.10`.
+You should avoid public access to etcd and instead run fleet [from your local laptop](https://github.com/coreos/fleet/blob/master/Documentation/using-the-client.md#get-up-and-running) with the `--tunnel` flag to run commands over an SSH tunnel. You can alias this flag for easier usage: `alias fleetctl=fleetctl --tunnel 10.10.10.10`.
 
 ## Fast Follow Plans
 

--- a/Documentation/signed-payloads.md
+++ b/Documentation/signed-payloads.md
@@ -22,4 +22,4 @@ To enable payload validation on a fleet server, simply set `verify_units=true` i
 fleet will validate payloads with the keys in `~/.ssh/authorized_keys` by default.
 A deployer may provide an alternate set of SSH keys to use for validation using the `authorized_keys_file` option.
 
-See [more information](configuration.md) on configuring `fleet`.
+See [more information](https://github.com/coreos/fleet/blob/master/Documentation/configuration.md) on configuring `fleet`.

--- a/Documentation/unit-files.md
+++ b/Documentation/unit-files.md
@@ -15,7 +15,7 @@ fleet will schedule any valid service or socket systemd unit to a machine in the
 | `X-ConditionMachineOf` | Limit eligible machines to the one that hosts a specific unit. |
 | `X-Conflicts` | Prevent a unit from being collocated with other units using glob-matching on the other unit names. |
 
-See [more information](scheduling.md) on these parameters and how they impact scheduling decisions.
+See [more information](https://github.com/coreos/fleet/blob/master/Documentation/scheduling.md) on these parameters and how they impact scheduling decisions.
 
 Take the following as an example of how your `[X-Fleet]` section could be written:
 

--- a/Documentation/using-the-client.md
+++ b/Documentation/using-the-client.md
@@ -28,11 +28,11 @@ One can also provide `--tunnel` through the environment variable `FLEETCTL_TUNNE
 
 When using `--tunnel` and `--endpoint` together, it is important to note that all etcd requests will be made through the SSH tunnel. The address in the `--endpoint` flag must be routable from the server hosting the tunnel.
 
-See more about [configuring remote access](remote-access.md).
+See more about [configuring remote access](https://github.com/coreos/fleet/blob/master/Documentation/remote-access.md).
 
 ## Interact with units
 
-For information about the additional unit file parameters fleet will interact with, see [this documentation](unit-files.md).
+For information about the additional unit file parameters fleet will interact with, see [this documentation](https://github.com/coreos/fleet/blob/master/Documentation/unit-files.md).
 
 ### Explore existing units
 


### PR DESCRIPTION
Not all of these docs are currently synced, but it's safer and easy to always use absolute links.

Initial broken link was reported via IRC.
