### PR TITLE
fix(Documentation): remove outdated note about the registry + etcd

### DIFF
--- a/Documentation/architecture.md
+++ b/Documentation/architecture.md
@@ -26,8 +26,6 @@ If an Agent's JobBid is rejected, that Agent simply forgets about it and moves o
 
 The Registry is the sole datastore in a fleet cluster. All persistent and ephemeral data is stored in the registry: unit files, cluster presence, job state, etc.
 
-**NOTE:**The backing store is currently the distributed locking service [etcd](https://github.com/coreos/etcd). This will continue to support fleet at a small scale, but scaling fleet up will require a redesign of the underlying datastores used by the Registry.
-
 ### Events
 
 There are four key pieces to the event system in fleet: the EventBus, EventStreams, EventListeners and Events. EventStreams generate Events, streaming them to the EventBus, which then distributes them amongst its registered EventListeners.


### PR DESCRIPTION
This note was probably from when fleet was using very very tight ttls, tons of
watchers and pushing lots of data through etcd. Lets remove this.
