### PR TITLE
fix(ssh/NewTLSSSHClient): add error handling

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -145,6 +145,9 @@ func NewTunnelledSSHClient(user, tunaddr, tgtaddr string, checker *HostKeyChecke
 	}
 
 	c, chans, reqs, err := gossh.NewClientConn(targetConn, tgtaddr, clientConfig)
+	if err != nil {
+		return nil, err
+	}
 	return gossh.NewClient(c, chans, reqs), nil
 }
 


### PR DESCRIPTION
```
% ~/src/fleet/bin/fleetctl ssh 6e4a0139 sudo reboot
The authenticity of host '0.0.0.0:0' can't be established.
RSA key fingerprint is b0:9f:78:c3:9d:98:03:28:76:b3:51:d7:d2:15:e9:79.
Are you sure you want to continue connecting (yes/no)?
```

If I answer no here, fleetctl will panic.
This PR fixes this.

Get idea from #230
