### PR TITLE
fix(ssh.Execute): Handle ssh execution errors.

### DIFF
--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -65,20 +65,10 @@ func printUnitStatus(c *cli.Context, jobName string) {
 	defer sshClient.Close()
 
 	cmd := fmt.Sprintf("systemctl status -l %s", jobName)
-	stdout, err := ssh.Execute(sshClient, cmd)
+	channel, err := ssh.Execute(sshClient, cmd)
 	if err != nil {
 		log.Fatalf("Unable to execute command over SSH: %s", err.Error())
 	}
 
-	for true {
-		bytes, prefix, err := stdout.ReadLine()
-		if err != nil {
-			break
-		}
-
-		fmt.Print(string(bytes))
-		if !prefix {
-			fmt.Print("\n")
-		}
-	}
+	readSSHChannel(channel)
 }


### PR DESCRIPTION
This ensures that `fleetctl ssh MACHINE COMMAND` returns the proper error log and exit code when the command fails.
