### PR TITLE
Store raw unit file in registry

### DIFF
--- a/unit/file.go
+++ b/unit/file.go
@@ -6,21 +6,38 @@ import (
 )
 
 type SystemdUnitFile struct {
-	Contents map[string]map[string]string
+	// Contents represents the parsed unit file.
+	// This field must be considered readonly.
+	Contents map[string]map[string][]string
+
+	raw      string
 }
 
-func (self *SystemdUnitFile) GetSection(section string) map[string]string {
-	result, ok := self.Contents[section]
-	if ok {
-		return result
-	} else {
-		return make(map[string]string, 0)
+func (self *SystemdUnitFile) String() string {
+	return self.raw
+}
+
+// LegacyContents serializes the contents of a unit file into an obsolete datastructure. This
+// datastructure is lossy and should only be used to remain backwards-compatible where necessary.
+func (self *SystemdUnitFile) LegacyContents() map[string]map[string]string {
+	coerced := make(map[string]map[string]string, len(self.Contents))
+	for section, options := range self.Contents {
+		coerced[section] = make(map[string]string)
+		for key, values := range options {
+			if len(values) == 0 {
+				continue
+			}
+			coerced[section][key] = values[len(values)-1]
+		}
 	}
+	return coerced
 }
 
+// Requirements returns all relevant options from the [X-Fleet] section
+// of a unit file. Relevant options are identified with a `X-` prefix.
 func (self *SystemdUnitFile) Requirements() map[string][]string {
-	requirements := make(map[string][]string, 0)
-	for key, value := range self.GetSection("X-Fleet") {
+	requirements := make(map[string][]string)
+	for key, value := range self.Contents["X-Fleet"] {
 		if !strings.HasPrefix(key, "X-") {
 			continue
 		}
@@ -32,37 +49,45 @@ func (self *SystemdUnitFile) Requirements() map[string][]string {
 			requirements[key] = make([]string, 0)
 		}
 
-		requirements[key] = append(requirements[key], value)
+		requirements[key] = value
 	}
+
 	return requirements
 }
 
+// Description returns the first Description option found in the [Unit] section.
+// If the option is not defined, an empty string is returned.
 func (self *SystemdUnitFile) Description() string {
-	return self.GetSection("Unit")["Description"]
+	if values := self.Contents["Unit"]["Description"]; len(values) > 0 {
+		return values[0]
+	}
+	return ""
 }
 
-func (self *SystemdUnitFile) String() string {
+func NewSystemdUnitFile(raw string) *SystemdUnitFile {
+	parsed := deserializeUnitFile(raw)
+	return &SystemdUnitFile{parsed, raw}
+}
+
+// NewSystemdUnitFileFromLegacyContents creates a SystemdUnitFile object from an obsolete unit
+// file datastructure. This should only be used to remain backwards-compatible where necessary.
+func NewSystemdUnitFileFromLegacyContents(contents map[string]map[string]string) *SystemdUnitFile {
 	var serialized string
-	for section, keyMap := range self.Contents {
+	for section, keyMap := range contents {
 		serialized += fmt.Sprintf("[%s]\n", section)
 		for key, value := range keyMap {
 			serialized += fmt.Sprintf("%s=%s\n", key, value)
 		}
 		serialized += "\n"
 	}
-	return serialized
+	return NewSystemdUnitFile(serialized)
 }
 
-func NewSystemdUnitFile(Contents string) *SystemdUnitFile {
-	parsed := deserializeUnitFile(Contents)
-	return &SystemdUnitFile{parsed}
-}
-
-// This is dangerously simple and should be rewritten to match the spec
-func deserializeUnitFile(contents string) map[string]map[string]string {
-	sections := make(map[string]map[string]string, 0)
+// deserializeUnitFile is dangerously simple and should be rewritten to match the systemd unit file spec
+func deserializeUnitFile(raw string) map[string]map[string][]string {
+	sections := make(map[string]map[string][]string)
 	var section string
-	for _, line := range strings.Split(contents, "\n") {
+	for _, line := range strings.Split(raw, "\n") {
 		// Ignore commented-out lines
 		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
 			continue
@@ -77,8 +102,8 @@ func deserializeUnitFile(contents string) map[string]map[string]string {
 
 		// Check for section
 		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section = line[1:len(line)-1]
-			sections[section] = make(map[string]string, 0)
+			section = line[1 : len(line)-1]
+			sections[section] = make(map[string][]string)
 			continue
 		}
 
@@ -89,7 +114,7 @@ func deserializeUnitFile(contents string) map[string]map[string]string {
 			value := strings.Trim(parts[1], " ")
 
 			if len(section) > 0 {
-				sections[section][key] = value
+				sections[section][key] = append(sections[section][key], value)
 			}
 
 		}

--- a/unit/file_test.go
+++ b/unit/file_test.go
@@ -1,32 +1,38 @@
 package unit
 
 import (
+	"reflect"
 	"testing"
 )
 
 func TestDeserialize(t *testing.T) {
 	contents := `
+This=Ignored
 [Unit]
+;ignore this guy
 Description = Foo
 
 [Service]
 ExecStart=echo "ping";
-ExecStop=echo "pong";
+ExecStop=echo "pong"
+# ignore me, too
+ExecStop=echo post
 `
+
+	expected := map[string]map[string][]string{
+		"Unit": map[string][]string{
+			"Description": []string{"Foo"},
+		},
+		"Service": map[string][]string{
+			"ExecStart": []string{"echo \"ping\";"},
+			"ExecStop": []string{"echo \"pong\"", "echo post"},
+		},
+	}
 
 	unitFile := NewSystemdUnitFile(contents)
 
-	section := unitFile.GetSection("Unit")
-	if section["Description"] != "Foo" {
-		t.Fatalf("Unit.Description is incorrect")
-	}
-
-	section = unitFile.GetSection("Service")
-	if section["ExecStart"] != "echo \"ping\";" {
-		t.Fatalf("Service.ExecStart is incorrect")
-	}
-	if section["ExecStop"] != "echo \"pong\";" {
-		t.Fatalf("Service.ExecStop is incorrect")
+	if !reflect.DeepEqual(expected, unitFile.Contents) {
+		t.Fatalf("Map func did not produce expected output.\nActual=%v\nExpected=%v", unitFile.Contents, expected)
 	}
 }
 
@@ -36,12 +42,17 @@ func TestSerializeDeserialize(t *testing.T) {
 Description = Foo
 `
 	deserialized := NewSystemdUnitFile(contents)
+	section := deserialized.Contents["Unit"]
+	if val, ok := section["Description"]; !ok || val[0] != "Foo" {
+		t.Errorf("Failed to persist data through serialize/deserialize: %v", val)
+	}
+
 	serialized := deserialized.String()
 	deserialized = NewSystemdUnitFile(serialized)
 
-	section := deserialized.GetSection("Unit")
-	if val, ok := section["Description"]; !ok || val != "Foo" {
-		t.Fatalf("Failed to persist data through serialize/deserialize")
+	section = deserialized.Contents["Unit"]
+	if val, ok := section["Description"]; !ok || val[0] != "Foo" {
+		t.Errorf("Failed to persist data through serialize/deserialize: %v", val)
 	}
 }
 
@@ -67,20 +78,26 @@ X-Key=Value
 	}
 }
 
-func TestParseRequirementsMultipleValuesForKeyOverwrite(t *testing.T) {
+func TestParseRequirementsMultipleValuesForKeyStack(t *testing.T) {
 	contents := `
 [X-Fleet]
 X-Foo=Bar
 X-Foo=Baz
+X-Ping=Pong
+X-Ping=Pang
 `
 	unitFile := NewSystemdUnitFile(contents)
 	reqs := unitFile.Requirements()
-	if len(reqs) != 1 {
-		t.Fatalf("Incorrect number of requirements; got %d, expected 1", len(reqs))
+	if len(reqs) != 2 {
+		t.Fatalf("Received %d requirements, expected 2: %v", len(reqs), reqs)
 	}
 
-	if len(reqs["Foo"]) != 1 || reqs["Foo"][0] != "Baz" {
-		t.Fatalf("Incorrect value %q of requirement 'Foo'", reqs["Foo"])
+	if len(reqs["Foo"]) != 2 || reqs["Foo"][0] != "Bar" || reqs["Foo"][1] != "Baz" {
+		t.Fatalf("Incorrect value %v of requirement 'Foo'", reqs["Foo"])
+	}
+
+	if len(reqs["Ping"]) != 2 || reqs["Ping"][0] != "Pong" || reqs["Ping"][1] != "Pang" {
+		t.Fatalf("Incorrect value %v of requirement 'Ping'", reqs["Ping"])
 	}
 }
 
@@ -93,19 +110,6 @@ Description=Timmy
 	reqs := unitFile.Requirements()
 	if len(reqs) != 0 {
 		t.Fatalf("Incorrect number of requirements; got %d, expected 0", len(reqs))
-	}
-}
-
-func TestGetSectionMissing(t *testing.T) {
-	contents := `
-[Unit]
-Description = Foo
-`
-	unitFile := NewSystemdUnitFile(contents)
-	section := unitFile.GetSection("Missing")
-
-	if len(section) != 0 {
-		t.Fatalf("Returned unexpected data for undefined section")
 	}
 }
 
@@ -137,5 +141,62 @@ ExecStop=echo "pong";
 	unitFile := NewSystemdUnitFile(contents)
 	if unitFile.Description() != "" {
 		t.Fatalf("Unit.Description is incorrect")
+	}
+}
+
+func TestLegacyContents(t *testing.T) {
+	contents := map[string]map[string][]string{
+		"Unit": map[string][]string{
+			"Description": []string{"foobar"},
+			"Wants": []string{},
+		},
+		"Service": map[string][]string{
+			"Type":      []string{"oneshot"},
+			"ExecStart": []string{"foo", "bar"},
+		},
+	}
+	expected := map[string]map[string]string{
+		"Unit": map[string]string{
+			"Description": "foobar",
+		},
+		"Service": map[string]string{
+			"Type":      "oneshot",
+			"ExecStart": "bar",
+		},
+	}
+
+	uf := &SystemdUnitFile{Contents: contents}
+	actual := uf.LegacyContents()
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Map func did not produce expected output.\nActual=%v\nExpected=%v", actual, expected)
+	}
+}
+
+func TestNewSystemdUnitFileFromLegacyContents(t *testing.T) {
+	legacy := map[string]map[string]string{
+		"Unit": map[string]string{
+			"Description": "foobar",
+		},
+		"Service": map[string]string{
+			"Type":      "oneshot",
+			"ExecStart": "/usr/bin/echo bar",
+		},
+	}
+
+	expected := map[string]map[string][]string{
+		"Unit": map[string][]string{
+			"Description": []string{"foobar"},
+		},
+		"Service": map[string][]string{
+			"Type":      []string{"oneshot"},
+			"ExecStart": []string{"/usr/bin/echo bar"},
+		},
+	}
+
+	actual := NewSystemdUnitFileFromLegacyContents(legacy).Contents
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Map func did not produce expected output.\nActual=%v\nExpected=%v", actual, expected)
 	}
 }


### PR DESCRIPTION
Storing the raw unit file means we can give to systemd exactly what the user provided rather than trying to re-serialize things. This also means our parsing logic will no longer stand in the way of users using multiple parameters,  multiline statements, etc.

This patch switches the parser over to use map[string]map[string][]string for its parsed form of a unit file, too.
