### PR TITLE
feat(agent): Allow to run jobs when the requirement in X-ConditionMachineBootID uses a short id.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -326,7 +326,7 @@ func (a *Agent) AbleToRun(j *job.Job) bool {
 	}
 
 	bootID, ok := requirements[unit.FleetXConditionMachineBootID]
-	if ok && len(bootID) > 0 && a.machine.State().BootID != bootID[0] {
+	if ok && len(bootID) > 0 && !a.machine.State().MatchBootID(bootID[0]) {
 		log.V(1).Infof("Agent does not pass MachineBootID condition for Job(%s)", j.Name)
 		return false
 	}

--- a/fleetctl/cmd.go
+++ b/fleetctl/cmd.go
@@ -166,7 +166,7 @@ func getEndpointFlag() string {
 func machineBootIDLegend(ms machine.MachineState, full bool) string {
 	legend := ms.BootID
 	if !full {
-		legend = ellipsize(legend, 8)
+		legend = fmt.Sprintf("%s...", ms.ShortBootID())
 	}
 	return legend
 }
@@ -177,18 +177,6 @@ func machineFullLegend(ms machine.MachineState, full bool) string {
 		legend = fmt.Sprintf("%s/%s", legend, ms.PublicIP)
 	}
 	return legend
-}
-
-func ellipsize(field string, n int) string {
-	// When ellipsing a field, we want to display the first n
-	// characters. We check for n+3 so we don't inadvertently
-	// make fields with fewer than n+3 characters even longer
-	// by adding unnecessary ellipses.
-	if len(field) > n+3 {
-		return fmt.Sprintf("%s...", field[0:n])
-	} else {
-		return field
-	}
 }
 
 func askToTrustHost(addr, algo, fingerprint string) bool {

--- a/machine/state.go
+++ b/machine/state.go
@@ -9,7 +9,10 @@ import (
 	"github.com/coreos/fleet/third_party/github.com/dotcloud/docker/pkg/netlink"
 )
 
-const bootIDPath = "/proc/sys/kernel/random/boot_id"
+const (
+	bootIDPath     = "/proc/sys/kernel/random/boot_id"
+	shortBootIDLen = 8
+)
 
 // MachineState represents a point-in-time snapshot of the
 // state of the local host.
@@ -27,6 +30,17 @@ func CurrentState() MachineState {
 	bootID := readLocalBootID()
 	publicIP := getLocalIP()
 	return MachineState{BootID: bootID, PublicIP: publicIP, Metadata: make(map[string]string, 0)}
+}
+
+func (s MachineState) ShortBootID() string {
+	if len(s.BootID) <= shortBootIDLen {
+		return s.BootID
+	}
+	return s.BootID[0:shortBootIDLen]
+}
+
+func (s MachineState) MatchBootID(bootID string) bool {
+	return s.BootID == bootID || s.ShortBootID() == bootID
 }
 
 // IsLocalMachineState checks whether machine state matches the state of local machine

--- a/machine/state_test.go
+++ b/machine/state_test.go
@@ -47,3 +47,65 @@ func TestStackStateEmptyTop(t *testing.T) {
 		t.Errorf("Unexpected Version value %s", stacked.Version)
 	}
 }
+
+var shortBootIDTests = []struct {
+	m MachineState
+	s string
+	l string
+}{
+	{
+		m: MachineState{},
+		s: "",
+		l: "",
+	},
+	{
+		m: MachineState{
+			"595989bb-cbb7-49ce-8726-722d6e157b4e",
+			"5.6.7.8",
+			map[string]string{"foo": "bar"},
+			"",
+		},
+		s: "595989bb",
+		l: "595989bb-cbb7-49ce-8726-722d6e157b4e",
+	},
+	{
+		m: MachineState{
+			"5959",
+			"5.6.7.8",
+			map[string]string{"foo": "bar"},
+			"",
+		},
+		s: "5959",
+		l: "5959",
+	},
+}
+
+func TestStateShortBootID(t *testing.T) {
+	for i, tt := range shortBootIDTests {
+		if g := tt.m.ShortBootID(); g != tt.s {
+			t.Errorf("#%d: got %q, want %q", i, g, tt.s)
+		}
+	}
+}
+
+func TestStateMatchBootID(t *testing.T) {
+	for i, tt := range shortBootIDTests {
+		if tt.s != "" {
+			if ok := tt.m.MatchBootID(""); ok {
+				t.Errorf("#%d: expected %v", i, false)
+			}
+		}
+
+		if ok := tt.m.MatchBootID("foobar"); ok {
+			t.Errorf("#%d: expected %v", i, false)
+		}
+
+		if ok := tt.m.MatchBootID(tt.l); !ok {
+			t.Errorf("#%d: expected %v", i, true)
+		}
+
+		if ok := tt.m.MatchBootID(tt.s); !ok {
+			t.Errorf("#%d: expected %v", i, true)
+		}
+	}
+}


### PR DESCRIPTION
This makes the agent to pass the bootID check with a short bootID.

Fixes #147
