### PR TITLE
chore(fleetctl): consistent fleet logging

### DIFF
--- a/fleetctl/cat.go
+++ b/fleetctl/cat.go
@@ -20,7 +20,7 @@ the correct version of a unit is running.`,
 
 func printUnitAction(c *cli.Context) {
 	if len(c.Args()) != 1 {
-		fmt.Println("One unit file must be provided.")
+		fmt.Fprintln(os.Stderr, "One unit file must be provided.")
 		os.Exit(1)
 	}
 
@@ -28,7 +28,7 @@ func printUnitAction(c *cli.Context) {
 	payload := registryCtl.GetPayload(name)
 
 	if payload == nil {
-		fmt.Println("Job not found.")
+		fmt.Fprintf(os.Stderr, "Job %s not found.\n", name)
 		os.Exit(1)
 	}
 

--- a/fleetctl/debug_info.go
+++ b/fleetctl/debug_info.go
@@ -11,23 +11,24 @@ import (
 
 func newDebugInfoCommand() cli.Command {
 	return cli.Command{
-		Name:  "debug-info",
-		Usage: "Print out debug information",
+		Name:        "debug-info",
+		Usage:       "Print out debug information",
 		Description: `Lists all values stored in etcd, which could reflect the status of the cluster comprehensively`,
-		Action: debugInfoAction,
+		Action:      debugInfoAction,
 	}
 }
 
 func debugInfoAction(c *cli.Context) {
 	info, err := registryCtl.GetDebugInfo()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Get response from etcd error:", err)
+		fmt.Fprintf(os.Stderr, "Failed communicating with etcd: %v\n", err)
 		os.Exit(1)
 	}
 
 	fmt.Println("All fleet entries in etcd service:")
 	buf := new(bytes.Buffer)
 	if err = json.Indent(buf, []byte(info), "", "\t"); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed indenting json: %v\n", err)
 		os.Exit(1)
 	}
 	fmt.Println(buf.String())

--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/coreos/fleet/third_party/github.com/codegangsta/cli"
@@ -30,7 +29,7 @@ fleetctl journal --lines 100 foo.service`,
 
 func journalAction(c *cli.Context) {
 	if len(c.Args()) != 1 {
-		fmt.Println("One unit file must be provided.")
+		fmt.Fprintln(os.Stderr, "One unit file must be provided.")
 		os.Exit(1)
 	}
 	jobName := c.Args()[0]
@@ -38,7 +37,7 @@ func journalAction(c *cli.Context) {
 	js := registryCtl.GetJobState(jobName)
 
 	if js == nil {
-		fmt.Printf("%s does not appear to be running\n", jobName)
+		fmt.Fprintf(os.Stderr, "Job %s does not appear to be running.\n", jobName)
 		os.Exit(1)
 	}
 
@@ -49,7 +48,8 @@ func journalAction(c *cli.Context) {
 
 	retcode, err := runCommand(cmd, js.MachineState)
 	if err != nil {
-		log.Fatalf("Unable to run command over SSH: %v", err)
+		fmt.Fprintf(os.Stderr, "Failed running command over SSH: %v\n", err)
+		os.Exit(1)
 	}
 
 	os.Exit(retcode)

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -60,12 +60,12 @@ func startUnitAction(c *cli.Context) {
 		var err error
 		sc, err = sign.NewSignatureCreatorFromSSHAgent()
 		if err != nil {
-			fmt.Println("Fail to create SignatureCreator:", err)
+			fmt.Fprintf(os.Stderr, "Failed creating SignatureCreator: %v\n", err)
 			os.Exit(1)
 		}
 		sv, err = sign.NewSignatureVerifierFromSSHAgent()
 		if err != nil {
-			fmt.Println("Fail to create SignatureVerifier:", err)
+			fmt.Fprintf(os.Stderr, "Failed creating SignatureVerifier: %v\n", err)
 			os.Exit(1)
 		}
 	}
@@ -83,13 +83,13 @@ func startUnitAction(c *cli.Context) {
 
 			err = registryCtl.CreatePayload(payload)
 			if err != nil {
-				fmt.Printf("Creation of payload %s failed: %v\n", payload.Name, err)
+				fmt.Fprintf(os.Stderr, "Failed creating payload %s: %v\n", payload.Name, err)
 				os.Exit(1)
 			}
 			if toSign {
 				s, err := sc.SignPayload(payload)
 				if err != nil {
-					fmt.Printf("Creation of sign for payload %s failed: %v\n", payload.Name, err)
+					fmt.Fprintf(os.Stderr, "Failed creating sign for payload %s: %v\n", payload.Name, err)
 					os.Exit(1)
 				}
 				registryCtl.CreateSignatureSet(s)
@@ -99,7 +99,7 @@ func startUnitAction(c *cli.Context) {
 			s := registryCtl.GetSignatureSetOfPayload(name)
 			ok, err := sv.VerifyPayload(payload, s)
 			if !ok || err != nil {
-				fmt.Printf("Check of payload %s failed: %v\n", payload.Name, err)
+				fmt.Fprintf(os.Stderr, "Failed checking payload %s: %v\n", payload.Name, err)
 				os.Exit(1)
 			}
 		}
@@ -115,7 +115,7 @@ func startUnitAction(c *cli.Context) {
 		j := job.NewJob(jp.Name, requirements, &jp, nil)
 		err := registryCtl.CreateJob(j)
 		if err != nil {
-			fmt.Printf("Creation of job %s failed: %v\n", j.Name, err)
+			fmt.Fprintf(os.Stderr, "Failed creating job %s: %v\n", j.Name, err)
 			os.Exit(1)
 		}
 		registeredJobs[j.Name] = true

--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 
@@ -42,14 +41,15 @@ func printUnitStatus(c *cli.Context, jobName string) {
 	js := registryCtl.GetJobState(jobName)
 
 	if js == nil {
-		fmt.Printf("%s does not appear to be running\n", jobName)
+		fmt.Fprintf(os.Stderr, "Job %s does not appear to be running.\n", jobName)
 		os.Exit(1)
 	}
 
 	cmd := fmt.Sprintf("systemctl status -l %s", jobName)
 	retcode, err := runCommand(cmd, js.MachineState)
 	if err != nil {
-		log.Fatalf("Unable to run command over SSH: %v", err)
+		fmt.Fprintf(os.Stderr, "Failed running command over SSH: %v\n", err)
+		os.Exit(1)
 	}
 
 	os.Exit(retcode)

--- a/fleetctl/submit.go
+++ b/fleetctl/submit.go
@@ -36,7 +36,7 @@ func submitUnitsAction(c *cli.Context) {
 		var err error
 		sc, err = sign.NewSignatureCreatorFromSSHAgent()
 		if err != nil {
-			fmt.Println("Fail to create SignatureVerifier:", err)
+			fmt.Fprintf(os.Stderr, "Failed creating SignatureVerifier: %v\n", err)
 			os.Exit(1)
 		}
 	}
@@ -46,7 +46,7 @@ func submitUnitsAction(c *cli.Context) {
 	for i, v := range c.Args() {
 		payload, err := getJobPayloadFromFile(v)
 		if err != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintf(os.Stderr, "Failed fetching payload from %v: %v\n", v, err)
 			os.Exit(1)
 		}
 		payloads[i] = *payload
@@ -57,13 +57,13 @@ func submitUnitsAction(c *cli.Context) {
 	for _, payload := range payloads {
 		err := registryCtl.CreatePayload(&payload)
 		if err != nil {
-			fmt.Printf("Creation of payload %s failed: %v\n", payload.Name, err)
+			fmt.Fprintf(os.Stderr, "Failed creating payload %s: %v\n", payload.Name, err)
 			os.Exit(1)
 		}
 		if toSign {
 			s, err := sc.SignPayload(&payload)
 			if err != nil {
-				fmt.Printf("Creation of sign for payload %s failed: %v\n", payload.Name, err)
+				fmt.Fprintf(os.Stderr, "Failed creating sign for payload %s: %v\n", payload.Name, err)
 				os.Exit(1)
 			}
 			registryCtl.CreateSignatureSet(s)

--- a/fleetctl/verify.go
+++ b/fleetctl/verify.go
@@ -24,7 +24,7 @@ func verifyUnitAction(c *cli.Context) {
 	r := getRegistry()
 
 	if len(c.Args()) != 1 {
-		fmt.Println("One unit file must be provided.")
+		fmt.Fprintln(os.Stderr, "One unit file must be provided.")
 		os.Exit(1)
 	}
 
@@ -32,22 +32,26 @@ func verifyUnitAction(c *cli.Context) {
 	payload := r.GetPayload(name)
 
 	if payload == nil {
-		fmt.Println("Job not found.")
+		fmt.Fprintf(os.Stderr, "Job %s not found.\n", name)
 		os.Exit(1)
 	}
 
 	sv, err := sign.NewSignatureVerifierFromSSHAgent()
 	if err != nil {
-		fmt.Println("Fail to create SignatureVerifier:", err)
+		fmt.Fprintf(os.Stderr, "Failed creating SignatureVerifier: %v\n", err)
 		os.Exit(1)
 	}
 
 	s := r.GetSignatureSetOfPayload(name)
 	ok, err := sv.VerifyPayload(payload, s)
-	if !ok || err != nil {
-		fmt.Printf("Check of payload %s failed: %v\n", payload.Name, err)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed checking payload %s: %v\n", payload.Name, err)
 		os.Exit(1)
 	}
 
+	if !ok {
+		fmt.Printf("Failed to verify job(%s).\n", payload.Name)
+		os.Exit(1)
+	}
 	fmt.Printf("Succeed to verify job(%s).\n", payload.Name)
 }


### PR DESCRIPTION
1. Use fmt.Printf for command output.
2. Use os.Exit to set return code.
3. Use glog for debug logging, with the verbosity level controlled with
   a --debug flag. Everything should be logged using verbosity level 1
   (i.e. glog.V(1).Infof) so it is off by default.
