### PR TITLE
Remove double RefreshState on fleet startup. Various other logging and error handling cleanup.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -24,9 +24,8 @@ type Server struct {
 	eventStream *registry.EventStream
 }
 
-func New(cfg config.Config) *Server {
+func New(cfg config.Config) (*Server, error) {
 	m := machine.New(cfg.BootID, cfg.PublicIP, cfg.Metadata())
-	m.RefreshState()
 
 	regClient := etcd.NewClient(cfg.EtcdServers)
 	regClient.SetConsistency(etcd.STRONG_CONSISTENCY)
@@ -51,13 +50,13 @@ func New(cfg config.Config) *Server {
 
 	a, err := agent.New(r, eb, m, cfg.AgentTTL, cfg.UnitPrefix, verifier)
 	if err != nil {
-		//TODO: return this as an error object rather than panicking
-		panic(err)
+		log.Errorf("Error creating Agent")
+		return nil, err
 	}
 
 	e := engine.New(r, eb, m)
 
-	return &Server{a, e, m, r, eb, es}
+	return &Server{a, e, m, r, eb, es}, nil
 }
 
 func (self *Server) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
as best as I can tell, this RefreshState() in Agent startup is redundant with the one performed just beforehand during Server creation. I noticed this from the dupe log messages:

```
I0403 18:41:56.616462 11868 fleet.go:135] Continuing without config file
I0403 18:41:56.616543 11868 machine.go:20] Created Machine with static state {  map[] 0.1.4+git}
I0403 18:41:56.616589 11868 state.go:85] Attempting to retrieve IP route info from netlink
I0403 18:41:56.616964 11868 state.go:103] Found default route with interface wlp2s0
I0403 18:41:56.620516 11868 agent.go:95] Initializing Agent
I0403 18:41:56.620557 11868 state.go:85] Attempting to retrieve IP route info from netlink
I0403 18:41:56.621083 11868 state.go:103] Found default route with interface wlp2s0
```

after the change:

```
I0403 18:42:47.295546 11983 fleet.go:144] No provided or default config file found - proceeding without
I0403 18:42:47.295620 11983 fleet.go:63] Creating Server
I0403 18:42:47.295630 11983 machine.go:20] Created Machine with static state {  map[] 0.1.4+git}
I0403 18:42:47.295705 11983 state.go:85] Attempting to retrieve IP route info from netlink
I0403 18:42:47.296046 11983 state.go:103] Found default route with interface wlp2s0
I0403 18:42:47.297553 11983 agent.go:95] Initializing Agent
```

I also manually verified that the MachineState is identical between the two, but couldn't think of how to wire up a good integration test for this without some significant refactoring.
