### PR TITLE
fix(pkg): build reasonable path always

### DIFF
--- a/pkg/filepath_test.go
+++ b/pkg/filepath_test.go
@@ -1,24 +1,43 @@
 package pkg
 
 import (
+	"os"
+	"strings"
 	"testing"
 )
 
+var pathtests = []struct {
+	in     string
+	home   string
+	prefix string
+	suffix string
+	full   string
+}{
+	{"~/a", "", "/", "/a", ""},
+	{"~", "", "/", "", ""},
+	{"~~", "", "", "", "~~"},
+	{"~/a", "/home", "", "", "/home/a"},
+}
+
 // TestParseFilepath tests parsing filepath
 func TestParseFilepath(t *testing.T) {
-	path := ParseFilepath("~/")
-	if path[0] != '/' {
-		t.Fatal("fail to parse ~")
-	}
-
-	// parse filepaths of corner case
-	path = ParseFilepath("~")
-	if path[0] != '/' {
-		t.Fatal(path)
-		t.Fatal("fail to parse ~")
-	}
-	path = ParseFilepath("~~")
-	if path != "~~" {
-		t.Fatal("fail to parse ~~ correctly")
+	for _, test := range pathtests {
+		oldHome := os.Getenv("HOME")
+		if err := os.Setenv("HOME", test.home); err != nil {
+			t.Fatalf("Failed setting $HOME")
+		}
+		path := ParseFilepath(test.in)
+		if !strings.HasPrefix(path, test.prefix) {
+			t.Errorf("Failed parsing out prefix %v for %v", test.prefix, test.in)
+		}
+		if !strings.HasSuffix(path, test.suffix) {
+			t.Errorf("Failed parsing out suffix %v for %v", test.suffix, test.in)
+		}
+		if test.full != "" && path != test.full {
+			t.Errorf("Failed parsing out %v for %v", test.full, test.in)
+		}
+		if err := os.Setenv("HOME", oldHome); err != nil {
+			t.Fatalf("Failed recovering $HOME")
+		}
 	}
 }


### PR DESCRIPTION
It may fail to get the current-user home directory, and return
path like '~/xxx', which is rather bad.
Let it points to current directory when failing, and log it
for debug.
#298
