### PR TITLE
refactor(registry): Return boot ID from GetJobTarget

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -444,7 +444,7 @@ func (a *Agent) peerScheduledHere(jobName, peerName string) bool {
 	log.V(1).Infof("Looking for target of Peer(%s)", peerName)
 
 	//FIXME: ideally the machine would use its own knowledge rather than calling GetJobTarget
-	if tgt := a.registry.GetJobTarget(peerName); tgt == nil || tgt.BootID != a.machine.State().BootID {
+	if tgt := a.registry.GetJobTarget(peerName); tgt == "" || tgt != a.machine.State().BootID {
 		log.V(1).Infof("Peer(%s) of Job(%s) not scheduled here", peerName, jobName)
 		return false
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -46,7 +46,7 @@ func (self *Engine) GetJobsScheduledToMachine(machBootID string) []job.Job {
 
 	for _, j := range self.registry.GetAllJobs() {
 		tgt := self.registry.GetJobTarget(j.Name)
-		if tgt == nil || tgt.BootID != machBootID {
+		if tgt == "" || tgt != machBootID {
 			continue
 		}
 		jobs = append(jobs, j)

--- a/engine/partitions.go
+++ b/engine/partitions.go
@@ -177,9 +177,9 @@ func (eg *Engine) refreshCluster(force bool) {
 
 	jobs := eg.registry.GetAllJobs()
 	for _, j := range jobs {
-		mst := eg.registry.GetJobTarget(j.Name)
-		if mst != nil {
-			cu.populateJob(j.Name, mst.BootID)
+		tgt := eg.registry.GetJobTarget(j.Name)
+		if tgt != "" {
+			cu.populateJob(j.Name, tgt)
 		}
 	}
 

--- a/fleetctl/registry.go
+++ b/fleetctl/registry.go
@@ -20,7 +20,7 @@ type Registry interface {
 	CreateSignatureSet(s *sign.SignatureSet) error
 	GetSignatureSetOfPayload(name string) *sign.SignatureSet
 	DestroySignatureSetOfPayload(name string)
-	GetJobTarget(name string) *machine.MachineState
+	GetJobTarget(name string) string
 	GetMachineState(bootID string) *machine.MachineState
 	GetDebugInfo() (string, error)
 }
@@ -81,7 +81,7 @@ func (m MainRegistry) DestroySignatureSetOfPayload(name string) {
 	m.registry.DestroySignatureSetOfPayload(name)
 }
 
-func (m MainRegistry) GetJobTarget(name string) *machine.MachineState {
+func (m MainRegistry) GetJobTarget(name string) string {
 	return m.registry.GetJobTarget(name)
 }
 

--- a/fleetctl/registry_test.go
+++ b/fleetctl/registry_test.go
@@ -58,12 +58,12 @@ func (t TestRegistry) GetSignatureSetOfPayload(name string) *sign.SignatureSet {
 func (t TestRegistry) DestroySignatureSetOfPayload(name string) {
 }
 
-func (t TestRegistry) GetJobTarget(name string) *machine.MachineState {
+func (t TestRegistry) GetJobTarget(name string) string {
 	js := t.jobStates[name]
 	if js != nil {
-		return js.MachineState
+		return js.MachineState.BootID
 	}
-	return nil
+	return ""
 }
 
 func (t TestRegistry) GetMachineState(bootID string) *machine.MachineState {

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -117,10 +117,10 @@ func checkJobTarget(jobName string, maxAttempts int, out io.Writer, wg *sync.Wai
 	defer wg.Done()
 
 	for attempts := 0; attempts < maxAttempts; attempts++ {
-		ms := registryCtl.GetJobTarget(jobName)
+		tgt := registryCtl.GetJobTarget(jobName)
 
-		if ms != nil {
-			m := registryCtl.GetMachineState(ms.BootID)
+		if tgt != "" {
+			m := registryCtl.GetMachineState(tgt)
 			fmt.Fprintf(out, "Job %s scheduled to %s\n", jobName, machineFullLegend(*m, false))
 			return
 		}

--- a/fleetctl/start_test.go
+++ b/fleetctl/start_test.go
@@ -14,7 +14,7 @@ type BlockedTestRegistry struct {
 	TestRegistry
 }
 
-func (b BlockedTestRegistry) GetJobTarget(name string) *machine.MachineState {
+func (b BlockedTestRegistry) GetJobTarget(name string) string {
 	if name == "hello.service" {
 		time.Sleep(500 * time.Millisecond)
 	}
@@ -22,7 +22,7 @@ func (b BlockedTestRegistry) GetJobTarget(name string) *machine.MachineState {
 	if name == "echo.service" {
 		if b.EchoAttempts != 0 {
 			b.EchoAttempts--
-			return nil
+			return ""
 		}
 	}
 

--- a/registry/offer.go
+++ b/registry/offer.go
@@ -127,11 +127,7 @@ func (self *EventStream) filterEventJobUpdated(resp *etcd.Response) *event.Event
 		return nil
 	}
 
-	var bootID string
-	if target := self.registry.GetJobTarget(j.Name); target != nil {
-		bootID = target.BootID
-	}
-
+	bootID := self.registry.GetJobTarget(j.Name)
 	return &event.Event{"EventJobUpdated", j, bootID}
 }
 


### PR DESCRIPTION
No callers of Registry.GetJobTarget need a full MachineState object. Rather
than create a dummy object, GetJobTarget can simply return the boot ID.
