### PR TITLE
fix(payload): Use FleetXConflicts constant

### DIFF
--- a/job/payload.go
+++ b/job/payload.go
@@ -73,7 +73,7 @@ func (jp *JobPayload) Peers() []string {
 }
 
 func (jp *JobPayload) Conflicts() []string {
-	conflicts, ok := jp.Requirements()["Conflicts"]
+	conflicts, ok := jp.Requirements()[FleetXConflicts]
 	if ok {
 		return conflicts
 	} else {


### PR DESCRIPTION
The "Conflicts" string was still being used directly in job/payload.go. It should be using the constant FleetXConflicts.
