### PR TITLE
Replace codegangsta/cli

### DIFF
--- a/fleetctl/cat.go
+++ b/fleetctl/cat.go
@@ -10,6 +10,7 @@ var (
 	cmdCatUnit = &Command{
 		Name:    "cat",
 		Summary: "Output the contents of a submitted unit",
+		Usage:   "UNIT",
 		Description: `Outputs the unit file that is currently loaded in the cluster. Useful to verify
 the correct version of a unit is running.`,
 		Run: runCatUnit,
@@ -30,5 +31,5 @@ func runCatUnit(args []string) (exit int) {
 	}
 
 	fmt.Print(j.Payload.Unit.String())
-	return 0
+	return
 }

--- a/fleetctl/debug_info.go
+++ b/fleetctl/debug_info.go
@@ -28,5 +28,5 @@ func runDebugInfo(args []string) (exit int) {
 		return 1
 	}
 	fmt.Println(buf.String())
-	return 0
+	return
 }

--- a/fleetctl/destroy.go
+++ b/fleetctl/destroy.go
@@ -8,7 +8,8 @@ import (
 var cmdDestroyUnit = &Command{
 	Name:    "destroy",
 	Summary: "Destroy one or more units in the cluster",
-	Description: `Completely remove a running or submitted unit from the cluster.
+	Usage:   "UNIT...",
+	Description: `Completely remove one or more running or submitted units from the cluster.
 
 Instructs systemd on the host machine to stop the unit, deferring to systemd
 completely for any custom stop directives (i.e. ExecStop option in the unit
@@ -25,5 +26,5 @@ func runDestroyUnits(args []string) (exit int) {
 		registryCtl.DestroyJob(name)
 		fmt.Printf("Destroyed Job %s\n", name)
 	}
-	return 0
+	return
 }

--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -11,15 +11,15 @@ var (
 	cmdJournal = &Command{
 		Name:    "journal",
 		Summary: "Print the journal of a unit in the cluster to stdout",
+		Usage:   "[--lines=N] [--follow] job",
 		Run:     runJournal,
-		Description: `Outputs the journal of a unit by connecting to the machine that the unit
-	occupies.
+		Description: `Outputs the journal of a unit by connecting to the machine that the unit occupies.
 
-	Read the last 10 lines:
-		fleetctl journal foo.service
+Read the last 10 lines:
+	fleetctl journal foo.service
 
-	Read the last 100 lines:
-		fleetctl journal --lines 100 foo.service`,
+Read the last 100 lines:
+	fleetctl journal --lines 100 foo.service`,
 	}
 )
 

--- a/fleetctl/list_machines.go
+++ b/fleetctl/list_machines.go
@@ -8,6 +8,7 @@ import (
 var cmdListMachines = &Command{
 	Name:    "list-machines",
 	Summary: "Enumerate the current hosts in the cluster",
+	Usage:   "[--full] [--no-legend]",
 	Description: `Lists all active machines within the cluster. Previously active machines will
 not appear in this list.
 
@@ -46,7 +47,7 @@ func runListMachines(args []string) (exit int) {
 	}
 
 	out.Flush()
-	return 0
+	return
 }
 
 func formatMetadata(metadata map[string]string) string {

--- a/fleetctl/list_units.go
+++ b/fleetctl/list_units.go
@@ -10,18 +10,18 @@ import (
 var cmdListUnits = &Command{
 	Name:    "list-units",
 	Summary: "Enumerate units loaded in the cluster",
+	Usage:   "[--no-legend] [--full]",
 	Description: `Lists all units submitted or started on the cluster.
 
 For easily parsable output, you can remove the column headers:
-fleetctl list-units --no-legend
+	fleetctl list-units --no-legend
 
 Output the list without ellipses:
-fleetctl list-units --full`,
+	fleetctl list-units --full`,
 	Run: runListUnits,
 }
 
 func init() {
-	// TODO(jonboulle): de-dupe with list_machines
 	cmdListUnits.Flags.BoolVar(&sharedFlags.Full, "full", false, "Do not ellipsize fields on output")
 	cmdListUnits.Flags.BoolVar(&sharedFlags.NoLegend, "no-legend", false, "Do not print a legend (column headers)")
 }
@@ -40,11 +40,11 @@ func runListUnits(args []string) (exit int) {
 			ps = j.PayloadState
 		}
 		description := names[name]
-		printPayloadState(name, description, ps, sharedFlags.full)
+		printPayloadState(name, description, ps, sharedFlags.Full)
 	}
 
 	out.Flush()
-	return exit
+	return
 }
 
 func findAllUnits() (names map[string]string, sortable sort.StringSlice) {

--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -23,24 +23,27 @@ var (
 	cmdSSH                 = &Command{
 		Name:    "ssh",
 		Summary: "Open interactive shell on a machine in the cluster",
-		Usage:   "ssh [options] (machine|unit)",
-		Description: `Open an interactive shell on a specific machine in the cluster or on the machine where the specified unit is located.
+		Usage:   "[--forward-agent] [--machine|--unit] {MACHINE|UNIT}",
+		Description: `Open an interactive shell on a specific machine in the cluster or on the machine 
+where the specified unit is located.
+
+fleetctl tries to detect whether your first argument is a machine or a unit. 
+To skip this check use the --machine or --unit flags.
 
 Open a shell on a machine:
-fleetctl ssh 2444264c-eac2-4eff-a490-32d5e5e4af24
+	fleetctl ssh 2444264c-eac2-4eff-a490-32d5e5e4af24
 
 Open a shell from your laptop, to the machine running a specific unit, using a
 cluster member as a bastion host:
-fleetctl --tunnel 10.10.10.10 ssh foo.service
+	fleetctl --tunnel 10.10.10.10 ssh foo.service
 
 Open a shell on a machine and forward the authentication agent connection:
-fleetctl ssh -A 2444264c-eac2-4eff-a490-32d5e5e4af24
+	fleetctl ssh --forward-agent 2444264c-eac2-4eff-a490-32d5e5e4af24
 
-Tip: fleetctl tries to detect whether your first argument is a machine or a unit. To skip this check use the flags "-m" and "-u".
 
-Pro-Tip: Create an alias for --tunnel:
-Add "alias fleetctl=fleetctl --tunnel 10.10.10.10" to your bash profile.
-Now you can run all fleet commands locally.`,
+Tip: Create an alias for --tunnel.
+	- Add "alias fleetctl=fleetctl --tunnel 10.10.10.10" to your bash profile.
+	- Now you can run all fleet commands locally.`,
 		Run: runSSH,
 	}
 )

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -6,10 +6,6 @@ import (
 	"os"
 	"sync"
 	"time"
-
-	log "github.com/coreos/fleet/third_party/github.com/golang/glog"
-
-	"github.com/coreos/fleet/job"
 )
 
 const (
@@ -24,15 +20,16 @@ var (
 	cmdStartUnit = &Command{
 		Name:    "start",
 		Summary: "Schedule and execute one or more units in the cluster",
+		Usage:   "[--sign] [--no-block|--block-attempts=N] UNIT...",
 		Description: `Start one or many units on the cluster. Select units to start by glob matching
 for units in the current working directory or matching names of previously
 submitted units.
 
 Start a single unit:
-fleetctl start foo.service
+	fleetctl start foo.service
 
 Start an entire directory of units with glob matching:
-fleetctl start myservice/*
+	fleetctl start myservice/*
 
 You may filter suitable hosts based on metadata provided by the machine.
 Machine metadata is located in the fleet configuration file.`,
@@ -51,7 +48,7 @@ func runStartUnit(args []string) (exit int) {
 		fmt.Fprintln(os.Stderr, "No units specified.")
 		return 1
 	}
-	jobs, err := findOrCreateJobs(args, sharedFlags.sign)
+	jobs, err := findOrCreateJobs(args, sharedFlags.Sign)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed creating jobs: %v", err)
 		return 1
@@ -69,7 +66,7 @@ func runStartUnit(args []string) (exit int) {
 	if !flagNoBlock {
 		waitForScheduledUnits(registeredJobs, flagBlockAttempts, os.Stdout)
 	}
-	return 0
+	return
 }
 
 func waitForScheduledUnits(jobs map[string]bool, maxAttempts int, out io.Writer) {

--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -9,12 +9,13 @@ import (
 var cmdStatusUnits = &Command{
 	Name:    "status",
 	Summary: "Output the status of one or more units in the cluster",
+	Usage:   "UNIT...",
 	Description: `Output the status of one or more units currently running in the cluster.
 Supports glob matching of units in the current working directory or matches
 previously started units.
 
 Show status of a single unit:
-fleetctl status foo.service
+	fleetctl status foo.service
 
 Show status of an entire directory with glob matching:
 fleetctl status myservice/*`,
@@ -22,7 +23,6 @@ fleetctl status myservice/*`,
 }
 
 func runStatusUnits(args []string) (exit int) {
-	var retcode int
 	for i, v := range args {
 		// This extra newline here to match systemctl status output
 		if i != 0 {
@@ -30,12 +30,12 @@ func runStatusUnits(args []string) (exit int) {
 		}
 
 		name := path.Base(v)
-		retcode = printUnitStatus(name)
-		if retcode != 0 {
+		exit = printUnitStatus(name)
+		if exit != 0 {
 			break
 		}
 	}
-	return retcode
+	return
 }
 
 func printUnitStatus(jobName string) int {

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -8,6 +8,7 @@ import (
 var cmdStopUnit = &Command{
 	Name:    "stop",
 	Summary: "Halt one or more units in the cluster",
+	Usage:   "UNIT...",
 	Description: `Stop one or more units from running in the cluster, but allow them to be
 started again in the future.
 
@@ -16,10 +17,10 @@ completely for any custom stop directives (i.e. ExecStop option in the unit
 file).
 
 Stop a single unit:
-fleetctl stop foo.service
+	fleetctl stop foo.service
 
 Stop an entire directory of units with glob matching:
-fleetctl stop myservice/*`,
+	fleetctl stop myservice/*`,
 	Run: runStopUnit,
 }
 
@@ -29,5 +30,5 @@ func runStopUnit(args []string) (exit int) {
 		registryCtl.StopJob(name)
 		fmt.Printf("Requested Job %s stop\n", name)
 	}
-	return 0
+	return
 }

--- a/fleetctl/submit.go
+++ b/fleetctl/submit.go
@@ -14,16 +14,17 @@ import (
 var cmdSubmitUnit = &Command{
 	Name:    "submit",
 	Summary: "Upload one or more units to the cluster without starting them",
+	Usage:   "[--sign] UNIT...",
 	Description: `Upload one or more units to the cluster without starting them. Useful
-	for validating units before they are started.
+for validating units before they are started.
 
-	This operation is idempotent; if a named unit already exists in the cluster, it will not be resubmitted.
-	However, its signature will still be validated if "sign" is enabled.
+This operation is idempotent; if a named unit already exists in the cluster, it will not be resubmitted.
+However, its signature will still be validated if "sign" is enabled.
 
-	Submit a single unit:
+Submit a single unit:
 	fleetctl submit foo.service
 
-	Submit a directory of units with glob matching:
+Submit a directory of units with glob matching:
 	fleetctl submit myservice/*`,
 	Run: runSubmitUnits,
 }
@@ -33,12 +34,12 @@ func init() {
 }
 
 func runSubmitUnits(args []string) (exit int) {
-	_, err := findOrCreateJobs(args, sharedFlags.sign)
+	_, err := findOrCreateJobs(args, sharedFlags.Sign)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed creating jobs: %v", err)
-		return 1
+		fmt.Fprintf(os.Stderr, "Failed creating jobs: %v\n", err)
+		exit = 1
 	}
-	return 0
+	return
 }
 
 // findOrCreateJobs queries the Registry for Jobs matching the given names.
@@ -99,7 +100,7 @@ func findOrCreateJobs(names []string, signPayloads bool) ([]job.Job, error) {
 			s := registryCtl.GetSignatureSetOfPayload(name)
 			ok, err := sv.VerifyPayload(&(j.Payload), s)
 			if !ok || err != nil {
-				return nil, fmt.Errorf("Failed checking signature for Payload(%s): %v", j.payload.Name, err)
+				return nil, fmt.Errorf("Failed checking signature for Payload(%s): %v", j.Payload.Name, err)
 			}
 
 			log.V(1).Infof("Verified signature of Payload(%s)", j.Payload.Name)

--- a/fleetctl/verify.go
+++ b/fleetctl/verify.go
@@ -11,6 +11,7 @@ import (
 var cmdVerifyUnit = &Command{
 	Name:    "verify",
 	Summary: "Verify unit file signatures using local SSH identities",
+	Usage:   "UNIT",
 	Description: `Outputs whether or not unit file fits its signature. Useful to secure
 the data of a unit.`,
 	Run: runVerifyUnit,
@@ -24,7 +25,7 @@ func runVerifyUnit(args []string) (exit int) {
 	}
 
 	name := path.Base(args[0])
-	j := r.GetJob(name)
+	j := registryCtl.GetJob(name)
 	if j == nil {
 		fmt.Fprintf(os.Stderr, "Job %s not found.\n", name)
 		return 1
@@ -36,7 +37,7 @@ func runVerifyUnit(args []string) (exit int) {
 		return 1
 	}
 
-	s := r.GetSignatureSetOfPayload(name)
+	s := registryCtl.GetSignatureSetOfPayload(name)
 	ok, err := sv.VerifyPayload(&(j.Payload), s)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed checking payload %s: %v\n", j.Payload.Name, err)
@@ -47,6 +48,6 @@ func runVerifyUnit(args []string) (exit int) {
 		fmt.Printf("Failed to verify job(%s).\n", j.Payload.Name)
 		return 1
 	}
-	fmt.Printf("Succeed to verify job(%s).\n", j.Payload.Name)
-	return 0
+	fmt.Printf("Succeeded verifying job(%s).\n", j.Payload.Name)
+	return
 }

--- a/fleetctl/version.go
+++ b/fleetctl/version.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/coreos/fleet/version"
 )
 
@@ -14,5 +15,5 @@ var cmdVersion = &Command{
 
 func runVersion(args []string) (exit int) {
 	fmt.Println("fleetctl version", version.Version)
-	return 0
+	return
 }


### PR DESCRIPTION
We've had a lot of trouble with the CLI framework used by fleetctl. It assumes too much about our flags and doesn't allow us to write our command functions like we want. The amount of code required to get this job done is actually quite small, so let's just roll our own. We can still use rakyll/globalconf for top-level flag parsing, while using the flag library directly for command-specific options.
