### PR TITLE
refactor(job): drop job-updating

### DIFF
--- a/agent/event.go
+++ b/agent/event.go
@@ -90,26 +90,6 @@ func (eh *EventHandler) HandleEventJobStopped(ev event.Event) {
 	eh.agent.BidForPossibleJobs()
 }
 
-func (eh *EventHandler) HandleEventJobUpdated(ev event.Event) {
-	j := ev.Payload.(job.Job)
-
-	localBootID := eh.agent.Machine().State().BootID
-	targetBootID := ev.Context.(string)
-
-	if targetBootID != localBootID {
-		log.V(1).Infof("EventJobUpdated(%s): Job not scheduled to Agent %s, skipping", j.Name, localBootID)
-		return
-	}
-
-	if ok := eh.agent.VerifyJob(&j); !ok {
-		log.Errorf("EventJobUpdated(%s): Failed to verify job", j.Name)
-		return
-	}
-
-	log.V(1).Infof("EventJobUpdated(%s): Starting Job", j.Name)
-	eh.agent.StartJob(&j)
-}
-
 func (eh *EventHandler) HandleEventPayloadStateUpdated(ev event.Event) {
 	jobName := ev.Context.(string)
 	state := ev.Payload.(*job.PayloadState)

--- a/registry/event.go
+++ b/registry/event.go
@@ -23,7 +23,7 @@ func NewEventStream(client *etcd.Client, registry *Registry) *EventStream {
 
 func (self *EventStream) Stream(idx uint64, eventchan chan *event.Event) {
 	watchMap := map[string][]func(*etcd.Response) *event.Event{
-		path.Join(keyPrefix, jobPrefix):     []func(*etcd.Response) *event.Event{filterEventJobCreated, filterEventJobScheduled, filterEventJobStopped, self.filterEventJobUpdated},
+		path.Join(keyPrefix, jobPrefix):     []func(*etcd.Response) *event.Event{filterEventJobCreated, filterEventJobScheduled, filterEventJobStopped},
 		path.Join(keyPrefix, machinePrefix): []func(*etcd.Response) *event.Event{self.filterEventMachineCreated, self.filterEventMachineRemoved},
 		path.Join(keyPrefix, offerPrefix):   []func(*etcd.Response) *event.Event{self.filterEventJobOffered, filterEventJobBidSubmitted},
 	}

--- a/registry/job.go
+++ b/registry/job.go
@@ -129,14 +129,11 @@ func (r *Registry) CreateJob(j *job.Job) (err error) {
 	key := path.Join(keyPrefix, jobPrefix, j.Name, "object")
 	json, _ := marshal(j)
 
-	if r.JobScheduled(j.Name) {
-		_, err = r.etcd.Update(key, json, 0)
-	} else {
-		_, err = r.etcd.Create(key, json, 0)
-		if err != nil && err.(*etcd.EtcdError).ErrorCode == etcdErr.EcodeNodeExist {
-			err = errors.New("job already exists")
-		}
+	_, err = r.etcd.Create(key, json, 0)
+	if err != nil && err.(*etcd.EtcdError).ErrorCode == etcdErr.EcodeNodeExist {
+		err = errors.New("job already exists")
 	}
+
 	return
 }
 

--- a/registry/offer.go
+++ b/registry/offer.go
@@ -110,27 +110,6 @@ func (self *EventStream) filterEventJobOffered(resp *etcd.Response) *event.Event
 	return &event.Event{"EventJobOffered", jo, nil}
 }
 
-func (self *EventStream) filterEventJobUpdated(resp *etcd.Response) *event.Event {
-	if resp.Action != "update" {
-		return nil
-	}
-
-	baseName := path.Base(resp.Node.Key)
-	if baseName != "object" {
-		return nil
-	}
-
-	var j job.Job
-	err := unmarshal(resp.Node.Value, &j)
-	if err != nil {
-		log.V(1).Infof("Failed to deserialize Job: %s", err)
-		return nil
-	}
-
-	bootID := self.registry.GetJobTarget(j.Name)
-	return &event.Event{"EventJobUpdated", j, bootID}
-}
-
 func filterEventJobBidSubmitted(resp *etcd.Response) *event.Event {
 	if resp.Action != "set" {
 		return nil


### PR DESCRIPTION
Remove the hack that allowed a job to be restarted on
the scheduled Agent. This will be replaced by a proper
state machine.
