### PR TITLE
fleetctl ssh not detecting unit vs machine by default

### DIFF
--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -75,7 +75,7 @@ func runSSH(args []string) (exit int) {
 			return 1
 		}
 		// trim machine/unit name from args
-		if len(args) > 1 {
+		if len(args) > 0 {
 			args = args[1:]
 		}
 	}


### PR DESCRIPTION
```
# /home/core/fleet/bin/fleetctl --strict-host-key-checking=false ssh e7b336a8-e07c-4ca3-90bc-c9cd41aa36e4
bash: e7b336a8-e07c-4ca3-90bc-c9cd41aa36e4: command not found
Failed reading SSH channel: Process exited with: 127. Reason was:  ()
# /home/core/fleet/bin/fleetctl --strict-host-key-checking=false ssh --machine e7b336a8-e07c-4ca3-90bc-c9cd41aa36e4Last login: Wed Apr 16 23:07:38 2014 from 172.17.0.1
   ______                ____  _____
  / ____/___  ________  / __ \/ ___/
 / /   / __ \/ ___/ _ \/ / / /\__ \
/ /___/ /_/ / /  /  __/ /_/ /___/ /
\____/\____/_/   \___/\____//____/
core@smoke0 ~ $
```
