### PR TITLE
Flag regression after refactor

### DIFF
--- a/fleetctl/help.go
+++ b/fleetctl/help.go
@@ -25,11 +25,18 @@ var (
 			// trim leading/trailing whitespace and split into slice of lines
 			return strings.Split(strings.Trim(s, "\n\t "), "\n")
 		},
+		"printOption": func(name, defvalue, usage string) string {
+			prefix := "--"
+			if len(name) == 1 {
+				prefix = "-"
+			}
+			return fmt.Sprintf("\t%s%s=%s\t%s", prefix, name, defvalue, usage)
+		},
 	}
 )
 
 func init() {
-	globalUsageTemplate = template.Must(template.New("global_usage").Parse(`
+	globalUsageTemplate = template.Must(template.New("global_usage").Funcs(templFuncs).Parse(`
 NAME:
 {{printf "\t%s - %s" .Executable .Description}}
 
@@ -43,7 +50,7 @@ COMMANDS:{{range .Commands}}
 {{printf "\t%s\t%s" .Name .Summary}}{{end}}
 
 GLOBAL OPTIONS:{{range .Flags}}
-{{printf "\t--%s=%s\t%s" .Name .DefValue .Usage}}{{end}}
+{{printOption .Name .DefValue .Usage}}{{end}}
 
 Global options can also be configured via upper-case environment variables prefixed with "FLEETCTL_"
 For example, "some-flag" => "FLEETCTL_SOME_FLAG"
@@ -60,9 +67,9 @@ USAGE:
 DESCRIPTION:
 {{range $line := descToLines .Cmd.Description}}{{printf "\t%s" $line}}
 {{end}}
-{{if .CmdFlags}}OPTIONS:
-{{range .CmdFlags}}{{printf "\t--%s=%s\t%s" .Name .DefValue .Usage}}
-{{end}}
+{{if .CmdFlags}}OPTIONS:{{range .CmdFlags}}
+{{printOption .Name .DefValue .Usage}}{{end}}
+
 {{end}}For help on global options run "{{.Executable}} help"
 `[1:]))
 }

--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -11,7 +11,7 @@ var (
 	cmdJournal = &Command{
 		Name:    "journal",
 		Summary: "Print the journal of a unit in the cluster to stdout",
-		Usage:   "[--lines=N] [--follow] job",
+		Usage:   "[--lines=N] [-f|--follow] job",
 		Run:     runJournal,
 		Description: `Outputs the journal of a unit by connecting to the machine that the unit occupies.
 
@@ -26,6 +26,7 @@ Read the last 100 lines:
 func init() {
 	cmdJournal.Flags.IntVar(&flagLines, "lines", 10, "Number of recent log lines to return")
 	cmdJournal.Flags.BoolVar(&flagFollow, "follow", false, "Continuously print new entries as they are appended to the journal.")
+	cmdJournal.Flags.BoolVar(&flagFollow, "f", false, "Shorthand for --follow")
 }
 
 func runJournal(args []string) (exit int) {

--- a/fleetctl/list_machines.go
+++ b/fleetctl/list_machines.go
@@ -8,7 +8,7 @@ import (
 var cmdListMachines = &Command{
 	Name:    "list-machines",
 	Summary: "Enumerate the current hosts in the cluster",
-	Usage:   "[--full] [--no-legend]",
+	Usage:   "[-l|--full] [--no-legend]",
 	Description: `Lists all active machines within the cluster. Previously active machines will
 not appear in this list.
 
@@ -22,6 +22,7 @@ Output the list without truncation:
 
 func init() {
 	cmdListMachines.Flags.BoolVar(&sharedFlags.Full, "full", false, "Do not ellipsize fields on output")
+	cmdListMachines.Flags.BoolVar(&sharedFlags.Full, "l", false, "Shorthand for --full")
 	cmdListMachines.Flags.BoolVar(&sharedFlags.NoLegend, "no-legend", false, "Do not print a legend (column headers)")
 }
 

--- a/fleetctl/list_units.go
+++ b/fleetctl/list_units.go
@@ -10,7 +10,7 @@ import (
 var cmdListUnits = &Command{
 	Name:    "list-units",
 	Summary: "Enumerate units loaded in the cluster",
-	Usage:   "[--no-legend] [--full]",
+	Usage:   "[--no-legend] [-l|--full]",
 	Description: `Lists all units submitted or started on the cluster.
 
 For easily parsable output, you can remove the column headers:
@@ -23,6 +23,7 @@ Output the list without ellipses:
 
 func init() {
 	cmdListUnits.Flags.BoolVar(&sharedFlags.Full, "full", false, "Do not ellipsize fields on output")
+	cmdListUnits.Flags.BoolVar(&sharedFlags.Full, "l", false, "Shorthand for --full")
 	cmdListUnits.Flags.BoolVar(&sharedFlags.NoLegend, "no-legend", false, "Do not print a legend (column headers)")
 }
 

--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -24,7 +24,7 @@ var (
 	cmdSSH                 = &Command{
 		Name:    "ssh",
 		Summary: "Open interactive shell on a machine in the cluster",
-		Usage:   "[--forward-agent] [--machine|--unit] {MACHINE|UNIT}",
+		Usage:   "[-A|--forward-agent] [--machine|--unit] {MACHINE|UNIT}",
 		Description: `Open an interactive shell on a specific machine in the cluster or on the machine 
 where the specified unit is located.
 
@@ -53,6 +53,7 @@ func init() {
 	cmdSSH.Flags.StringVar(&flagMachine, "machine", "", "Open SSH connection to a specific machine.")
 	cmdSSH.Flags.StringVar(&flagUnit, "unit", "", "Open SSH connection to machine running provided unit.")
 	cmdSSH.Flags.BoolVar(&flagSSHAgentForwarding, "forward-agent", false, "Forward local ssh-agent to target machine.")
+	cmdSSH.Flags.BoolVar(&flagSSHAgentForwarding, "A", false, "Shorthand for --forward-agent")
 }
 
 func runSSH(args []string) (exit int) {


### PR DESCRIPTION
Both `fleetctl list-machines` and `fleetctl list-units` support a `-l` flag in the latest release. For example:

```
$ fleetctl list-machines -h
NAME:
   fleetctl list-machines - Enumerate the current hosts in the cluster

DESCRIPTION:
   Lists all active machines within the cluster. Previously active machines will
not appear in this list.

For easily parsable output, you can remove the column headers:
fleetctl list-machines --no-legend

Output the list without truncation:
fleetctl list-machines --full

OPTIONS:
   --full, -l   Do not ellipsize fields on output
   --no-legend  Do not print a legend (column headers)
```

However, in master, this `-l` flag is missing:

```
$ ./bin/fleetctl list-machines -h
Usage:
  -full=false: Do not ellipsize fields on output
  -no-legend=false: Do not print a legend (column headers)
flag: help requested
$ ./bin/fleetctl list-machines -l
flag provided but not defined: -l
```

The flag seems to have been dropped in commit 341433a62296e97b96d9e4f54400c54b29afafbb.
