### PR TITLE
flag parsing: flags to ssh commands

### DIFF
--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -13,6 +13,7 @@ import (
 	gossh "github.com/coreos/fleet/third_party/code.google.com/p/gosshnew/ssh"
 
 	"github.com/coreos/fleet/machine"
+	"github.com/coreos/fleet/pkg"
 	"github.com/coreos/fleet/ssh"
 )
 
@@ -84,6 +85,8 @@ func runSSH(args []string) (exit int) {
 		fmt.Fprintln(os.Stderr, "Requested machine could not be found.")
 		return 1
 	}
+
+	args = pkg.TrimToDashes(args)
 
 	var sshClient *ssh.SSHForwardingClient
 	if tun := getTunnelFlag(); tun != "" {

--- a/pkg/args.go
+++ b/pkg/args.go
@@ -1,0 +1,13 @@
+package pkg
+
+// TrimToDashes takes a slice of strings (e.g. a
+// command line) and returns everything after the first
+// double dash (--), if any are present
+func TrimToDashes(args []string) []string {
+	for i, arg := range args {
+		if arg == "--" {
+			return args[i+1:]
+		}
+	}
+	return args
+}

--- a/pkg/args_test.go
+++ b/pkg/args_test.go
@@ -1,0 +1,30 @@
+package pkg
+
+import "testing"
+
+func TestTrimToDashes(t *testing.T) {
+	var argtests = []struct {
+		input  []string
+		output []string
+	}{
+		{[]string{"foo", "bar", "baz"}, []string{"foo", "bar", "baz"}},
+		{[]string{"abc", "def", "--", "ghi"}, []string{"ghi"}},
+		{[]string{"abc", "def", "--"}, []string{}},
+		{[]string{"--"}, []string{}},
+		{[]string{"--", "abc", "def", "ghi"}, []string{"abc", "def", "ghi"}},
+		{[]string{"--", "bar", "--", "baz"}, []string{"bar", "--", "baz"}},
+		{[]string{"--flagname", "--", "ghi"}, []string{"ghi"}},
+		{[]string{"--", "--flagname", "ghi"}, []string{"--flagname", "ghi"}},
+	}
+	for _, test := range argtests {
+		args := TrimToDashes(test.input)
+		if len(test.output) != len(args) {
+			t.Fatalf("error trimming dashes: expected %s, got %s", test.output, args)
+		}
+		for i, v := range args {
+			if v != test.output[i] {
+				t.Fatalf("error trimming dashes: expected %s, got %s", test.output, args)
+			}
+		}
+	}
+}


### PR DESCRIPTION
In the latest release of fleetctl I can't do something like:

```
fleetctl ssh dd -- echo -n "hello world"
```

This is because the -n get interpreted as an arg to fleetctl. Is this fixed with the latest changes to the flag parsing?

/cc @jonboulle 
