### PR TITLE
fix(scheduling): Correct the ConditionMachineOf behavior (mostly)

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -56,11 +56,6 @@ func (self *Engine) GetJobsScheduledToMachine(machBootID string) []job.Job {
 	return jobs
 }
 
-func (self *Engine) UnscheduleJob(jobName string) {
-	self.registry.UnscheduleJob(jobName)
-	log.Infof("Unscheduled Job(%s)", jobName)
-}
-
 func (self *Engine) OfferJob(j job.Job) error {
 	log.V(2).Infof("Attempting to lock Job(%s)", j.Name)
 

--- a/registry/event.go
+++ b/registry/event.go
@@ -23,7 +23,7 @@ func NewEventStream(client *etcd.Client, registry *Registry) *EventStream {
 
 func (self *EventStream) Stream(idx uint64, eventchan chan *event.Event) {
 	watchMap := map[string][]func(*etcd.Response) *event.Event{
-		path.Join(keyPrefix, jobPrefix):     []func(*etcd.Response) *event.Event{filterEventJobDestroyed, filterEventJobScheduled, self.filterJobTargetStateChanges},
+		path.Join(keyPrefix, jobPrefix):     []func(*etcd.Response) *event.Event{filterEventJobDestroyed, filterEventJobScheduled, filterEventJobUnscheduled, self.filterJobTargetStateChanges},
 		path.Join(keyPrefix, machinePrefix): []func(*etcd.Response) *event.Event{self.filterEventMachineCreated, self.filterEventMachineRemoved},
 		path.Join(keyPrefix, offerPrefix):   []func(*etcd.Response) *event.Event{self.filterEventJobOffered, filterEventJobBidSubmitted},
 	}


### PR DESCRIPTION
This defines ConditionMachineOf as a live scheduling relationship. The system should be guaranteeing units with a target-state of 'launched' are actually 'launched' after migrating around the cluster, but that's a bit bigger than the scope of ConditionMachineOf. That will be addressed in a subsequent PR.

Here's what I did at a high level:
- Stop creating job offers in the agents, just clear a job's target
- Add EventJobUnscheduled, facilitating communication of need to reschedule
- Only clear a job's target if it the target is known

Fix #287 
