### PR TITLE
refactor(fleetctl): Break apart lazyCreateJobs

### DIFF
--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -39,8 +39,7 @@ func init() {
 }
 
 func runStartUnit(args []string) (exit int) {
-	err := lazyCreateJobs(args, sharedFlags.Sign)
-	if err != nil {
+	if err := lazyCreateJobs(args, sharedFlags.Sign); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return 1
 	}


### PR DESCRIPTION
The submit action needs to fail if it cannot create a Job, while the other callers of lazyCreateJobs just want to make sure a job/payload exist. Add a test to solidify this behavior of fleetctl submit.
