### PR TITLE
Subscribe to dbus events before writing unit file

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -234,16 +234,6 @@ func (a *Agent) LoadJob(j *job.Job) {
 	}
 
 	a.systemd.LoadJob(j)
-
-	//TODO(bcwaldon): Investigate whether or not this manual
-	// fetching of the payload state is necessary.
-	ps, err := a.systemd.GetPayloadState(j.Name)
-	if err != nil {
-		log.Errorf("Failed fetching state of Job(%s)", j.Name)
-		return
-	}
-
-	a.ReportPayloadState(j.Name, ps)
 }
 
 func (a *Agent) StartJob(jobName string) {

--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -81,8 +81,8 @@ func (m *SystemdManager) Publish(bus *event.EventBus, stopchan chan bool) {
 // relevant dbus events, and only if necessary, instructs the systemd
 // daemon to reload
 func (m *SystemdManager) LoadJob(job *job.Job) {
-	m.writeUnit(job.Name, job.Payload.Unit.String())
 	m.subscriptions.Add(job.Name)
+	m.writeUnit(job.Name, job.Payload.Unit.String())
 
 	if m.unitRequiresDaemonReload(job.Name) {
 		m.daemonReload()


### PR DESCRIPTION
We don't have to manually refresh the unit state if we simply subscribe to its events before creating it.
