### PR TITLE
feat(payload): Add support for Path unit types.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -380,7 +380,12 @@ func (a *Agent) AbleToRun(j *job.Job) bool {
 		return false
 	}
 
-	peers := j.Payload.Peers()
+	peers, err := j.Payload.Peers()
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
 	if len(peers) > 0 {
 		log.V(1).Infof("Asserting required Peers %v of Job(%s) are scheduled locally", peers, j.Name)
 		for _, peer := range peers {

--- a/agent/state.go
+++ b/agent/state.go
@@ -77,7 +77,13 @@ func (self *AgentState) TrackJob(j *job.Job) {
 	self.lock()
 	defer self.unlock()
 
-	self.trackJobPeers(j.Name, j.Payload.Peers())
+	peers, err := j.Payload.Peers()
+	if err != nil {
+		log.Error("Received error while getting peers for '%s': %v", j.Name, err)
+	} else {
+		self.trackJobPeers(j.Name, peers)
+	}
+
 	self.trackJobConflicts(j.Name, j.Payload.Conflicts())
 }
 

--- a/job/type.go
+++ b/job/type.go
@@ -1,0 +1,78 @@
+package job
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	PathUnit    = "path"
+	ServiceUnit = "service"
+	SocketUnit  = "socket"
+	TimerUnit   = "timer"
+)
+
+func SupportedUnitTypes() []string {
+	return []string{PathUnit, ServiceUnit, SocketUnit, TimerUnit}
+}
+
+func newJobType(jtName string) JobType {
+	switch jtName {
+	case PathUnit:
+		return &PathType{jtName}
+	case ServiceUnit:
+		return &ServiceType{jtName}
+	default:
+		return &JobUnitType{jtName}
+	}
+}
+
+type JobType interface {
+	Peers(jp *JobPayload) []string
+}
+
+type JobUnitType struct {
+	name string
+}
+
+// Peers assigns the service with the same name to the unit
+// for default unit type, like socket and timer.
+func (jt *JobUnitType) Peers(jp *JobPayload) (peers []string) {
+	peers = append(peers, servicePeer(jp.Name, jt.name))
+	return
+}
+
+type PathType JobUnitType
+
+// Peers returns the unit peers for the path job.
+// The service with the same name is assigned
+// when the configuration doesn't specify a `Unit` to pair with.
+func (pt *PathType) Peers(jp *JobPayload) (peers []string) {
+	pathSection, ok := jp.Unit.Contents["Path"]
+	if !ok {
+		//Section `Path` is required, no peers.
+		return
+	}
+
+	if units, ok := pathSection["Unit"]; ok {
+		peers = units
+		return
+	}
+
+	peers = append(peers, servicePeer(jp.Name, pt.name))
+	return
+}
+
+type ServiceType JobUnitType
+
+// Peers doesn't asign units to pair a service.
+// Services need to use X-ConditionMachineOf to specify
+// the machines where they need to be scheduled.
+func (st *ServiceType) Peers(jp *JobPayload) (peers []string) {
+	return
+}
+
+func servicePeer(jpName, jtName string) string {
+	baseName := strings.TrimSuffix(jpName, fmt.Sprintf(".%s", jtName))
+	return fmt.Sprintf("%s.%s", baseName, "service")
+}

--- a/job/type_test.go
+++ b/job/type_test.go
@@ -1,0 +1,33 @@
+package job
+
+import (
+	"testing"
+)
+
+func TestNewPathType(t *testing.T) {
+	jt := newJobType(PathUnit)
+
+	if j, ok := jt.(*PathType); !ok {
+		t.Errorf("Unexpected job type %q", j)
+	}
+}
+
+func TestNewServiceType(t *testing.T) {
+	jt := newJobType(ServiceUnit)
+
+	if j, ok := jt.(*ServiceType); !ok {
+		t.Errorf("Unexpected job type %q", j)
+	}
+}
+
+func TestNewJobUnitType(t *testing.T) {
+	types := []string{SocketUnit, TimerUnit}
+
+	for _, tt := range types {
+		jt := newJobType(tt)
+
+		if j, ok := jt.(*JobUnitType); !ok {
+			t.Errorf("Unexpected job type %q for %s", j, tt)
+		}
+	}
+}


### PR DESCRIPTION
It also moves the logic to retrieve peers for unit types to an interface.
This way we can specify what to do for each type.
