### PR TITLE
Drop default peer behavior

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -49,30 +49,12 @@ func (self *Job) Requirements() map[string][]string {
 }
 
 // Peers returns a list of Job names that must be scheduled to the same
-// machine as this Job. If no peers were explicitly defined for certain unit
-// types, a default list of peers will be returned. This behavior only applies
-// to the socket unit type. For example, the default peer of foo.socket would
-// be foo.service.
+// machine as this Job.
 func (self *Job) Peers() []string {
-	if peers, ok := self.Requirements()[unit.FleetXConditionMachineOf]; ok {
-		return peers
+	peers, ok := self.Requirements()[unit.FleetXConditionMachineOf]
+	if !ok {
+		return []string{}
 	}
-
-	peers := make([]string, 0)
-
-	jType, err := self.Type()
-	if err != nil {
-		return peers
-	}
-
-	if jType != "socket" {
-		return peers
-	}
-
-	baseName := strings.TrimSuffix(self.Name, fmt.Sprintf(".%s", jType))
-	serviceName := fmt.Sprintf("%s.%s", baseName, "service")
-	peers = append(peers, serviceName)
-
 	return peers
 }
 

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -44,8 +44,8 @@ func TestNewJobGoodTypes(t *testing.T) {
 	}
 }
 
-func TestJobServiceDefaultPeers(t *testing.T) {
-	j := NewJob("echo.service", *unit.NewUnit(""))
+func TestJobWithPeers(t *testing.T) {
+	j := NewJob("echo.service", *unit.NewUnit(``))
 	peers := j.Peers()
 
 	if len(peers) != 0 {
@@ -53,16 +53,23 @@ func TestJobServiceDefaultPeers(t *testing.T) {
 	}
 }
 
-func TestJobSocketDefaultPeers(t *testing.T) {
-	j := NewJob("echo.socket", *unit.NewUnit(""))
+func TestJobWithoutPeers(t *testing.T) {
+	contents := `[X-Fleet]
+X-ConditionMachineOf="foo.service" "bar.service"
+`
+	j := NewJob("echo.service", *unit.NewUnit(contents))
 	peers := j.Peers()
 
-	if len(peers) != 1 {
-		t.Fatalf("Unexpected number of peers %d, expected 1", len(peers))
+	if len(peers) != 2 {
+		t.Fatalf("Unexpected number of peers %d, expected 2", len(peers))
 	}
 
-	if peers[0] != "echo.service" {
-		t.Fatalf("Unexpected peers: %v", peers)
+	if peers[0] != "foo.service" {
+		t.Errorf("Expected first peer to be foo.service, got %s", peers[0])
+	}
+
+	if peers[1] != "bar.service" {
+		t.Errorf("Expected second peer to be bar.service, got %s", peers[1])
 	}
 }
 


### PR DESCRIPTION
Creating a default set of peers in the engine is convenient, but can have unintended consequences. A user should have to explicitly define the set of peers a given Job needs before submitting a unit to the cluster.

This is dependent on https://github.com/coreos/fleet/pull/325.
