### PR TITLE
Fix conflict-checking in Agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -377,7 +377,6 @@ func (a *Agent) AbleToRun(j *job.Job) bool {
 	requirements := j.Requirements()
 	if len(requirements) == 0 {
 		log.V(1).Infof("Job(%s) has no requirements", j.Name)
-		return true
 	}
 
 	log.Infof("Job(%s) has requirements: %s", j.Name, requirements)

--- a/functional/fixtures/units/conflicts-with-hello.service
+++ b/functional/fixtures/units/conflicts-with-hello.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Test Unit
+
+[Service]
+ExecStart=/bin/bash -c "while true; do echo Hello, World!; sleep 1; done"
+
+[X-Fleet]
+X-Conflicts=hello.service


### PR DESCRIPTION
Agent.AbleToRun must not short-circuit when a job defines no requirements as there may be a job already scheduled locally that has a conflict. 
