### PR TITLE
Refresh Machine state before Agent/Engine init

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -105,7 +105,6 @@ func (a *Agent) Run() {
 // index of the first successful response received from etcd.
 func (a *Agent) initialize() uint64 {
 	log.Infof("Initializing Agent")
-	a.machine.RefreshState()
 
 	var idx uint64
 	wait := time.Second

--- a/server/server.go
+++ b/server/server.go
@@ -32,6 +32,7 @@ func New(cfg config.Config) (*Server, error) {
 
 func newAgentFromConfig(cfg config.Config) (*agent.Agent, error) {
 	mach := machine.New("", cfg.PublicIP, cfg.Metadata())
+	mach.RefreshState()
 
 	regClient := etcd.NewClient(cfg.EtcdServers)
 	regClient.SetConsistency(etcd.STRONG_CONSISTENCY)
@@ -56,6 +57,7 @@ func newAgentFromConfig(cfg config.Config) (*agent.Agent, error) {
 
 func newEngineFromConfig(cfg config.Config) *engine.Engine {
 	mach := machine.New("", cfg.PublicIP, cfg.Metadata())
+	mach.RefreshState()
 
 	regClient := etcd.NewClient(cfg.EtcdServers)
 	regClient.SetConsistency(etcd.STRONG_CONSISTENCY)


### PR DESCRIPTION
The Machine state needs to be rereshed so it can have a chance
to read the machine-id before it registers with event listeners.
