### PR TITLE
fix(fleetctl): Print job targets when state changes occur

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -471,7 +471,15 @@ func checkJobState(jobName string, js job.JobState, maxAttempts int, out io.Writ
 			continue
 		}
 
-		fmt.Fprintf(out, "Job %s %s\n", jobName, *(j.State))
+		msg := fmt.Sprintf("Job %s %s", jobName, *(j.State))
+
+		if tgt := registryCtl.GetJobTarget(jobName); tgt != "" {
+			if ms := registryCtl.GetMachineState(tgt); ms != nil {
+				msg = fmt.Sprintf("%s on %s", msg, machineFullLegend(*ms, false))
+			}
+		}
+
+		fmt.Fprintln(out, msg)
 		return
 	}
 


### PR DESCRIPTION
This feature was dropped during the great state refactor. Return it to its previous glory:

```
core@core-03 ~/fleet $ ./bin/fleetctl load ping.service
Job ping.service loaded on 1c52a187.../172.17.8.101
core@core-03 ~/fleet $ ./bin/fleetctl start ping.service
Job ping.service launched on 1c52a187.../172.17.8.101
core@core-03 ~/fleet $ ./bin/fleetctl stop ping.service
Job ping.service loaded on 1c52a187.../172.17.8.101
core@core-03 ~/fleet $ ./bin/fleetctl unload ping.service
Job ping.service inactive
```
