### PR TITLE
refactor(*): remove all use of "self" for receiver names

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,10 +22,10 @@ type Config struct {
 	AuthorizedKeysFile string
 }
 
-func (self *Config) Metadata() map[string]string {
+func (c *Config) Metadata() map[string]string {
 	meta := make(map[string]string, 0)
 
-	for _, pair := range strings.Split(self.RawMetadata, ",") {
+	for _, pair := range strings.Split(c.RawMetadata, ",") {
 		parts := strings.SplitN(pair, "=", 2)
 		if len(parts) != 2 {
 			continue

--- a/engine/event.go
+++ b/engine/event.go
@@ -16,67 +16,67 @@ func NewEventHandler(engine *Engine) *EventHandler {
 	return &EventHandler{engine}
 }
 
-func (self *EventHandler) HandleCommandLoadJob(ev event.Event) {
+func (eh *EventHandler) HandleCommandLoadJob(ev event.Event) {
 	jobName := ev.Payload.(string)
 
-	j := self.engine.registry.GetJob(jobName)
+	j := eh.engine.registry.GetJob(jobName)
 	if j == nil {
 		log.Infof("CommandLoadJob(%s): asked to offer job that could not be found")
 		return
 	}
 
 	log.Infof("CommandLoadJob(%s): publishing JobOffer", jobName)
-	self.engine.OfferJob(*j)
+	eh.engine.OfferJob(*j)
 }
 
-func (self *EventHandler) HandleCommandUnloadJob(ev event.Event) {
+func (eh *EventHandler) HandleCommandUnloadJob(ev event.Event) {
 	jobName := ev.Payload.(string)
 	target := ev.Context.(string)
 
 	if target != "" {
 		log.Infof("CommandUnloadJob(%s): clearing scheduling decision", jobName)
-		self.engine.registry.ClearJobTarget(jobName, target)
+		eh.engine.registry.ClearJobTarget(jobName, target)
 	}
 }
 
-func (self *EventHandler) HandleEventJobScheduled(ev event.Event) {
+func (eh *EventHandler) HandleEventJobScheduled(ev event.Event) {
 	jobName := ev.Payload.(string)
 	target := ev.Context.(string)
 	log.V(1).Infof("EventJobScheduled(%s): updating cluster", jobName)
-	self.engine.clust.jobScheduled(jobName, target)
+	eh.engine.clust.jobScheduled(jobName, target)
 }
 
 // EventJobUnscheduled is triggered when a scheduling decision has been
 // rejected, or is now unfulfillable due to changes in the cluster.
 // Attempt to reschedule the job if it is in a non-inactive state.
-func (self *EventHandler) HandleEventJobUnscheduled(ev event.Event) {
+func (eh *EventHandler) HandleEventJobUnscheduled(ev event.Event) {
 	jobName := ev.Payload.(string)
 
-	ts := self.engine.registry.GetJobTargetState(jobName)
+	ts := eh.engine.registry.GetJobTargetState(jobName)
 	if ts == nil || *ts == job.JobStateInactive {
 		return
 	}
 
-	j := self.engine.registry.GetJob(jobName)
+	j := eh.engine.registry.GetJob(jobName)
 	if j == nil {
 		log.Errorf("EventJobUnscheduled(%s): unable to re-offer Job, as it could not be found in the Registry", jobName)
 		return
 	}
 
 	log.Infof("EventJobUnscheduled(%s): publishing JobOffer", jobName)
-	self.engine.OfferJob(*j)
+	eh.engine.OfferJob(*j)
 }
 
-func (self *EventHandler) HandleCommandStopJob(ev event.Event) {
+func (eh *EventHandler) HandleCommandStopJob(ev event.Event) {
 	jobName := ev.Payload.(string)
 	log.V(1).Infof("EventJobStopped(%s): updating cluster", jobName)
-	self.engine.clust.jobStopped(jobName)
+	eh.engine.clust.jobStopped(jobName)
 }
 
-func (self *EventHandler) HandleEventJobBidSubmitted(ev event.Event) {
+func (eh *EventHandler) HandleEventJobBidSubmitted(ev event.Event) {
 	jb := ev.Payload.(job.JobBid)
 
-	err := self.engine.ResolveJobOffer(jb.JobName, jb.MachineID)
+	err := eh.engine.ResolveJobOffer(jb.JobName, jb.MachineID)
 	if err == nil {
 		log.Infof("EventJobBidSubmitted(%s): successfully scheduled Job to Machine(%s)", jb.JobName, jb.MachineID)
 	} else {
@@ -84,32 +84,32 @@ func (self *EventHandler) HandleEventJobBidSubmitted(ev event.Event) {
 	}
 }
 
-func (self *EventHandler) HandleEventMachineCreated(ev event.Event) {
+func (eh *EventHandler) HandleEventMachineCreated(ev event.Event) {
 	machineState := ev.Payload.(machine.MachineState)
 	log.V(1).Infof("EventMachineCreated(%s): updating cluster", machineState.ID)
-	self.engine.clust.machineCreated(machineState.ID)
+	eh.engine.clust.machineCreated(machineState.ID)
 }
 
-func (self *EventHandler) HandleEventMachineRemoved(ev event.Event) {
+func (eh *EventHandler) HandleEventMachineRemoved(ev event.Event) {
 	machID := ev.Payload.(string)
-	mutex := self.engine.LockMachine(machID)
+	mutex := eh.engine.LockMachine(machID)
 	if mutex == nil {
 		log.V(1).Infof("EventMachineRemoved(%s): failed to lock Machine, ignoring event", machID)
 		return
 	}
 	defer mutex.Unlock()
 
-	jobs := self.engine.GetJobsScheduledToMachine(machID)
+	jobs := eh.engine.GetJobsScheduledToMachine(machID)
 
 	for _, j := range jobs {
 		log.Infof("EventMachineRemoved(%s): unscheduling Job(%s)", machID, j.Name)
-		self.engine.registry.ClearJobTarget(j.Name, machID)
-		self.engine.RemoveUnitState(j.Name)
+		eh.engine.registry.ClearJobTarget(j.Name, machID)
+		eh.engine.RemoveUnitState(j.Name)
 	}
 
 	for _, j := range jobs {
 		log.Infof("EventMachineRemoved(%s): re-publishing JobOffer(%s)", machID, j.Name)
-		self.engine.OfferJob(j)
+		eh.engine.OfferJob(j)
 	}
-	self.engine.clust.machineRemoved(machID)
+	eh.engine.clust.machineRemoved(machID)
 }

--- a/event/bus.go
+++ b/event/bus.go
@@ -17,32 +17,32 @@ func NewEventBus() *EventBus {
 	return &EventBus{listeners, make(chan *Event)}
 }
 
-func (self *EventBus) Listen(stop chan bool) {
+func (eb *EventBus) Listen(stop chan bool) {
 	go func() {
 		for {
 			select {
 			case <-stop:
 				return
-			case ev := <-self.Channel:
-				self.dispatch(ev)
+			case ev := <-eb.Channel:
+				eb.dispatch(ev)
 			}
 		}
 	}()
 }
 
-func (self *EventBus) AddListener(name string, l interface{}) {
-	self.listeners[name] = l
+func (eb *EventBus) AddListener(name string, l interface{}) {
+	eb.listeners[name] = l
 }
 
-func (self *EventBus) RemoveListener(name string) {
-	delete(self.listeners, name)
+func (eb *EventBus) RemoveListener(name string) {
+	delete(eb.listeners, name)
 }
 
 // Distribute an Event to all listeners registered to Event.Type
-func (self *EventBus) dispatch(ev *Event) {
+func (eb *EventBus) dispatch(ev *Event) {
 	log.V(1).Infof("Dispatching %s to listeners", ev.Type)
 	handlerFuncName := fmt.Sprintf("Handle%s", ev.Type)
-	for name, listener := range self.listeners {
+	for name, listener := range eb.listeners {
 		log.V(1).Infof("Looking for event handler func %s on listener %s", handlerFuncName, name)
 		handlerFunc := reflect.ValueOf(listener).MethodByName(handlerFuncName)
 		if handlerFunc.IsValid() {

--- a/job/job.go
+++ b/job/job.go
@@ -45,14 +45,14 @@ func NewJob(name string, unit unit.Unit) *Job {
 	}
 }
 
-func (self *Job) Requirements() map[string][]string {
-	return self.Unit.Requirements()
+func (j *Job) Requirements() map[string][]string {
+	return j.Unit.Requirements()
 }
 
 // Conflicts returns a list of Job names that cannot be scheduled to the same
 // machine as this Job.
-func (self *Job) Conflicts() []string {
-	conflicts, ok := self.Requirements()[unit.FleetXConflicts]
+func (j *Job) Conflicts() []string {
+	conflicts, ok := j.Requirements()[unit.FleetXConflicts]
 	if ok {
 		return conflicts
 	} else {
@@ -62,8 +62,8 @@ func (self *Job) Conflicts() []string {
 
 // Peers returns a list of Job names that must be scheduled to the same
 // machine as this Job.
-func (self *Job) Peers() []string {
-	peers, ok := self.Requirements()[unit.FleetXConditionMachineOf]
+func (j *Job) Peers() []string {
+	peers, ok := j.Requirements()[unit.FleetXConditionMachineOf]
 	if !ok {
 		return []string{}
 	}
@@ -75,8 +75,8 @@ func (self *Job) Peers() []string {
 // represents the ID of such a machine, while the second value will be a bool
 // true. If no requirement exists, an empty string along with a bool false
 // will be returned.
-func (self *Job) RequiredTarget() (string, bool) {
-	requirements := self.Unit.Requirements()
+func (j *Job) RequiredTarget() (string, bool) {
+	requirements := j.Unit.Requirements()
 
 	machIDs, ok := requirements[unit.FleetXConditionMachineID]
 	if ok && len(machIDs) != 0 {
@@ -96,12 +96,12 @@ func (self *Job) RequiredTarget() (string, bool) {
 }
 
 // Type attempts to determine the Type of systemd unit that this Job contains, based on the suffix of the job name
-func (self *Job) Type() (string, error) {
+func (j *Job) Type() (string, error) {
 	for _, ut := range unit.SupportedUnitTypes() {
-		if strings.HasSuffix(self.Name, fmt.Sprintf(".%s", ut)) {
+		if strings.HasSuffix(j.Name, fmt.Sprintf(".%s", ut)) {
 			return ut, nil
 		}
 	}
 
-	return "", errors.New(fmt.Sprintf("Unrecognized systemd unit %s", self.Name))
+	return "", errors.New(fmt.Sprintf("Unrecognized systemd unit %s", j.Name))
 }

--- a/registry/event.go
+++ b/registry/event.go
@@ -20,9 +20,9 @@ func NewEventStream(client *etcd.Client, registry *Registry) *EventStream {
 	return &EventStream{client, registry}
 }
 
-func (self *EventStream) Stream(idx uint64, eventchan chan *event.Event, stop chan bool) {
+func (es *EventStream) Stream(idx uint64, eventchan chan *event.Event, stop chan bool) {
 	watchMap := map[string][]func(*etcd.Response) *event.Event{
-		path.Join(keyPrefix, jobPrefix):     []func(*etcd.Response) *event.Event{filterEventJobDestroyed, filterEventJobScheduled, filterEventJobUnscheduled, self.filterJobTargetStateChanges},
+		path.Join(keyPrefix, jobPrefix):     []func(*etcd.Response) *event.Event{filterEventJobDestroyed, filterEventJobScheduled, filterEventJobUnscheduled, es.filterJobTargetStateChanges},
 		path.Join(keyPrefix, machinePrefix): []func(*etcd.Response) *event.Event{filterEventMachineCreated, filterEventMachineRemoved},
 		path.Join(keyPrefix, offerPrefix):   []func(*etcd.Response) *event.Event{filterEventJobOffered, filterEventJobBidSubmitted},
 	}
@@ -30,7 +30,7 @@ func (self *EventStream) Stream(idx uint64, eventchan chan *event.Event, stop ch
 	for key, funcs := range watchMap {
 		for _, f := range funcs {
 			etcdchan := make(chan *etcd.Response)
-			go watch(self.etcd, idx, etcdchan, key, stop)
+			go watch(es.etcd, idx, etcdchan, key, stop)
 			go pipe(etcdchan, f, eventchan, stop)
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -68,20 +68,20 @@ func newEngineFromConfig(cfg config.Config) *engine.Engine {
 	return engine.New(reg, eStream, mach)
 }
 
-func (self *Server) Run() {
-	self.agent.Run()
-	self.engine.Run()
+func (s *Server) Run() {
+	s.agent.Run()
+	s.engine.Run()
 }
 
-func (self *Server) Stop() {
-	self.agent.Stop()
-	self.engine.Stop()
+func (s *Server) Stop() {
+	s.agent.Stop()
+	s.engine.Stop()
 }
 
-func (self *Server) Purge() {
-	self.agent.Purge()
+func (s *Server) Purge() {
+	s.agent.Purge()
 }
 
-func (self *Server) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct{ Agent *agent.Agent }{Agent: self.agent})
+func (s *Server) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct{ Agent *agent.Agent }{Agent: s.agent})
 }

--- a/systemd/event.go
+++ b/systemd/event.go
@@ -16,10 +16,10 @@ func NewEventStream() *EventStream {
 	return &EventStream{make(chan bool)}
 }
 
-func (self *EventStream) Stream(unitchan <-chan map[string]*dbus.UnitStatus, eventchan chan *event.Event) {
+func (es *EventStream) Stream(unitchan <-chan map[string]*dbus.UnitStatus, eventchan chan *event.Event) {
 	for true {
 		select {
-		case <-self.close:
+		case <-es.close:
 			return
 		case units := <-unitchan:
 			log.V(1).Infof("Received event from dbus")
@@ -33,8 +33,8 @@ func (self *EventStream) Stream(unitchan <-chan map[string]*dbus.UnitStatus, eve
 	}
 }
 
-func (self *EventStream) Close() {
-	close(self.close)
+func (es *EventStream) Close() {
+	close(es.close)
 }
 
 func translateUnitStatusEvents(changes map[string]*dbus.UnitStatus) []event.Event {

--- a/unit/file.go
+++ b/unit/file.go
@@ -8,8 +8,8 @@ import (
 
 // Description returns the first Description option found in the [Unit] section.
 // If the option is not defined, an empty string is returned.
-func (self *Unit) Description() string {
-	if values := self.Contents["Unit"]["Description"]; len(values) > 0 {
+func (u *Unit) Description() string {
+	if values := u.Contents["Unit"]["Description"]; len(values) > 0 {
 		return values[0]
 	}
 	return ""

--- a/unit/unit.go
+++ b/unit/unit.go
@@ -52,8 +52,8 @@ type Unit struct {
 	Raw string
 }
 
-func (self *Unit) String() string {
-	return self.Raw
+func (u *Unit) String() string {
+	return u.Raw
 }
 
 // Hash returns the SHA1 hash of the raw contents of the Unit


### PR DESCRIPTION
Be less Pythonic, more like Go. Per the [unofficial golang style guide](https://code.google.com/p/go-wiki/wiki/CodeReviewComments#Receiver_Names), "the name of a method's receiver should be a reflection of its identity".
