### PR TITLE
fix(job): marshal only Name and UnitHash for job

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -137,7 +137,7 @@ func (a *Agent) initialize() uint64 {
 		a.StartJob(j.Name)
 	}
 
-	for _, jo := range a.UnresolvedJobOffers() {
+	for _, jo := range a.registry.UnresolvedJobOffers() {
 		// Everything we check against could change over time, so we track
 		// all offers starting here for future bidding even if we are
 		// currently unable to bid
@@ -455,10 +455,6 @@ func (a *Agent) peerScheduledHere(jobName, peerName string) bool {
 
 	log.V(1).Infof("Peer(%s) of Job(%s) scheduled here", peerName, jobName)
 	return true
-}
-
-func (a *Agent) UnresolvedJobOffers() []job.JobOffer {
-	return a.registry.UnresolvedJobOffers()
 }
 
 // HasConflict determines whether there are any known conflicts with the given argument

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -77,10 +77,12 @@ func (e *Engine) OfferJob(j job.Job) error {
 
 	offer := job.NewOfferFromJob(j, machineIDs)
 
-	e.registry.CreateJobOffer(offer)
-	log.Infof("Published JobOffer(%s)", offer.Job.Name)
+	err = e.registry.CreateJobOffer(offer)
+	if err == nil {
+		log.Infof("Published JobOffer(%s)", offer.Job.Name)
+	}
 
-	return nil
+	return err
 }
 
 func (e *Engine) ResolveJobOffer(jobName string, machID string) error {

--- a/registry/event.go
+++ b/registry/event.go
@@ -24,7 +24,7 @@ func (es *EventStream) Stream(idx uint64, eventchan chan *event.Event, stop chan
 	watchMap := map[string][]func(*etcd.Response) *event.Event{
 		path.Join(es.registry.keyPrefix, jobPrefix):     []func(*etcd.Response) *event.Event{filterEventJobDestroyed, filterEventJobScheduled, filterEventJobUnscheduled, es.filterJobTargetStateChanges},
 		path.Join(es.registry.keyPrefix, machinePrefix): []func(*etcd.Response) *event.Event{filterEventMachineCreated, filterEventMachineRemoved},
-		path.Join(es.registry.keyPrefix, offerPrefix):   []func(*etcd.Response) *event.Event{filterEventJobOffered, filterEventJobBidSubmitted},
+		path.Join(es.registry.keyPrefix, offerPrefix):   []func(*etcd.Response) *event.Event{es.filterEventJobOffered, filterEventJobBidSubmitted},
 	}
 
 	for key, funcs := range watchMap {


### PR DESCRIPTION
Similarly, `JobOffer` should only embed this marshaled job, and hydrate where necessary.
