### PR TITLE
Go panic when parsing unit files that have line continuations

### DIFF
--- a/unit/file.go
+++ b/unit/file.go
@@ -41,14 +41,10 @@ func deserializeUnitFile(raw string) map[string]map[string][]string {
 	var section string
 	var prev string
 	for _, line := range strings.Split(raw, "\n") {
-		// Ignore commented-out lines
-		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
-			continue
-		}
 
 		// Join lines ending in backslash
 		if strings.HasSuffix(line, "\\") {
-			// replace trailing slash with space
+			// Replace trailing slash with space
 			prev = prev + line[:len(line)-1] + " "
 			continue
 		}
@@ -57,6 +53,9 @@ func deserializeUnitFile(raw string) map[string]map[string][]string {
 		if prev != "" {
 			line = prev + line
 			prev = ""
+		} else if strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			// Ignore commented-out lines that are not part of a continuation
+			continue
 		}
 
 		line = strings.TrimSpace(line)

--- a/unit/file_test.go
+++ b/unit/file_test.go
@@ -50,14 +50,21 @@ ExecStart=echo \
   "pi\
   ng"
 ExecStop=\
-# comment should be ignored
 echo "po\
 ng"
+# comments within continuation should not be ignored
+ExecStopPre=echo\
+#pang
+ExecStopPost=echo\
+#peng\
+pung
 `
 	expected := map[string]map[string][]string{
 		"Service": map[string][]string{
-			"ExecStart": []string{`echo    "pi   ng"`},
-			"ExecStop":  []string{`echo "po ng"`},
+			"ExecStart":    []string{`echo    "pi   ng"`},
+			"ExecStop":     []string{`echo "po ng"`},
+			"ExecStopPre":  []string{`echo #pang`},
+			"ExecStopPost": []string{`echo #peng pung`},
 		},
 	}
 	unitFile := NewUnit(contents)

--- a/unit/unit_test.go
+++ b/unit/unit_test.go
@@ -1,8 +1,8 @@
 package unit
 
-import (
-	"testing"
-)
+import "testing"
+import "reflect"
+import "github.com/coreos/fleet/machine"
 
 const (
 	// $ echo -n "foo" | sha1sum
@@ -22,4 +22,27 @@ func TestUnitHash(t *testing.T) {
 	if !eh.Empty() {
 		t.Fatalf("Empty hash check failed: %v", eh.Empty())
 	}
+}
+
+func TestSupportedUnitTypes(t *testing.T) {
+	ut := SupportedUnitTypes()
+	if len(ut) < 1 {
+		t.Fatalf("SupportedUnitTypes should return non-empty []string, got %v", ut)
+	}
+}
+
+func TestNewUnitState(t *testing.T) {
+	ms := &machine.MachineState{"id", "ip", nil, "version"}
+	want := &UnitState{
+		LoadState:    "ls",
+		ActiveState:  "as",
+		SubState:     "ss",
+		MachineState: ms,
+	}
+
+	got := NewUnitState("ls", "as", "ss", ms)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NewUnitState did not create a correct UnitState: got %s, want %s", got, want)
+	}
+
 }


### PR DESCRIPTION
From the [systemd.unit man page](http://www.freedesktop.org/software/systemd/man/systemd.unit.html):

> Lines ending in a backslash are concatenated with the following line while reading and the backslash is replaced by a space character. This may be used to wrap long lines.

`unit.deserializeUnitFile` currently does not handle this situation properly. If you attempt to feed a unit file with a line continuation in it (backslash at the end of the line) it dies with `panic: runtime error: index out of range`.

This is pretty easy to reproduce in the unit test with a minor change to the test data:

```
$ git diff
diff --git a/unit/file_test.go b/unit/file_test.go
index 7e25193..aeb701a 100644
--- a/unit/file_test.go
+++ b/unit/file_test.go
@@ -16,7 +16,8 @@ Description = Foo
 ExecStart=echo "ping";
 ExecStop=echo "pong"
 # ignore me, too
-ExecStop=echo post
+ExecStop=echo \
+       post

 [Fleet]
 X-ConditionMachineMetadata=foo=bar
$ go test github.com/coreos/fleet/unit
--- FAIL: TestDeserialize (0.00 seconds)
panic: runtime error: index out of range [recovered]
    panic: runtime error: index out of range
… output truncated …
```
