### PR TITLE
list-units should show unit hash

### DIFF
--- a/fleetctl/list_units.go
+++ b/fleetctl/list_units.go
@@ -77,6 +77,12 @@ Or, choose the columns to display:
 			}
 			return machineFullLegend(*us.MachineState, full)
 		},
+		"hash": func(j *job.Job, full bool) string {
+			if !full {
+				return j.UnitHash.Short()
+			}
+			return j.UnitHash.String()
+		},
 	}
 )
 

--- a/fleetctl/list_units_test.go
+++ b/fleetctl/list_units_test.go
@@ -73,9 +73,8 @@ func TestFieldsToStrings(t *testing.T) {
 	f := fieldsToOutput["unit"](j, false)
 	assertEqual(t, "unit", "test", f)
 
-	j.Unit = *unit.NewUnit(`[Unit]
-Description=some description
-`)
+	j = job.NewJob("test", *unit.NewUnit(`[Unit]
+Description=some description`))
 	d := fieldsToOutput["desc"](j, false)
 	assertEqual(t, "desc", "some description", d)
 
@@ -99,4 +98,10 @@ Description=some description
 	j.UnitState.MachineState = &machine.MachineState{"some-id", "1.2.3.4", nil, "", resource.ResourceTuple{}}
 	ms := fieldsToOutput["machine"](j, true)
 	assertEqual(t, "machine", "some-id/1.2.3.4", ms)
+
+	uh := "f035b2f14edc4d23572e5f3d3d4cb4f78d0e53c3"
+	fuh := fieldsToOutput["hash"](j, true)
+	suh := fieldsToOutput["hash"](j, false)
+	assertEqual(t, "hash", uh, fuh)
+	assertEqual(t, "hash", uh[:7], suh)
 }

--- a/unit/unit.go
+++ b/unit/unit.go
@@ -34,6 +34,10 @@ func (h Hash) String() string {
 	return fmt.Sprintf("%x", h[:])
 }
 
+func (h Hash) Short() string {
+	return fmt.Sprintf("%.7s", h)
+}
+
 func (h *Hash) Empty() bool {
 	return *h == Hash{}
 }

--- a/unit/unit_test.go
+++ b/unit/unit_test.go
@@ -13,6 +13,7 @@ const (
 	// 0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33 -
 	testData      = "foo"
 	testShaString = "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
+	testShaShort  = "0beec7b"
 )
 
 func TestUnitHash(t *testing.T) {
@@ -20,6 +21,10 @@ func TestUnitHash(t *testing.T) {
 	h := u.Hash()
 	if h.String() != testShaString {
 		t.Fatalf("Unit Hash (%s) does not match expected (%s)", h.String(), testShaString)
+	}
+
+	if h.Short() != testShaShort {
+		t.Fatalf("Unit Hash short (%s) does not match expected (%s)", h.Short(), testShaShort)
 	}
 
 	eh := &Hash{}


### PR DESCRIPTION
When I deploy some units I sometimes forget which ones have been deployed. It would be nice if list-units either showed "systemd start time" or "md5 hash of .service file".

The md5 hash would be nice because you then know what version of the .service file is deployed. Maybe this is overkill, but it's great for debugging new .service file tweaks.
