### PR TITLE
docs(unit-files): Add Documentation about Specifiers

### DIFF
--- a/Documentation/unit-files.md
+++ b/Documentation/unit-files.md
@@ -29,3 +29,5 @@ ExecStart=/bin/monitorme
 [X-Fleet]
 X-ConditionMachineID=148a18ff-6e95-4cd8-92da-c9de9bb90d5a
 ```
+
+Note that [Systemd Specifiers](http://www.freedesktop.org/software/systemd/man/systemd.unit.html#Specifiers) are not yet available within `[X-Fleet]` sections. See [the issue](https://github.com/coreos/fleet/issues/303) for more information. 


### PR DESCRIPTION
Systemd specifiers aren't yet supported in [X-Fleet] sections
until #303 is resolved. This notes the issues encountered in #437 and #438.

Hey all, this stumped me for quite sometime, just wanted to add a note to the docs, until the issue is resolved. 
