### PR TITLE
fix(registry): add isKeyNotFound helper and ignore more KeyNotFounds

### DIFF
--- a/registry/job.go
+++ b/registry/job.go
@@ -25,7 +25,7 @@ func (r *EtcdRegistry) GetAllJobs() ([]job.Job, error) {
 	key := path.Join(r.keyPrefix, jobPrefix)
 	resp, err := r.etcd.Get(key, true, true)
 	if err != nil {
-		if e, ok := err.(*etcd.EtcdError); ok && e.ErrorCode == etcdErr.EcodeKeyNotFound {
+		if isKeyNotFound(err) {
 			err = nil
 		}
 		return jobs, err
@@ -66,6 +66,9 @@ func (r *EtcdRegistry) GetJobTarget(jobName string) (string, error) {
 func (r *EtcdRegistry) ClearJobTarget(jobName, machID string) error {
 	key := r.jobTargetAgentPath(jobName)
 	_, err := r.etcd.CompareAndDelete(key, machID, 0)
+	if isKeyNotFound(err) {
+		err = nil
+	}
 	return err
 }
 
@@ -75,7 +78,7 @@ func (r *EtcdRegistry) GetJob(jobName string) (j *job.Job, err error) {
 	key := path.Join(r.keyPrefix, jobPrefix, jobName, "object")
 	resp, err := r.etcd.Get(key, false, true)
 	if err != nil {
-		if e, ok := err.(*etcd.EtcdError); ok && e.ErrorCode == etcdErr.EcodeKeyNotFound {
+		if isKeyNotFound(err) {
 			err = nil
 		}
 		return

--- a/registry/machine.go
+++ b/registry/machine.go
@@ -82,6 +82,9 @@ func (r *EtcdRegistry) SetMachineState(ms machine.MachineState, ttl time.Duratio
 func (r *EtcdRegistry) RemoveMachineState(machID string) error {
 	key := path.Join(r.keyPrefix, machinePrefix, machID, "object")
 	_, err := r.etcd.Delete(key, false)
+	if isKeyNotFound(err) {
+		err = nil
+	}
 	return err
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	etcdErr "github.com/coreos/fleet/third_party/github.com/coreos/etcd/error"
 	"github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
 )
 
@@ -45,4 +46,9 @@ func unmarshal(val string, obj interface{}) error {
 	} else {
 		return errors.New(fmt.Sprintf("Unable to JSON-deserialize object: %s", err))
 	}
+}
+
+func isKeyNotFound(err error) bool {
+	e, ok := err.(*etcd.EtcdError)
+	return ok && e.ErrorCode == etcdErr.EcodeKeyNotFound
 }

--- a/registry/unit.go
+++ b/registry/unit.go
@@ -42,7 +42,7 @@ func (r *EtcdRegistry) getUnitFromLegacyPayload(name string) (*unit.Unit, error)
 	key := path.Join(r.keyPrefix, payloadPrefix, name)
 	resp, err := r.etcd.Get(key, true, true)
 	if err != nil {
-		if e, ok := err.(*etcd.EtcdError); ok && e.ErrorCode == etcdErr.EcodeKeyNotFound {
+		if isKeyNotFound(err) {
 			err = nil
 		}
 		return nil, err
@@ -64,7 +64,7 @@ func (r *EtcdRegistry) getUnitByHash(hash unit.Hash) *unit.Unit {
 	key := r.hashedUnitPath(hash)
 	resp, err := r.etcd.Get(key, false, true)
 	if err != nil {
-		if e, ok := err.(*etcd.EtcdError); ok && e.ErrorCode == etcdErr.EcodeKeyNotFound {
+		if isKeyNotFound(err) {
 			err = nil
 		}
 		return nil

--- a/registry/unit_state.go
+++ b/registry/unit_state.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"path"
-
 	"github.com/coreos/fleet/unit"
 )
 
@@ -38,5 +37,8 @@ func (r *EtcdRegistry) SaveUnitState(jobName string, unitState *unit.UnitState) 
 func (r *EtcdRegistry) RemoveUnitState(jobName string) error {
 	key := path.Join(r.keyPrefix, statePrefix, jobName)
 	_, err := r.etcd.Delete(key, false)
+	if isKeyNotFound(err) {
+		err = nil
+	}
 	return err
 }


### PR DESCRIPTION
Following on from #451, and before we upstream this behaviour more cleanly in go-etcd
