### PR TITLE
fleet prints error on `fleetctl list-machines` against empty cluster

### DIFF
--- a/registry/machine.go
+++ b/registry/machine.go
@@ -20,8 +20,10 @@ func (r *EtcdRegistry) GetActiveMachines() (machines []machine.MachineState, err
 	key := path.Join(r.keyPrefix, machinePrefix)
 	resp, err := r.etcd.Get(key, false, true)
 
-	// Assume the error was KeyNotFound and return an empty data structure
 	if err != nil {
+		if isKeyNotFound(err) {
+			err = nil
+		}
 		return
 	}
 
@@ -41,8 +43,10 @@ func (r *EtcdRegistry) GetMachineState(machID string) (*machine.MachineState, er
 	key := path.Join(r.keyPrefix, machinePrefix, machID, "object")
 	resp, err := r.etcd.Get(key, false, true)
 
-	// Assume the error was KeyNotFound and return an empty data structure
 	if err != nil {
+		if isKeyNotFound(err) {
+			err = nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Running fleetctl against etcd in-which no activity had yet happened (no machines were even running):

```
$ fleetctl list-machines
Error retrieving list of active machines: 100: Key not found (/_coreos.com) [6]
```

As soon as I start a machine the error goes away. I would expect an empty machine list, not an error.
