### PR TITLE
fix(agent): Clear UnitState before unscheduling on shutdown

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -168,10 +168,10 @@ func (a *Agent) Purge() {
 	machID := a.machine.State().ID
 
 	for _, jobName := range a.state.ScheduledJobs() {
-		log.Infof("Unscheduling Job(%s) from local machine", jobName)
-		a.registry.ClearJobTarget(jobName, machID)
 		log.Infof("Unloading Job(%s) from local machine", jobName)
 		a.UnloadJob(jobName)
+		log.Infof("Unscheduling Job(%s) from local machine", jobName)
+		a.registry.ClearJobTarget(jobName, machID)
 	}
 
 	// Jobs have been stopped, the heartbeat can stop


### PR DESCRIPTION
On graceful shutdown, an Agent must clear each individual Job's UnitState
before unscheduling it. If an Agent takes these two actions in the
opposite order, it runs the risk of deleting legitimate state from the
Registry that was published by a different Agent.
