### PR TITLE
Allow user to define fields returned in fleetctl list-units and list-machines

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -69,6 +69,7 @@ var (
 		NoLegend      bool
 		NoBlock       bool
 		BlockAttempts int
+		Fields        string
 	}{}
 )
 


### PR DESCRIPTION
e.g.

```
fleetctl list-units -o name,machine
fleetctl list-units -o name,state,sub
```
