### PR TITLE
Fix logic bug where break didn't exit as many levels as intended.

### DIFF
--- a/event/bus_test.go
+++ b/event/bus_test.go
@@ -20,7 +20,7 @@ func TestEventBus(t *testing.T) {
 	evchan := make(chan Event)
 
 	bus := NewEventBus()
-	bus.AddListener("test",&TestListener{evchan})
+	bus.AddListener("test", &TestListener{evchan})
 	bus.Listen(stopchan)
 
 	ev := Event{"EventTypeOne", "payload", "Y"}

--- a/job/offer.go
+++ b/job/offer.go
@@ -14,7 +14,7 @@ type JobOffer struct {
 
 func NewOfferFromJob(j Job, machineIDs []string) *JobOffer {
 	return &JobOffer{
-		Job:            j,
+		Job:        j,
 		MachineIDs: machineIDs,
 	}
 }
@@ -31,7 +31,7 @@ func (jo *JobOffer) OfferedTo(machineID string) bool {
 }
 
 type JobBid struct {
-	JobName string
+	JobName   string
 	MachineID string
 }
 

--- a/registry/unit_state.go
+++ b/registry/unit_state.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"path"
+
 	"github.com/coreos/fleet/unit"
 )
 

--- a/unit/unit_test.go
+++ b/unit/unit_test.go
@@ -25,7 +25,7 @@ func TestUnitHash(t *testing.T) {
 }
 
 func TestRecognizedUnitTypes(t *testing.T) {
-	tts := []struct{
+	tts := []struct {
 		name string
 		ok   bool
 	}{
@@ -54,7 +54,7 @@ func TestRecognizedUnitTypes(t *testing.T) {
 }
 
 func TestDefaultUnitType(t *testing.T) {
-	tts := []struct{
+	tts := []struct {
 		name string
 		out  string
 	}{


### PR DESCRIPTION
Break only exits from the innermost for/select/switch. I changed it to a return and moved the post-loop cleanup to a defer.

I also ran gofmt. See https://github.com/coreos/fleet/pull/481/files?w=1 to elide whitespace changes.
