### PR TITLE
gofmt -s and golint

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -392,7 +392,7 @@ func (a *Agent) bidForPossibleJobs() {
 	offers := a.state.GetOffersWithoutBids()
 
 	log.V(1).Infof("Checking %d unbade offers", len(offers))
-	for i, _ := range offers {
+	for i := range offers {
 		offer := offers[i]
 		log.V(1).Infof("Checking ability to run Job(%s)", offer.Job.Name)
 		if a.ableToRun(&offer.Job) {

--- a/agent/state.go
+++ b/agent/state.go
@@ -127,9 +127,8 @@ func (as *AgentState) GetJobsByPeer(peerName string) []string {
 	peers, ok := as.peers[peerName]
 	if ok {
 		return peers
-	} else {
-		return make([]string, 0)
 	}
+	return make([]string, 0)
 }
 
 // Remove all references to a given Job from all Peer indexes

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -69,7 +69,7 @@ func (e *Engine) OfferJob(j job.Job) error {
 	mutex := e.registry.LockJob(j.Name, e.machine.State().ID)
 	if mutex == nil {
 		log.V(1).Infof("Could not lock Job(%s)", j.Name)
-		return errors.New("Could not lock Job")
+		return errors.New("could not lock Job")
 	}
 	defer mutex.Unlock()
 
@@ -77,7 +77,7 @@ func (e *Engine) OfferJob(j job.Job) error {
 
 	machineIDs, err := e.partitionCluster(&j)
 	if err != nil {
-		log.Errorf("Failed partitioning cluster for Job(%s): %v", j.Name, err)
+		log.Errorf("failed partitioning cluster for Job(%s): %v", j.Name, err)
 		return err
 	}
 
@@ -97,7 +97,7 @@ func (e *Engine) ResolveJobOffer(jobName string, machID string) error {
 
 	if mutex == nil {
 		log.V(1).Infof("Could not lock JobOffer(%s)", jobName)
-		return errors.New("Could not lock JobOffer")
+		return errors.New("could not lock JobOffer")
 	}
 	defer mutex.Unlock()
 

--- a/fleet.go
+++ b/fleet.go
@@ -169,7 +169,7 @@ func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error
 func listenForSignals(sigmap map[os.Signal]func()) {
 	sigchan := make(chan os.Signal, 1)
 
-	for k, _ := range sigmap {
+	for k := range sigmap {
 		signal.Notify(sigchan, k)
 	}
 

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -42,7 +42,7 @@ recommended to upgrade fleetctl to prevent incompatibility issues.
 
 var (
 	out           *tabwriter.Writer
-	globalFlagset *flag.FlagSet = flag.NewFlagSet("fleetctl", flag.ExitOnError)
+	globalFlagset = flag.NewFlagSet("fleetctl", flag.ExitOnError)
 
 	// set of top-level commands
 	commands []*Command
@@ -137,7 +137,7 @@ func checkVersion() (string, bool) {
 	fv := version.SemVersion
 	lv, err := registryCtl.GetLatestVersion()
 	if err != nil {
-		log.Errorf("Error attempting to check latest fleet version in Registry: %v", err)
+		log.Errorf("error attempting to check latest fleet version in Registry: %v", err)
 	} else if lv != nil && fv.LessThan(*lv) {
 		return fmt.Sprintf(oldVersionWarning, fv.String(), lv.String()), false
 	}
@@ -316,9 +316,9 @@ func findJobs(args []string) (jobs []job.Job, err error) {
 		name := unitNameMangle(v)
 		j, err := registryCtl.GetJob(name)
 		if err != nil {
-			return nil, fmt.Errorf("Error retrieving Job(%s) from Registry: %v", name, err)
+			return nil, fmt.Errorf("error retrieving Job(%s) from Registry: %v", name, err)
 		} else if j == nil {
-			return nil, fmt.Errorf("Could not find Job(%s)", name)
+			return nil, fmt.Errorf("could not find Job(%s)", name)
 		}
 
 		jobs[i] = *j
@@ -331,7 +331,7 @@ func createJob(jobName string, unit *unit.Unit) (*job.Job, error) {
 	j := job.NewJob(jobName, *unit)
 
 	if err := registryCtl.CreateJob(j); err != nil {
-		return nil, fmt.Errorf("Failed creating job %s: %v", j.Name, err)
+		return nil, fmt.Errorf("failed creating job %s: %v", j.Name, err)
 	}
 
 	log.V(1).Infof("Created Job(%s) in Registry", j.Name)
@@ -344,17 +344,17 @@ func createJob(jobName string, unit *unit.Unit) (*job.Job, error) {
 func signJob(j *job.Job) error {
 	sc, err := sign.NewSignatureCreatorFromSSHAgent()
 	if err != nil {
-		return fmt.Errorf("Failed creating SignatureCreator: %v", err)
+		return fmt.Errorf("failed creating SignatureCreator: %v", err)
 	}
 
 	ss, err := sc.SignJob(j)
 	if err != nil {
-		return fmt.Errorf("Failed signing Job(%s): %v", j.Name, err)
+		return fmt.Errorf("failed signing Job(%s): %v", j.Name, err)
 	}
 
 	err = registryCtl.CreateSignatureSet(ss)
 	if err != nil {
-		return fmt.Errorf("Failed storing Job signature in registry: %v", err)
+		return fmt.Errorf("failed storing Job signature in registry: %v", err)
 	}
 
 	log.V(1).Infof("Signed Job(%s)", j.Name)
@@ -366,18 +366,18 @@ func signJob(j *job.Job) error {
 func verifyJob(j *job.Job) error {
 	sv, err := sign.NewSignatureVerifierFromSSHAgent()
 	if err != nil {
-		return fmt.Errorf("Failed creating SignatureVerifier: %v", err)
+		return fmt.Errorf("failed creating SignatureVerifier: %v", err)
 	}
 
 	ss, err := registryCtl.GetSignatureSetOfJob(j.Name)
 	if err != nil {
-		return fmt.Errorf("Failed attempting to retrieve SignatureSet of Job(%s): %v", j.Name, err)
+		return fmt.Errorf("failed attempting to retrieve SignatureSet of Job(%s): %v", j.Name, err)
 	}
 	verified, err := sv.VerifyJob(j, ss)
 	if err != nil {
-		return fmt.Errorf("Failed attempting to verify Job(%s): %v", j.Name, err)
+		return fmt.Errorf("failed attempting to verify Job(%s): %v", j.Name, err)
 	} else if !verified {
-		return fmt.Errorf("Unable to verify Job(%s)", j.Name)
+		return fmt.Errorf("unable to verify Job(%s)", j.Name)
 	}
 
 	log.V(1).Infof("Verified signature of Job(%s)", j.Name)
@@ -404,7 +404,7 @@ func lazyCreateJobs(args []string, signAndVerify bool) error {
 
 		unit, err := getUnitFromFile(arg)
 		if err != nil {
-			return fmt.Errorf("Failed getting Unit(%s) from file: %v", jobName, err)
+			return fmt.Errorf("failed getting Unit(%s) from file: %v", jobName, err)
 		}
 
 		j, err = createJob(jobName, unit)
@@ -427,9 +427,9 @@ func lazyLoadJobs(args []string) ([]string, error) {
 		name := unitNameMangle(v)
 		j, err := registryCtl.GetJob(name)
 		if err != nil {
-			return nil, fmt.Errorf("Error retrieving Job(%s) from Registry: %v", name, err)
+			return nil, fmt.Errorf("error retrieving Job(%s) from Registry: %v", name, err)
 		} else if j == nil || j.State == nil {
-			return nil, fmt.Errorf("Unable to determine state of job %s", name)
+			return nil, fmt.Errorf("unable to determine state of job %s", name)
 		} else if *(j.State) == job.JobStateLoaded || *(j.State) == job.JobStateLaunched {
 			log.V(1).Infof("Job(%s) already %s, skipping.", j.Name, *(j.State))
 			continue
@@ -449,11 +449,11 @@ func lazyStartJobs(args []string) ([]string, error) {
 		name := unitNameMangle(v)
 		j, err := registryCtl.GetJob(name)
 		if err != nil {
-			return nil, fmt.Errorf("Error retrieving Job(%s) from Registry: %v", name, err)
+			return nil, fmt.Errorf("error retrieving Job(%s) from Registry: %v", name, err)
 		} else if j == nil {
-			return nil, fmt.Errorf("Unable to find Job(%s)", name)
+			return nil, fmt.Errorf("unable to find Job(%s)", name)
 		} else if j.State == nil {
-			return nil, fmt.Errorf("Unable to determine current state of Job")
+			return nil, fmt.Errorf("unable to determine current state of Job")
 		} else if *(j.State) == job.JobStateLaunched {
 			log.V(1).Infof("Job(%s) already %s, skipping.", j.Name, *(j.State))
 			continue
@@ -509,7 +509,7 @@ func checkJobState(jobName string, js job.JobState, maxAttempts int, out io.Writ
 			}
 			time.Sleep(sleep)
 		}
-		errchan <- fmt.Errorf("Timed out waiting for job %s to report state %s", jobName, js)
+		errchan <- fmt.Errorf("timed out waiting for job %s to report state %s", jobName, js)
 	}
 }
 

--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -117,7 +117,7 @@ func runSSH(args []string) (exit int) {
 
 func globalMachineLookup(args []string) (string, error) {
 	if len(args) == 0 {
-		return "", errors.New("Provide one machine or unit.")
+		return "", errors.New("one machine or unit must be provided")
 	}
 
 	lookup := args[0]
@@ -127,7 +127,7 @@ func globalMachineLookup(args []string) (string, error) {
 
 	switch {
 	case machineOk && unitOk:
-		return "", fmt.Errorf("Ambiguous argument, both machine and unit found for `%s`.\nPlease use flag `-m` or `-u` to refine the search.", lookup)
+		return "", fmt.Errorf("ambiguous argument, both machine and unit found for `%s`.\nPlease use flag `-m` or `-u` to refine the search", lookup)
 	case machineOk:
 		return machineAddr, nil
 	case unitOk:
@@ -146,7 +146,7 @@ func findAddressInMachineList(lookup string) (string, bool) {
 
 	var match *machine.MachineState
 
-	for i, _ := range states {
+	for i := range states {
 		machState := states[i]
 		if !strings.HasPrefix(machState.ID, lookup) {
 			continue

--- a/fleetctl/ssh_test.go
+++ b/fleetctl/ssh_test.go
@@ -12,9 +12,9 @@ import (
 
 func newTestRegistryForSsh() registry.Registry {
 	machines := []machine.MachineState{
-		machine.MachineState{"c31e44e1-f858-436e-933e-59c642517860", "1.2.3.4", map[string]string{"ping": "pong"}, "", resource.ResourceTuple{}},
-		machine.MachineState{"595989bb-cbb7-49ce-8726-722d6e157b4e", "5.6.7.8", map[string]string{"foo": "bar"}, "", resource.ResourceTuple{}},
-		machine.MachineState{"hello.service", "8.7.6.5", map[string]string{"foo": "bar"}, "", resource.ResourceTuple{}},
+		{"c31e44e1-f858-436e-933e-59c642517860", "1.2.3.4", map[string]string{"ping": "pong"}, "", resource.ResourceTuple{}},
+		{"595989bb-cbb7-49ce-8726-722d6e157b4e", "5.6.7.8", map[string]string{"foo": "bar"}, "", resource.ResourceTuple{}},
+		{"hello.service", "8.7.6.5", map[string]string{"foo": "bar"}, "", resource.ResourceTuple{}},
 	}
 
 	jobs := []job.Job{

--- a/functional/platform/nspawn.go
+++ b/functional/platform/nspawn.go
@@ -136,7 +136,7 @@ ExecStart=/opt/fleet/fleet -config /opt/fleet/fleet.conf
 
 func (nc *nspawnCluster) Members() []string {
 	names := make([]string, 0)
-	for member, _ := range nc.members {
+	for member := range nc.members {
 		names = append(names, member)
 	}
 	return names
@@ -166,7 +166,7 @@ ip:
 		}
 		return ip, nil
 	}
-	return "", errors.New("Unable to find unused IP address")
+	return "", errors.New("unable to find unused IP address")
 }
 
 func (nc *nspawnCluster) CreateMember(name string, cfg MachineConfig) (err error) {
@@ -246,7 +246,7 @@ func (nc *nspawnCluster) CreateMember(name string, cfg MachineConfig) (err error
 }
 
 func (nc *nspawnCluster) Destroy() error {
-	for name, _ := range nc.members {
+	for name := range nc.members {
 		log.Printf("Destroying nspawn machine %s", name)
 		nc.DestroyMember(name)
 	}
@@ -332,13 +332,13 @@ func (nc *nspawnCluster) machinePID(name string) (int, error) {
 				time.Sleep(time.Second)
 				continue
 			}
-			return -1, fmt.Errorf("Failed detecting machine %s status: %v", mach, err)
+			return -1, fmt.Errorf("failed detecting machine %s status: %v", mach, err)
 		}
 
 		out := strings.SplitN(strings.TrimSpace(stdout), "=", 2)
 		return strconv.Atoi(out[1])
 	}
-	return -1, fmt.Errorf("Unable to detect machine PID")
+	return -1, fmt.Errorf("unable to detect machine PID")
 }
 
 func (nc *nspawnCluster) nsenter(name string, cmd string) error {

--- a/functional/scheduling_test.go
+++ b/functional/scheduling_test.go
@@ -216,7 +216,7 @@ func TestScheduleOneWayConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for unit, _ := range states {
+	for unit := range states {
 		if unit != "conflicts-with-hello.service" {
 			t.Error("Incorrect unit started:", unit)
 		}
@@ -239,7 +239,7 @@ func TestScheduleOneWayConflict(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for unit, _ := range states {
+	for unit := range states {
 		if unit != "hello.service" {
 			t.Error("Incorrect unit started:", unit)
 		}

--- a/functional/util/util.go
+++ b/functional/util/util.go
@@ -75,7 +75,7 @@ loop:
 	for {
 		select {
 		case <-alarm:
-			return machines, fmt.Errorf("Failed to find %d machines within %v", count, timeout)
+			return machines, fmt.Errorf("failed to find %d machines within %v", count, timeout)
 		case <-ticker:
 			stdout, _, err := fleetctl("list-machines", "--no-legend", "--full")
 			stdout = strings.TrimSpace(stdout)
@@ -119,7 +119,7 @@ loop:
 	for {
 		select {
 		case <-alarm:
-			return nil, fmt.Errorf("Failed to find %d active units within %v (last found: %d)", count, timeout, nactive)
+			return nil, fmt.Errorf("failed to find %d active units within %v (last found: %d)", count, timeout, nactive)
 		case <-ticker:
 			stdout, _, err := fleetctl("list-units", "--no-legend", "--full")
 			stdout = strings.TrimSpace(stdout)

--- a/job/job.go
+++ b/job/job.go
@@ -99,9 +99,8 @@ func (j *Job) Conflicts() []string {
 	conflicts, ok := j.Requirements()[fleetXConflicts]
 	if ok {
 		return conflicts
-	} else {
-		return make([]string, 0)
 	}
+	return make([]string, 0)
 }
 
 // Peers returns a list of Job names that must be scheduled to the same

--- a/machine/machine_test.go
+++ b/machine/machine_test.go
@@ -11,7 +11,7 @@ func TestHasMetadataSimpleMatch(t *testing.T) {
 	ms := &MachineState{Metadata: metadata}
 
 	match := map[string][]string{
-		"region": []string{"us-east-1"},
+		"region": {"us-east-1"},
 	}
 	if !HasMetadata(ms, match) {
 		t.Errorf("Machine reported it did not have expected state")
@@ -25,7 +25,7 @@ func TestHasMetadataMultiMatch(t *testing.T) {
 	ms := &MachineState{Metadata: metadata}
 
 	match := map[string][]string{
-		"groups": []string{"ping", "pong"},
+		"groups": {"ping", "pong"},
 	}
 	if !HasMetadata(ms, match) {
 		t.Errorf("Machine reported it did not have expected state")
@@ -39,7 +39,7 @@ func TestHasMetadataSingleMatchFail(t *testing.T) {
 	ms := &MachineState{Metadata: metadata}
 
 	match := map[string][]string{
-		"groups": []string{"pong"},
+		"groups": {"pong"},
 	}
 	if HasMetadata(ms, match) {
 		t.Errorf("Machine reported a successful match for metadata which it does not have")
@@ -54,8 +54,8 @@ func TestHasMetadataPartialMatchFail(t *testing.T) {
 	ms := &MachineState{Metadata: metadata}
 
 	match := map[string][]string{
-		"region": []string{"us-east-1"},
-		"groups": []string{"pong"},
+		"region": {"us-east-1"},
+		"groups": {"pong"},
 	}
 	if HasMetadata(ms, match) {
 		t.Errorf("Machine reported a successful match for metadata which it does not have")

--- a/registry/lock.go
+++ b/registry/lock.go
@@ -47,7 +47,7 @@ type TimedResourceMutex struct {
 func (t *TimedResourceMutex) Unlock() error {
 	_, err := t.etcd.CompareAndDelete(t.node.Key, "", t.node.CreatedIndex)
 	if err != nil {
-		err = fmt.Errorf("Received error while unlocking mutex: %v", err)
+		err = fmt.Errorf("received error while unlocking mutex: %v", err)
 		log.Error(err)
 		return err
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	etcdErr "github.com/coreos/fleet/third_party/github.com/coreos/etcd/error"
@@ -34,18 +33,16 @@ func marshal(obj interface{}) (string, error) {
 	encoded, err := json.Marshal(obj)
 	if err == nil {
 		return string(encoded), nil
-	} else {
-		return "", errors.New(fmt.Sprintf("Unable to JSON-serialize object: %s", err))
 	}
+	return "", fmt.Errorf("unable to JSON-serialize object: %s", err)
 }
 
 func unmarshal(val string, obj interface{}) error {
 	err := json.Unmarshal([]byte(val), &obj)
 	if err == nil {
 		return nil
-	} else {
-		return errors.New(fmt.Sprintf("Unable to JSON-deserialize object: %s", err))
 	}
+	return fmt.Errorf("unable to JSON-deserialize object: %s", err)
 }
 
 func isKeyNotFound(err error) bool {

--- a/registry/unit.go
+++ b/registry/unit.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"path"
 
@@ -50,10 +49,10 @@ func (r *EtcdRegistry) getUnitFromLegacyPayload(name string) (*unit.Unit, error)
 
 	var ljp LegacyJobPayload
 	if err := unmarshal(resp.Node.Value, &ljp); err != nil {
-		return nil, errors.New(fmt.Sprintf("Error unmarshaling LegacyJobPayload(%s): %v", name, err))
+		return nil, fmt.Errorf("error unmarshaling LegacyJobPayload(%s): %v", name, err)
 	}
 	if ljp.Name != name {
-		return nil, errors.New(fmt.Sprintf("Payload name in Registry (%s) does not match expected name (%s)", ljp.Name, name))
+		return nil, fmt.Errorf("payload name in Registry (%s) does not match expected name (%s)", ljp.Name, name)
 	}
 	// After the unmarshaling, the LegacyPayload should contain a fully hydrated Unit
 	return &ljp.Unit, nil
@@ -71,7 +70,7 @@ func (r *EtcdRegistry) getUnitByHash(hash unit.Hash) *unit.Unit {
 	}
 	var u unit.Unit
 	if err := unmarshal(resp.Node.Value, &u); err != nil {
-		log.Errorf("Error unmarshaling Unit(%s): %v", hash, err)
+		log.Errorf("error unmarshaling Unit(%s): %v", hash, err)
 		return nil
 	}
 	return &u
@@ -92,7 +91,7 @@ func (ljp *LegacyJobPayload) UnmarshalJSON(data []byte) error {
 	var ljpm legacyJobPayloadModel
 	err := json.Unmarshal(data, &ljpm)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Unable to JSON-deserialize object: %s", err))
+		return fmt.Errorf("unable to JSON-deserialize object: %s", err)
 	}
 
 	if len(ljpm.Unit.Raw) > 0 {

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -169,7 +169,6 @@ func marshal(obj interface{}) ([]byte, error) {
 	encoded, err := json.Marshal(obj)
 	if err == nil {
 		return encoded, nil
-	} else {
-		return nil, errors.New(fmt.Sprintf("Unable to JSON-serialize object: %s", err))
 	}
+	return nil, fmt.Errorf("unable to JSON-serialize object: %s", err)
 }

--- a/ssh/known_hosts.go
+++ b/ssh/known_hosts.go
@@ -104,11 +104,10 @@ func (kc *HostKeyChecker) Check(addr string, remote net.Addr, key gossh.PublicKe
 			// Any matching key is considered a success, irrespective of previous failures
 			if hostKey.Type() == key.Type() && bytes.Compare(hostKey.Marshal(), key.Marshal()) == 0 {
 				return nil
-			} else {
-				// TODO(jonboulle): could be super friendly like the OpenSSH client
-				// and note exactly which key failed (file + line number)
-				mismatched = true
 			}
+			// TODO(jonboulle): could be super friendly like the OpenSSH client
+			// and note exactly which key failed (file + line number)
+			mismatched = true
 		}
 	}
 
@@ -257,7 +256,7 @@ func parseKnownHostsLine(line []byte) (string, gossh.PublicKey, error) {
 	// Finally, actually try to extract the key.
 	key, _, _, _, err := gossh.ParseAuthorizedKey(keyBytes)
 	if err != nil {
-		return "", nil, errors.New(fmt.Sprintf("error parsing key: %v", err))
+		return "", nil, fmt.Errorf("error parsing key: %v", err)
 	}
 
 	return hosts, key, nil

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -257,7 +257,7 @@ func timeoutSSHDial(dial func(chan error)) error {
 
 	select {
 	case <-time.After(time.Duration(time.Second * 10)):
-		return errors.New("Timed out while initiating SSH connection")
+		return errors.New("timed out while initiating SSH connection")
 	case err = <-echan:
 		return err
 	}

--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -2,7 +2,6 @@ package systemd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -93,12 +92,11 @@ func (m *SystemdUnitManager) getUnitStates(name string) (string, string, string,
 
 	if err != nil {
 		return "", "", "", err
-	} else {
-		loadState := info["LoadState"].(string)
-		activeState := info["ActiveState"].(string)
-		subState := info["SubState"].(string)
-		return loadState, activeState, subState, nil
 	}
+	loadState := info["LoadState"].(string)
+	activeState := info["ActiveState"].(string)
+	subState := info["SubState"].(string)
+	return loadState, activeState, subState, nil
 }
 
 func (m *SystemdUnitManager) startUnit(name string) {
@@ -122,9 +120,8 @@ func (m *SystemdUnitManager) readUnit(name string) (string, error) {
 	contents, err := ioutil.ReadFile(path)
 	if err == nil {
 		return string(contents), nil
-	} else {
-		return "", errors.New(fmt.Sprintf("No unit file at local path %s", path))
 	}
+	return "", fmt.Errorf("no unit file at local path %s", path)
 }
 
 func (m *SystemdUnitManager) unitRequiresDaemonReload(name string) bool {

--- a/unit/file_test.go
+++ b/unit/file_test.go
@@ -24,15 +24,15 @@ X-ConditionMachineMetadata=baz=qux
 `
 
 	expected := map[string]map[string][]string{
-		"Unit": map[string][]string{
-			"Description": []string{"Foo"},
+		"Unit": {
+			"Description": {"Foo"},
 		},
-		"Service": map[string][]string{
-			"ExecStart": []string{`echo "ping";`},
-			"ExecStop":  []string{`echo "pong"`, "echo post"},
+		"Service": {
+			"ExecStart": {`echo "ping";`},
+			"ExecStop":  {`echo "pong"`, "echo post"},
 		},
-		"Fleet": map[string][]string{
-			"X-ConditionMachineMetadata": []string{"foo=bar", "baz=qux"},
+		"Fleet": {
+			"X-ConditionMachineMetadata": {"foo=bar", "baz=qux"},
 		},
 	}
 
@@ -60,11 +60,11 @@ ExecStopPost=echo\
 pung
 `
 	expected := map[string]map[string][]string{
-		"Service": map[string][]string{
-			"ExecStart":    []string{`echo    "pi   ng"`},
-			"ExecStop":     []string{`echo "po ng"`},
-			"ExecStopPre":  []string{`echo #pang`},
-			"ExecStopPost": []string{`echo #peng pung`},
+		"Service": {
+			"ExecStart":    {`echo    "pi   ng"`},
+			"ExecStop":     {`echo "po ng"`},
+			"ExecStopPre":  {`echo #pang`},
+			"ExecStopPost": {`echo #peng pung`},
 		},
 	}
 	unitFile := NewUnit(contents)
@@ -127,22 +127,22 @@ ExecStop=echo "pong";
 
 func TestNewSystemdUnitFileFromLegacyContents(t *testing.T) {
 	legacy := map[string]map[string]string{
-		"Unit": map[string]string{
+		"Unit": {
 			"Description": "foobar",
 		},
-		"Service": map[string]string{
+		"Service": {
 			"Type":      "oneshot",
 			"ExecStart": "/usr/bin/echo bar",
 		},
 	}
 
 	expected := map[string]map[string][]string{
-		"Unit": map[string][]string{
-			"Description": []string{"foobar"},
+		"Unit": {
+			"Description": {"foobar"},
 		},
-		"Service": map[string][]string{
-			"Type":      []string{"oneshot"},
-			"ExecStart": []string{"/usr/bin/echo bar"},
+		"Service": {
+			"Type":      {"oneshot"},
+			"ExecStart": {"/usr/bin/echo bar"},
 		},
 	}
 
@@ -155,13 +155,13 @@ func TestNewSystemdUnitFileFromLegacyContents(t *testing.T) {
 
 func TestDeserializeLine(t *testing.T) {
 	deserializeLineExamples := map[string][]string{
-		`key=foo=bar`:             []string{`foo=bar`},
-		`key="foo=bar"`:           []string{`foo=bar`},
-		`key="foo=bar" "baz=qux"`: []string{`foo=bar`, `baz=qux`},
-		`key="foo=bar baz"`:       []string{`foo=bar baz`},
-		`key="foo=bar" baz`:       []string{`"foo=bar" baz`},
-		`key=baz "foo=bar"`:       []string{`baz "foo=bar"`},
-		`key="foo=bar baz=qux"`:   []string{`foo=bar baz=qux`},
+		`key=foo=bar`:             {`foo=bar`},
+		`key="foo=bar"`:           {`foo=bar`},
+		`key="foo=bar" "baz=qux"`: {`foo=bar`, `baz=qux`},
+		`key="foo=bar baz"`:       {`foo=bar baz`},
+		`key="foo=bar" baz`:       {`"foo=bar" baz`},
+		`key=baz "foo=bar"`:       {`baz "foo=bar"`},
+		`key="foo=bar baz=qux"`:   {`foo=bar baz=qux`},
 	}
 
 	for q, w := range deserializeLineExamples {


### PR DESCRIPTION
I'm trying to wrap my head around fleet, and I'm going to try to clean up some of the code as I go through. I did a first pass with gofmt/govet/golint. Changes here:
- omitting type annotations for literals when inferrable from context (`gofmt -s`)
- omitting second `range` key when ignored (`k, _` -> `k`, `gofmt -s`)
- Idiomatic error messages: Start lowecase, except where referencing an uppercase value/type, no terminal punctuation (`golint`)
- `errors.New(fmt.Sprintf(args))` -> `fmt.Errorf(args)` (`golint`)
- `if foo { return bar } else { baz }` -> `if foo { return bar } baz` (`golint`)

I guess the error message changes imply a bit of a functionality change. I can revert those if you don't want them to change.
