### PR TITLE
Simplify EventBus

### DIFF
--- a/event/bus.go
+++ b/event/bus.go
@@ -3,31 +3,18 @@ package event
 import (
 	"fmt"
 	"reflect"
+	"sync"
 
 	log "github.com/coreos/fleet/third_party/github.com/golang/glog"
 )
 
 type EventBus struct {
 	listeners map[string]interface{}
-	Channel   chan *Event
 }
 
 func NewEventBus() *EventBus {
 	listeners := make(map[string]interface{}, 0)
-	return &EventBus{listeners, make(chan *Event)}
-}
-
-func (eb *EventBus) Listen(stop chan bool) {
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			case ev := <-eb.Channel:
-				eb.dispatch(ev)
-			}
-		}
-	}()
+	return &EventBus{listeners}
 }
 
 func (eb *EventBus) AddListener(name string, l interface{}) {
@@ -39,15 +26,24 @@ func (eb *EventBus) RemoveListener(name string) {
 }
 
 // Distribute an Event to all listeners registered to Event.Type
-func (eb *EventBus) dispatch(ev *Event) {
+func (eb *EventBus) Dispatch(ev *Event) {
 	log.V(1).Infof("Dispatching %s to listeners", ev.Type)
+
+	wg := sync.WaitGroup{}
+
 	handlerFuncName := fmt.Sprintf("Handle%s", ev.Type)
 	for name, listener := range eb.listeners {
 		log.V(1).Infof("Looking for event handler func %s on listener %s", handlerFuncName, name)
 		handlerFunc := reflect.ValueOf(listener).MethodByName(handlerFuncName)
 		if handlerFunc.IsValid() {
 			log.V(1).Infof("Calling event handler for %s on listener %s", ev.Type, name)
-			go handlerFunc.Call([]reflect.Value{reflect.ValueOf(*ev)})
+			wg.Add(1)
+			go func() {
+				handlerFunc.Call([]reflect.Value{reflect.ValueOf(*ev)})
+				wg.Done()
+			}()
 		}
 	}
+
+	wg.Wait()
 }

--- a/registry/event_test.go
+++ b/registry/event_test.go
@@ -24,7 +24,11 @@ func TestPipe(t *testing.T) {
 	eventchan := make(chan *event.Event)
 	stopchan := make(chan bool)
 
-	go pipe(etcdchan, filters, eventchan, stopchan)
+	send := func(ev *event.Event) {
+		eventchan <- ev
+	}
+
+	go pipe(etcdchan, filters, send, stopchan)
 
 	resp := etcd.Response{Action: "TestAction", Node: &etcd.Node{Key: "/", ModifiedIndex: 0}}
 	etcdchan <- &resp

--- a/server/server.go
+++ b/server/server.go
@@ -130,11 +130,14 @@ func newEngineFromConfig(mach machine.Machine, cfg config.Config) (*engine.Engin
 func (s *Server) Run() {
 	idx := s.agent.Initialize()
 
+	asyncDispatch := func(ev *event.Event) {
+		go s.eBus.Dispatch(ev)
+	}
+
 	s.stop = make(chan bool)
 	go s.mach.PeriodicRefresh(machineStateRefreshInterval, s.stop)
-	go s.eBus.Listen(s.stop)
-	go s.rStream.Stream(idx, s.eBus.Channel, s.stop)
-	go s.sStream.Stream(s.eBus.Channel, s.stop)
+	go s.rStream.Stream(idx, asyncDispatch, s.stop)
+	go s.sStream.Stream(asyncDispatch, s.stop)
 	go s.agent.Heartbeat(s.stop)
 
 	s.engine.CheckForWork()

--- a/systemd/event.go
+++ b/systemd/event.go
@@ -17,7 +17,7 @@ func NewEventStream(mgr *SystemdUnitManager) *EventStream {
 	return &EventStream{mgr, nil}
 }
 
-func (es *EventStream) Stream(eventchan chan *event.Event, stop chan bool) {
+func (es *EventStream) Stream(sendFunc func(*event.Event), stop chan bool) {
 
 	es.mgr.systemd.Subscribe()
 	defer es.mgr.systemd.Unsubscribe()
@@ -35,7 +35,7 @@ func (es *EventStream) Stream(eventchan chan *event.Event, stop chan bool) {
 			for i := range events {
 				ev := events[i]
 				log.V(1).Infof("Translated dbus event to event(Type=%s)", ev.Type)
-				eventchan <- &ev
+				sendFunc(&ev)
 			}
 		}
 	}


### PR DESCRIPTION
Refactor the EventBus dispatch approach to be synchronous. This makes testing more deterministic and removes some unnecessary layers of goroutines.
