### PR TITLE
Serialize event dispatch

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -130,14 +130,10 @@ func newEngineFromConfig(mach machine.Machine, cfg config.Config) (*engine.Engin
 func (s *Server) Run() {
 	idx := s.agent.Initialize()
 
-	asyncDispatch := func(ev *event.Event) {
-		go s.eBus.Dispatch(ev)
-	}
-
 	s.stop = make(chan bool)
 	go s.mach.PeriodicRefresh(machineStateRefreshInterval, s.stop)
-	go s.rStream.Stream(idx, asyncDispatch, s.stop)
-	go s.sStream.Stream(asyncDispatch, s.stop)
+	go s.rStream.Stream(idx, s.eBus.Dispatch, s.stop)
+	go s.sStream.Stream(s.eBus.Dispatch, s.stop)
 	go s.agent.Heartbeat(s.stop)
 
 	s.engine.CheckForWork()


### PR DESCRIPTION
Serializing event dispatch will help the operation of the Agent in two major ways:
1. detection/management of etcd connectivity in agent/engine much simpler
2. systemd jobs put in queue in same order as etcd log

I'm not worried about performance impact here, as we're just serializing the glue between etcd and systemd. The Agent is not blocking on the jobs it submits to systemd.
