### PR TITLE
Gather etcd-related code in etcd pkg

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,14 +2,12 @@ package config
 
 import (
 	"flag"
-	"io/ioutil"
-	"log"
-	"os"
 	"strconv"
 	"strings"
 
-	"github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
 	"github.com/coreos/fleet/third_party/github.com/golang/glog"
+
+	"github.com/coreos/fleet/etcd"
 )
 
 type Config struct {
@@ -55,8 +53,8 @@ func UpdateLoggingFlagsFromConfig(flagset *flag.FlagSet, conf *Config) {
 	}
 
 	if conf.Verbosity > 2 {
-		etcd.SetLogger(log.New(os.Stdout, "go-etcd", log.LstdFlags))
+		etcd.EnableDebugLogging()
 	} else {
-		etcd.SetLogger(log.New(ioutil.Discard, "go-etcd", log.LstdFlags))
+		etcd.DisableDebugLogging()
 	}
 }

--- a/etcd/client.go
+++ b/etcd/client.go
@@ -1,0 +1,28 @@
+package etcd
+
+import (
+	"net/http"
+
+	goetcd "github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
+)
+
+type Client interface {
+	GetCluster() []string
+	SetTransport(tr *http.Transport)
+
+	CompareAndDelete(key string, prevValue string, prevIndex uint64) (*goetcd.Response, error)
+	Create(key string, value string, ttl uint64) (*goetcd.Response, error)
+	Delete(key string, recursive bool) (*goetcd.Response, error)
+	Get(key string, sort, recursive bool) (*goetcd.Response, error)
+	RawGet(key string, sort, recursive bool) (*goetcd.RawResponse, error)
+	Set(key string, value string, ttl uint64) (*goetcd.Response, error)
+	Update(key string, value string, ttl uint64) (*goetcd.Response, error)
+
+	Watch(prefix string, waitIndex uint64, recursive bool, receiver chan *goetcd.Response, stop chan bool) (*goetcd.Response, error)
+}
+
+func NewClient(servers []string) Client {
+	c := goetcd.NewClient(servers)
+	c.SetConsistency(goetcd.STRONG_CONSISTENCY)
+	return c
+}

--- a/etcd/error.go
+++ b/etcd/error.go
@@ -1,0 +1,11 @@
+package etcd
+
+import (
+	ee "github.com/coreos/fleet/third_party/github.com/coreos/etcd/error"
+)
+
+const (
+	EcodeEventIndexCleared = ee.EcodeEventIndexCleared
+	EcodeNodeExist         = ee.EcodeNodeExist
+	EcodeKeyNotFound       = ee.EcodeKeyNotFound
+)

--- a/etcd/logging.go
+++ b/etcd/logging.go
@@ -1,0 +1,17 @@
+package etcd
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+
+	goetcd "github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
+)
+
+func EnableDebugLogging() {
+	goetcd.SetLogger(log.New(os.Stdout, "go-etcd", log.LstdFlags))
+}
+
+func DisableDebugLogging() {
+	goetcd.SetLogger(log.New(ioutil.Discard, "go-etcd", log.LstdFlags))
+}

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -16,9 +16,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
 	log "github.com/coreos/fleet/third_party/github.com/golang/glog"
 
+	"github.com/coreos/fleet/etcd"
 	"github.com/coreos/fleet/job"
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/registry"

--- a/registry/event_test.go
+++ b/registry/event_test.go
@@ -3,23 +3,23 @@ package registry
 import (
 	"testing"
 
-	"github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
+	goetcd "github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
 
 	"github.com/coreos/fleet/event"
 )
 
 func TestPipe(t *testing.T) {
-	etcdchan := make(chan *etcd.Response)
+	etcdchan := make(chan *goetcd.Response)
 
-	translate1 := func(resp *etcd.Response) *event.Event {
+	translate1 := func(resp *goetcd.Response) *event.Event {
 		return &event.Event{"TranslateTest1", resp.Action, nil}
 	}
 
-	translate2 := func(resp *etcd.Response) *event.Event {
+	translate2 := func(resp *goetcd.Response) *event.Event {
 		return &event.Event{"TranslateTest2", resp.Action, "foo"}
 	}
 
-	filters := []func(resp *etcd.Response) *event.Event{translate1, translate2}
+	filters := []func(resp *goetcd.Response) *event.Event{translate1, translate2}
 
 	eventchan := make(chan *event.Event)
 	stopchan := make(chan bool)
@@ -30,7 +30,7 @@ func TestPipe(t *testing.T) {
 
 	go pipe(etcdchan, filters, send, stopchan)
 
-	resp := etcd.Response{Action: "TestAction", Node: &etcd.Node{Key: "/", ModifiedIndex: 0}}
+	resp := goetcd.Response{Action: "TestAction", Node: &goetcd.Node{Key: "/", ModifiedIndex: 0}}
 	etcdchan <- &resp
 
 	ev1 := <-eventchan

--- a/registry/lock.go
+++ b/registry/lock.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
+	goetcd "github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
 	log "github.com/coreos/fleet/third_party/github.com/golang/glog"
+
+	"github.com/coreos/fleet/etcd"
 )
 
 const (
@@ -38,8 +40,8 @@ func (r *EtcdRegistry) lockResource(class, id, context string) *TimedResourceMut
 // stored in the Registry. It assumes the mutex creator has
 // initialized a timer.
 type TimedResourceMutex struct {
-	etcd *etcd.Client
-	node etcd.Node
+	etcd etcd.Client
+	node goetcd.Node
 }
 
 // Unlock will attempt to remove the lock held on the mutex

--- a/registry/machine.go
+++ b/registry/machine.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
+	goetcd "github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
 
 	"github.com/coreos/fleet/event"
 	"github.com/coreos/fleet/machine"
@@ -97,7 +97,7 @@ func (r *EtcdRegistry) LockMachine(machID, context string) *TimedResourceMutex {
 	return r.lockResource("machine", machID, context)
 }
 
-func filterEventMachineCreated(resp *etcd.Response) *event.Event {
+func filterEventMachineCreated(resp *goetcd.Response) *event.Event {
 	dir, baseName := path.Split(resp.Node.Key)
 	if baseName != "object" {
 		return nil
@@ -120,7 +120,7 @@ func filterEventMachineCreated(resp *etcd.Response) *event.Event {
 	return &event.Event{"EventMachineCreated", m, nil}
 }
 
-func filterEventMachineRemoved(resp *etcd.Response) *event.Event {
+func filterEventMachineRemoved(resp *goetcd.Response) *event.Event {
 	dir, baseName := path.Split(resp.Node.Key)
 	if baseName != "object" {
 		return nil

--- a/registry/offer.go
+++ b/registry/offer.go
@@ -4,7 +4,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
+	goetcd "github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
 	log "github.com/coreos/fleet/third_party/github.com/golang/glog"
 
 	"github.com/coreos/fleet/event"
@@ -145,7 +145,7 @@ func (r *EtcdRegistry) SubmitJobBid(jb *job.JobBid) {
 	r.etcd.Set(key, "", 0)
 }
 
-func (es *EventStream) filterEventJobOffered(resp *etcd.Response) *event.Event {
+func (es *EventStream) filterEventJobOffered(resp *goetcd.Response) *event.Event {
 	if resp.Action != "set" {
 		return nil
 	}
@@ -171,7 +171,7 @@ func (es *EventStream) filterEventJobOffered(resp *etcd.Response) *event.Event {
 	return &event.Event{"EventJobOffered", *jo, nil}
 }
 
-func filterEventJobBidSubmitted(resp *etcd.Response) *event.Event {
+func filterEventJobBidSubmitted(resp *goetcd.Response) *event.Event {
 	if resp.Action != "set" {
 		return nil
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -4,20 +4,21 @@ import (
 	"encoding/json"
 	"fmt"
 
-	etcdErr "github.com/coreos/fleet/third_party/github.com/coreos/etcd/error"
-	"github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
+	goetcd "github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
+
+	"github.com/coreos/fleet/etcd"
 )
 
 const DefaultKeyPrefix = "/_coreos.com/fleet/"
 
 // EtcdRegistry fulfils the Registry interface and uses etcd as a backend
 type EtcdRegistry struct {
-	etcd      *etcd.Client
+	etcd      etcd.Client
 	keyPrefix string
 }
 
 // New creates a new EtcdRegistry with the given parameters
-func New(client *etcd.Client, keyPrefix string) (registry Registry) {
+func New(client etcd.Client, keyPrefix string) (registry Registry) {
 	return &EtcdRegistry{client, keyPrefix}
 }
 
@@ -46,6 +47,6 @@ func unmarshal(val string, obj interface{}) error {
 }
 
 func isKeyNotFound(err error) bool {
-	e, ok := err.(*etcd.EtcdError)
-	return ok && e.ErrorCode == etcdErr.EcodeKeyNotFound
+	e, ok := err.(*goetcd.EtcdError)
+	return ok && e.ErrorCode == etcd.EcodeKeyNotFound
 }

--- a/registry/unit.go
+++ b/registry/unit.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"path"
 
-	etcdErr "github.com/coreos/fleet/third_party/github.com/coreos/etcd/error"
-	"github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
+	goetcd "github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
 	log "github.com/coreos/fleet/third_party/github.com/golang/glog"
 
+	"github.com/coreos/fleet/etcd"
 	"github.com/coreos/fleet/unit"
 )
 
@@ -28,7 +28,7 @@ func (r *EtcdRegistry) storeOrGetUnit(u unit.Unit) (err error) {
 	log.V(3).Infof("Storing Unit(%s) in Registry: %s", u.Hash(), json)
 	_, err = r.etcd.Create(key, json, 0)
 	// unit is already stored
-	if err != nil && err.(*etcd.EtcdError).ErrorCode == etcdErr.EcodeNodeExist {
+	if err != nil && err.(*goetcd.EtcdError).ErrorCode == etcd.EcodeNodeExist {
 		log.V(2).Infof("Unit(%s) already exists in Registry", u.Hash())
 		// TODO(jonboulle): verify more here?
 		err = nil

--- a/server/server.go
+++ b/server/server.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"time"
 
-	"github.com/coreos/fleet/third_party/github.com/coreos/go-etcd/etcd"
 	log "github.com/coreos/fleet/third_party/github.com/golang/glog"
 
 	"github.com/coreos/fleet/agent"
 	"github.com/coreos/fleet/config"
 	"github.com/coreos/fleet/engine"
+	"github.com/coreos/fleet/etcd"
 	"github.com/coreos/fleet/event"
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/registry"
@@ -49,7 +49,6 @@ func New(cfg config.Config) (*Server, error) {
 	}
 
 	eClient := etcd.NewClient(cfg.EtcdServers)
-	eClient.SetConsistency(etcd.STRONG_CONSISTENCY)
 
 	reg := registry.New(eClient, cfg.EtcdKeyPrefix)
 


### PR DESCRIPTION
Two main benefits here:
1. usage of etcd libraries centralized in a single package (except for go-etcd - the code still uses its data objects)
2. ability to wrap go-etcd.Client with fancy retry and error-handling logic to detect when etcd is unavailable
