### PR TITLE
fix(go-etcd): Close response bodies

### DIFF
--- a/third_party/github.com/coreos/go-etcd/etcd/requests.go
+++ b/third_party/github.com/coreos/go-etcd/etcd/requests.go
@@ -272,7 +272,6 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 
 		// if there is no error, it should receive response
 		resps = append(resps, *resp)
-		defer resp.Body.Close()
 		logger.Debug("recv.response.from", httpPath)
 
 		if validHttpStatusCode[resp.StatusCode] {
@@ -303,6 +302,7 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 			errors.New("Unexpected HTTP status code")); checkErr != nil {
 			return nil, checkErr
 		}
+		resp.Body.Close()
 	}
 
 	r := &RawResponse{


### PR DESCRIPTION
This is a hack roughly equivalent to go-etcd commit 2df4f0d2729c5ca94955b44604a87929306e2ace
