### PR TITLE
fix(server): be more careful about shutting down

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -24,7 +24,7 @@ func New(reg registry.Registry, mach machine.Machine) *Engine {
 // CheckForWork attempts to rectify the current state of all Jobs in the cluster
 // with their target states wherever discrepancies are identified.
 func (e *Engine) CheckForWork() {
-	log.Infof("Polling etcd for actionable Jobs")
+	log.Info("Polling etcd for actionable Jobs")
 
 	for _, jo := range e.registry.UnresolvedJobOffers() {
 		bids, err := e.registry.Bids(&jo)
@@ -61,6 +61,8 @@ func (e *Engine) CheckForWork() {
 			e.registry.ClearJobTarget(j.Name, target)
 		}
 	}
+
+	log.Info("Done checking for work")
 }
 
 func (e *Engine) OfferJob(j job.Job) error {

--- a/fleet.go
+++ b/fleet.go
@@ -65,10 +65,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed creating Server: %v", err.Error())
 	}
-	srv.Run()
 
 	reconfigure := func() {
-		log.Infof("Reloading configuration from %s", *cfgPath)
+		log.Infof("Reloading configuration")
 
 		cfg, err := getConfig(cfgset, *cfgPath)
 		if err != nil {
@@ -117,7 +116,9 @@ func main() {
 		syscall.SIGUSR1: writeState,
 	}
 
-	listenForSignals(signals)
+	go listenForSignals(signals)
+
+	srv.Run()
 }
 
 func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error) {


### PR DESCRIPTION
Server start-up has become a relatively complex process and there are now
various opportunities for it to block before the signal handlers were set up
appropriately. This makes it awkward to cleanly shut down fleet. This change
registers the signal handlers early in the process and makes several changes
to the initialization to facilitate this.
