### PR TITLE
fix(third_party/github.com/coreos/go-semver): fix incorrect import path

### DIFF
--- a/third_party/github.com/coreos/go-semver/example.go
+++ b/third_party/github.com/coreos/go-semver/example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/coreos/fleet/github.com/coreos/go-semver/semver"
+	"github.com/coreos/fleet/third_party/github.com/coreos/go-semver/semver"
 	"os"
 )
 


### PR DESCRIPTION
The copy of go-semver included in Fleet has an incorrect import path. "third_party" is missing from the import path. This causes the "go get" command to fail.
