### PR TITLE
fix(fleetctl): initialize slices properly

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -422,7 +422,7 @@ func lazyCreateJobs(args []string, signAndVerify bool) error {
 }
 
 func lazyLoadJobs(args []string) ([]string, error) {
-	jobs := make([]string, len(args))
+	jobs := make([]string, 0, len(args))
 	for _, j := range args {
 		jobs = append(jobs, unitNameMangle(j))
 	}
@@ -430,7 +430,7 @@ func lazyLoadJobs(args []string) ([]string, error) {
 }
 
 func lazyStartJobs(args []string) ([]string, error) {
-	jobs := make([]string, len(args))
+	jobs := make([]string, 0, len(args))
 	for _, j := range args {
 		jobs = append(jobs, unitNameMangle(j))
 	}


### PR DESCRIPTION
We can't initialize slices with a length if we're going to append to them. We end up with a slice of N empty elements followed by the N elements we want. We should be using the capacity argument in this case.
