### PR TITLE
fix(fleetctl): write directly os.Stdout instead of tabwriter

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -571,14 +571,14 @@ func checkJobState(jobName string, js job.JobState, maxAttempts int, out io.Writ
 
 	if maxAttempts < 1 {
 		for {
-			if assertJobState(jobName, js) {
+			if assertJobState(jobName, js, out) {
 				return
 			}
 			time.Sleep(sleep)
 		}
 	} else {
 		for attempt := 0; attempt < maxAttempts; attempt++ {
-			if assertJobState(jobName, js) {
+			if assertJobState(jobName, js, out) {
 				return
 			}
 			time.Sleep(sleep)
@@ -587,7 +587,7 @@ func checkJobState(jobName string, js job.JobState, maxAttempts int, out io.Writ
 	}
 }
 
-func assertJobState(name string, js job.JobState) bool {
+func assertJobState(name string, js job.JobState, out io.Writer) bool {
 	j, err := registryCtl.GetJob(name)
 	if err != nil {
 		log.Warningf("Error retrieving Job(%s) from Registry: %v", name, err)


### PR DESCRIPTION
1. Using tabwriter here is unnecessary, and was probably a mistake from the beginning
2. This removes concurrent access to tabwriter.Writer, which is apparently not threadsafe
