### PR TITLE
fix(tests): plethora of fixes to functional tests

### DIFF
--- a/functional/README.md
+++ b/functional/README.md
@@ -47,12 +47,14 @@ ssh-add functional/fixtures/id_rsa
 export GOPATH="$(pwd)/gopath"
 export FLEET_BIN="$(pwd)/bin/fleet"
 export FLEETCTL_BIN="$(pwd)/bin/fleetctl"
-sudo -E env PATH=$PATH go test github.com/coreos/fleet/functional
+sudo -E env PATH=$PATH go test github.com/coreos/fleet/functional -v
 ```
 
 If the tests are aborted partway through, it's currently possible for them to leave residual state as a result of the systemd-nspawn operations. Manual cleanup can be performed as follows:
 ```
-sudo rm -fr /run/systemd/system/*smoke*
-machinectl --no-legend | cut -d ' ' -f1 | sudo xargs machinectl terminate
+machinectl --no-legend | cut -d ' ' -f1 | sudo xargs -r machinectl terminate
+sudo pkill -9 systemd-nspawn
+sudo rm -fr /run/systemd/system/*smoke* /tmp/smoke
 sudo systemctl daemon-reload
+ip link show fleet0 >/dev/null && sudo ip link del fleet0
 ```

--- a/functional/cluster_test.go
+++ b/functional/cluster_test.go
@@ -140,18 +140,9 @@ func TestDynamicClusterMemberReboot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	found := false
 	for _, unit := range []string{"conflict.0.service", "conflict.1.service", "conflict.2.service"} {
 		if oldStates[unit].Machine != newStates[unit].Machine {
-			if found {
-				t.Fatal("More than one unit migrated")
-			} else {
-				found = true
-			}
+			t.Fatalf("Unit %s migrated unexpectedly", unit)
 		}
-	}
-
-	if !found {
-		t.Fatal("Could not find migrated unit")
 	}
 }

--- a/functional/util/util.go
+++ b/functional/util/util.go
@@ -66,7 +66,6 @@ func RunFleetctlWithInput(input string, args ...string) (string, string, error) 
 // Wait up to 10s to find the specified number of machines, retrying periodically.
 func WaitForNMachines(fleetctl fleetfunc, count int) ([]string, error) {
 	var machines []string
-
 	timeout := 10 * time.Second
 	alarm := time.After(timeout)
 


### PR DESCRIPTION
- remove update-ca-certificates from node start, dramatically reducing
  container spin-up time
- removing time.Sleep when spinning up a node; instead, poll until
  it looks like the container is fully booted
- cleaning up network interfaces more thoroughly between tests,
  preventing a race where one test failure will cause a cascading
  failure in subsequent tests
- copies /etc/nsswitch.conf into container to ensure users are available
  during startup (in the non-container world this is handled by initrd)
