### PR TITLE
Use FleetController interface in fleetctl

### DIFF
--- a/fleetctl/cat.go
+++ b/fleetctl/cat.go
@@ -23,7 +23,7 @@ func runCatUnit(args []string) (exit int) {
 	}
 
 	name := unitNameMangle(args[0])
-	j, err := registryCtl.GetJob(name)
+	j, err := fc.GetJob(name)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error retrieving Job %s: %v\n", name, err)
 		return 1

--- a/fleetctl/controller.go
+++ b/fleetctl/controller.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/coreos/fleet/third_party/github.com/coreos/go-semver/semver"
+
+	"github.com/coreos/fleet/job"
+	"github.com/coreos/fleet/machine"
+	"github.com/coreos/fleet/sign"
+)
+
+type FleetController interface {
+	CreateJob(*job.Job) error
+	CreateSignatureSet(*sign.SignatureSet) error
+	DestroyJob(string) error
+	GetActiveMachines() ([]machine.MachineState, error)
+	GetAllJobs() ([]job.Job, error)
+	GetJob(string) (*job.Job, error)
+	GetJobTarget(string) (string, error)
+	GetLatestVersion() (*semver.Version, error)
+	GetMachineState(string) (*machine.MachineState, error)
+	GetSignatureSetOfJob(string) (*sign.SignatureSet, error)
+	SetJobTargetState(string, job.JobState) error
+}

--- a/fleetctl/destroy.go
+++ b/fleetctl/destroy.go
@@ -21,7 +21,7 @@ Destroyed units are impossible to start unless re-submitted.`,
 func runDestroyUnits(args []string) (exit int) {
 	for _, v := range args {
 		name := unitNameMangle(v)
-		registryCtl.DestroyJob(name)
+		fc.DestroyJob(name)
 		fmt.Printf("Destroyed Job %s\n", name)
 	}
 	return

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -47,8 +47,8 @@ var (
 	// set of top-level commands
 	commands []*Command
 
-	// global Registry used by commands
-	registryCtl registry.Registry
+	// global object used by commands to interact with an actual cluster
+	fc FleetController
 
 	// flags used by all commands
 	globalFlags = struct {
@@ -135,7 +135,7 @@ func getFlags(flagset *flag.FlagSet) (flags []*flag.Flag) {
 // false and a scary warning to the user.
 func checkVersion() (string, bool) {
 	fv := version.SemVersion
-	lv, err := registryCtl.GetLatestVersion()
+	lv, err := fc.GetLatestVersion()
 	if err != nil {
 		log.Errorf("error attempting to check latest fleet version in Registry: %v", err)
 	} else if lv != nil && fv.LessThan(*lv) {
@@ -192,9 +192,8 @@ func main() {
 		os.Exit(2)
 	}
 
-	// TODO(jonboulle): increase cleverness of registry initialization
 	if cmd.Name != "help" && cmd.Name != "version" {
-		registryCtl = getRegistry()
+		fc = getFleetController()
 		msg, ok := checkVersion()
 		if !ok {
 			fmt.Fprint(os.Stderr, msg)
@@ -227,8 +226,8 @@ func getFlagsFromEnv(prefix string, fs *flag.FlagSet) {
 	})
 }
 
-// getRegistry initializes a connection to the Registry
-func getRegistry() registry.Registry {
+// getFleetController initializes a connection to the Registry
+func getFleetController() FleetController {
 	var dial func(string, string) (net.Conn, error)
 	tun := getTunnelFlag()
 	if tun != "" {
@@ -315,7 +314,7 @@ func findJobs(args []string) (jobs []job.Job, err error) {
 	jobs = make([]job.Job, len(args))
 	for i, v := range args {
 		name := unitNameMangle(v)
-		j, err := registryCtl.GetJob(name)
+		j, err := fc.GetJob(name)
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving Job(%s) from Registry: %v", name, err)
 		} else if j == nil {
@@ -331,7 +330,7 @@ func findJobs(args []string) (jobs []job.Job, err error) {
 func createJob(jobName string, unit *unit.Unit) (*job.Job, error) {
 	j := job.NewJob(jobName, *unit)
 
-	if err := registryCtl.CreateJob(j); err != nil {
+	if err := fc.CreateJob(j); err != nil {
 		return nil, fmt.Errorf("failed creating job %s: %v", j.Name, err)
 	}
 
@@ -353,7 +352,7 @@ func signJob(j *job.Job) error {
 		return fmt.Errorf("failed signing Job(%s): %v", j.Name, err)
 	}
 
-	err = registryCtl.CreateSignatureSet(ss)
+	err = fc.CreateSignatureSet(ss)
 	if err != nil {
 		return fmt.Errorf("failed storing Job signature in registry: %v", err)
 	}
@@ -370,7 +369,7 @@ func verifyJob(j *job.Job) error {
 		return fmt.Errorf("failed creating SignatureVerifier: %v", err)
 	}
 
-	ss, err := registryCtl.GetSignatureSetOfJob(j.Name)
+	ss, err := fc.GetSignatureSetOfJob(j.Name)
 	if err != nil {
 		return fmt.Errorf("failed attempting to retrieve SignatureSet of Job(%s): %v", j.Name, err)
 	}
@@ -404,7 +403,7 @@ func lazyCreateJobs(args []string, signAndVerify bool) error {
 		jobName := unitNameMangle(arg)
 
 		// First, check if there already exists a Job by the given name in the Registry
-		j, err := registryCtl.GetJob(jobName)
+		j, err := fc.GetJob(jobName)
 		if err != nil {
 			return fmt.Errorf("error retrieving Job(%s) from Registry: %v", jobName, err)
 		}
@@ -445,7 +444,7 @@ func lazyCreateJobs(args []string, signAndVerify bool) error {
 		} else if !uni.IsInstance() {
 			return fmt.Errorf("unable to find Unit(%s) in Registry or on filesystem", jobName)
 		}
-		tmpl, err := registryCtl.GetJob(uni.Template)
+		tmpl, err := fc.GetJob(uni.Template)
 		if err != nil {
 			return fmt.Errorf("error retrieving template Job(%s) from Registry: %v", uni.Template, err)
 		}
@@ -523,7 +522,7 @@ func lazyStartJobs(args []string) ([]string, error) {
 func setTargetStateOfJobs(jobs []string, state job.JobState) ([]string, error) {
 	triggered := make([]string, 0)
 	for _, name := range jobs {
-		j, err := registryCtl.GetJob(name)
+		j, err := fc.GetJob(name)
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving Job(%s) from Registry: %v", name, err)
 		} else if j == nil {
@@ -536,7 +535,7 @@ func setTargetStateOfJobs(jobs []string, state job.JobState) ([]string, error) {
 		}
 
 		log.V(1).Infof("Setting Job(%s) target state to %s", j.Name, state)
-		registryCtl.SetJobTargetState(j.Name, state)
+		fc.SetJobTargetState(j.Name, state)
 		triggered = append(triggered, j.Name)
 	}
 
@@ -590,7 +589,7 @@ func checkJobState(jobName string, js job.JobState, maxAttempts int, out io.Writ
 }
 
 func assertJobState(name string, js job.JobState, out io.Writer) bool {
-	j, err := registryCtl.GetJob(name)
+	j, err := fc.GetJob(name)
 	if err != nil {
 		log.Warningf("Error retrieving Job(%s) from Registry: %v", name, err)
 		return false
@@ -601,11 +600,11 @@ func assertJobState(name string, js job.JobState, out io.Writer) bool {
 
 	msg := fmt.Sprintf("Job %s %s", name, *(j.State))
 
-	tgt, err := registryCtl.GetJobTarget(name)
+	tgt, err := fc.GetJobTarget(name)
 	if err != nil {
 		log.Warningf("Error retrieving target information for Job(%s) from Registry: %v", name, err)
 	} else if tgt != "" {
-		if ms, _ := registryCtl.GetMachineState(tgt); ms != nil {
+		if ms, _ := fc.GetMachineState(tgt); ms != nil {
 			msg = fmt.Sprintf("%s on %s", msg, machineFullLegend(*ms, false))
 		}
 	}

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -24,12 +24,12 @@ func newFakeRegistryForCheckVersion(v string) registry.Registry {
 }
 
 func TestCheckVersion(t *testing.T) {
-	registryCtl = newFakeRegistryForCheckVersion(version.Version)
+	fc = newFakeRegistryForCheckVersion(version.Version)
 	_, ok := checkVersion()
 	if !ok {
 		t.Errorf("checkVersion failed but should have succeeded")
 	}
-	registryCtl = newFakeRegistryForCheckVersion("9.0.0")
+	fc = newFakeRegistryForCheckVersion("9.0.0")
 	msg, ok := checkVersion()
 	if ok || msg == "" {
 		t.Errorf("checkVersion succeeded but should have failed")

--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -36,7 +36,7 @@ func runJournal(args []string) (exit int) {
 	}
 	jobName := unitNameMangle(args[0])
 
-	j, err := registryCtl.GetJob(jobName)
+	j, err := fc.GetJob(jobName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error retrieving Job %s: %v", jobName, err)
 		return 1

--- a/fleetctl/list_machines.go
+++ b/fleetctl/list_machines.go
@@ -109,7 +109,7 @@ func formatMetadata(metadata map[string]string) string {
 // machine IDs). It returns any error encountered in communicating with the Registry.
 func findAllMachines() (machines map[string]machine.MachineState, sortable sort.StringSlice, err error) {
 	machines = make(map[string]machine.MachineState, 0)
-	mm, err := registryCtl.GetActiveMachines()
+	mm, err := fc.GetActiveMachines()
 	if err != nil {
 		return
 	}

--- a/fleetctl/list_machines_test.go
+++ b/fleetctl/list_machines_test.go
@@ -22,7 +22,7 @@ func newTestRegistryForListMachines() registry.Registry {
 }
 
 func TestGetAllMachines(t *testing.T) {
-	registryCtl = newTestRegistryForListMachines()
+	fc = newTestRegistryForListMachines()
 	machines, sortable, err := findAllMachines()
 	if err != nil {
 		t.Fatalf("Unexpected error getting all machines: %v\n", err)

--- a/fleetctl/list_units.go
+++ b/fleetctl/list_units.go
@@ -140,7 +140,7 @@ func runListUnits(args []string) (exit int) {
 // It returns any error encountered in communicating with the Registry.
 func findAllUnits() (jobs map[string]job.Job, sortable sort.StringSlice, err error) {
 	jobs = make(map[string]job.Job, 0)
-	jj, err := registryCtl.GetAllJobs()
+	jj, err := fc.GetAllJobs()
 	if err != nil {
 		return
 	}

--- a/fleetctl/list_units_test.go
+++ b/fleetctl/list_units_test.go
@@ -26,7 +26,7 @@ func newFakeRegistryForListUnits(jobs []job.Job) registry.Registry {
 }
 
 func TestGetAllJobs(t *testing.T) {
-	registryCtl = newFakeRegistryForListUnits(nil)
+	fc = newFakeRegistryForListUnits(nil)
 
 	jobs, sortable, err := findAllUnits()
 	if err != nil {
@@ -46,7 +46,7 @@ func TestJobDescription(t *testing.T) {
 Description=PING
 `
 	j := []job.Job{*job.NewJob("ping.service", *unit.NewUnit(contents))}
-	registryCtl = newFakeRegistryForListUnits(j)
+	fc = newFakeRegistryForListUnits(j)
 
 	jobs, _, _ := findAllUnits()
 	if len(jobs) != 2 {

--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -138,7 +138,7 @@ func globalMachineLookup(args []string) (string, error) {
 }
 
 func findAddressInMachineList(lookup string) (string, bool) {
-	states, err := registryCtl.GetActiveMachines()
+	states, err := fc.GetActiveMachines()
 	if err != nil {
 		log.V(1).Infof("Unable to retrieve list of active machines from the Registry: %v", err)
 		return "", false
@@ -165,7 +165,7 @@ func findAddressInMachineList(lookup string) (string, bool) {
 
 func findAddressInRunningUnits(jobName string) (string, bool) {
 	name := unitNameMangle(jobName)
-	j, err := registryCtl.GetJob(name)
+	j, err := fc.GetJob(name)
 	if err != nil {
 		log.V(1).Infof("Unable to retrieve Job(%s) from Repository: %v", name, err)
 	}

--- a/fleetctl/ssh_test.go
+++ b/fleetctl/ssh_test.go
@@ -38,7 +38,7 @@ func newFakeRegistryForSsh() registry.Registry {
 }
 
 func TestSshUnknownMachine(t *testing.T) {
-	registryCtl = newFakeRegistryForSsh()
+	fc = newFakeRegistryForSsh()
 
 	_, ok := findAddressInMachineList("asdf")
 	if ok {
@@ -47,7 +47,7 @@ func TestSshUnknownMachine(t *testing.T) {
 }
 
 func TestSshFindMachine(t *testing.T) {
-	registryCtl = newFakeRegistryForSsh()
+	fc = newFakeRegistryForSsh()
 
 	ip, _ := findAddressInMachineList("c31e44e1-f858-436e-933e-59c642517860")
 	if ip != "1.2.3.4" {
@@ -56,7 +56,7 @@ func TestSshFindMachine(t *testing.T) {
 }
 
 func TestSshFindMachineByUnknownJobName(t *testing.T) {
-	registryCtl = newFakeRegistryForSsh()
+	fc = newFakeRegistryForSsh()
 
 	_, ok := findAddressInRunningUnits("asdf")
 	if ok {
@@ -65,7 +65,7 @@ func TestSshFindMachineByUnknownJobName(t *testing.T) {
 }
 
 func TestSshFindMachineByJobName(t *testing.T) {
-	registryCtl = newFakeRegistryForSsh()
+	fc = newFakeRegistryForSsh()
 
 	ip, _ := findAddressInRunningUnits("j1")
 	if ip != "1.2.3.4" {
@@ -74,7 +74,7 @@ func TestSshFindMachineByJobName(t *testing.T) {
 }
 
 func TestGlobalLookupByUnknownArgument(t *testing.T) {
-	registryCtl = newFakeRegistryForSsh()
+	fc = newFakeRegistryForSsh()
 
 	ip, err := globalMachineLookup([]string{"asdf"})
 	if err != nil {
@@ -87,7 +87,7 @@ func TestGlobalLookupByUnknownArgument(t *testing.T) {
 }
 
 func TestGlobalLookupByMachineID(t *testing.T) {
-	registryCtl = newFakeRegistryForSsh()
+	fc = newFakeRegistryForSsh()
 
 	ip, err := globalMachineLookup([]string{"c31e44e1-f858-436e-933e-59c642517860"})
 	if err != nil {
@@ -100,7 +100,7 @@ func TestGlobalLookupByMachineID(t *testing.T) {
 }
 
 func TestGlobalLookupByJobName(t *testing.T) {
-	registryCtl = newFakeRegistryForSsh()
+	fc = newFakeRegistryForSsh()
 
 	ip, err := globalMachineLookup([]string{"j1"})
 	if err != nil {
@@ -113,7 +113,7 @@ func TestGlobalLookupByJobName(t *testing.T) {
 }
 
 func TestGlobalLookupWithAmbiguousArgument(t *testing.T) {
-	registryCtl = newFakeRegistryForSsh()
+	fc = newFakeRegistryForSsh()
 
 	_, err := globalMachineLookup([]string{"hello.service"})
 	if err == nil {

--- a/fleetctl/start_test.go
+++ b/fleetctl/start_test.go
@@ -46,5 +46,5 @@ func setupRegistryForStart(echoAttempts int) {
 	reg.SetMachines(machines)
 	reg.SetUnitStates(states)
 
-	registryCtl = &BlockedFakeRegistry{echoAttempts, *reg}
+	fc = &BlockedFakeRegistry{echoAttempts, *reg}
 }

--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -38,7 +38,7 @@ func runStatusUnits(args []string) (exit int) {
 }
 
 func printUnitStatus(jobName string) int {
-	j, err := registryCtl.GetJob(jobName)
+	j, err := fc.GetJob(jobName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error retrieving Job %s: %v", jobName, err)
 		return 1

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -55,7 +55,7 @@ func runStopUnit(args []string) (exit int) {
 			continue
 		}
 
-		registryCtl.SetJobTargetState(j.Name, job.JobStateLoaded)
+		fc.SetJobTargetState(j.Name, job.JobStateLoaded)
 		stopping = append(stopping, j.Name)
 	}
 

--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -43,7 +43,7 @@ func runUnloadUnit(args []string) (exit int) {
 		}
 
 		log.V(1).Infof("Unloading Job(%s)", j.Name)
-		registryCtl.SetJobTargetState(j.Name, job.JobStateInactive)
+		fc.SetJobTargetState(j.Name, job.JobStateInactive)
 		wait = append(wait, j.Name)
 	}
 

--- a/fleetctl/verify.go
+++ b/fleetctl/verify.go
@@ -22,7 +22,7 @@ func runVerifyUnit(args []string) (exit int) {
 	}
 
 	name := unitNameMangle(args[0])
-	j, err := registryCtl.GetJob(name)
+	j, err := fc.GetJob(name)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error retrieving Job %s: %v", name, err)
 		return 1


### PR DESCRIPTION
Add a layer of abstraction between the fleetctl command code and the Registry. This will be used to ease the transition to the new API client.
