### PR TITLE
fix(fleetctl): sort metadata explicitly by keys

### DIFF
--- a/fleetctl/list_machines.go
+++ b/fleetctl/list_machines.go
@@ -97,7 +97,13 @@ func runListMachines(args []string) (exit int) {
 func formatMetadata(metadata map[string]string) string {
 	pairs := make([]string, len(metadata))
 	idx := 0
-	for key, value := range metadata {
+	var sorted sort.StringSlice
+	for k := range metadata {
+		sorted = append(sorted, k)
+	}
+	sorted.Sort()
+	for _, key := range sorted {
+		value := metadata[key]
 		pairs[idx] = fmt.Sprintf("%s=%s", key, value)
 		idx++
 	}


### PR DESCRIPTION
In [go1.3](http://golang.org/doc/go1.3#map), keys for small maps are now
actually no longer iterated over in a consistent order. This caused the list_machines_test
to fail as it relies on the metadata to be sorted. Sorting it provides a more consistent
experience for users too.
