### PR TITLE
feat(API): Return error entities on bad page tokens

### DIFF
--- a/Documentation/api-v1-alpha.md
+++ b/Documentation/api-v1-alpha.md
@@ -7,7 +7,7 @@ The version of the API will transition from "v1-alpha" to "v1" when it has been 
 ## Capability Discovery
 
 The v1 fleet API is described by a [discovery document][disco].
-This document is available in the [fleet source][schema]:
+This document is available in the [fleet source][schema].
 
 [disco]: https://developers.google.com/discovery/v1/reference/apis
 [schema]: ../schema/v1-alpha.json
@@ -52,6 +52,26 @@ GET /cats?nextPageToken=cbb06916 HTTP/1.1
 HTTP/1.1 200 OK
 
 {"cats": [{"id":"timothy"}]}
+```
+
+## Error Communication
+
+400- and 500-level API responses may return JSON-encoded error entities.
+The response will have an `application/json` Content-Type header.
+An error entity has the following fields:
+
+- **error**
+  - **code**: The HTTP status code of the response
+  - **message**: A human-readable error message explaining the failure
+
+For example, if an invalid value is passed for a `nextPageToken`, the following HTTP response could be sent:
+
+```
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 80
+
+{"error:{"code":400,"message":"invalid value of nextPageToken query parameter"}}
 ```
 
 ## Units

--- a/api/deserialization_test.go
+++ b/api/deserialization_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+)
+
+func assertErrorResponse(rr *httptest.ResponseRecorder, code int) error {
+	if rr.Code != code {
+		return fmt.Errorf("expected HTTP code %d, got %d", code, rr.Code)
+	}
+
+	var eresp errorResponse
+	dec := json.NewDecoder(rr.Body)
+	err := dec.Decode(&eresp)
+	if err != nil {
+		return fmt.Errorf("unable to decode error entity in body: %v", err)
+	}
+
+	if eresp.Error.Code != code {
+		return fmt.Errorf("expected error entity code %d, got %d", code, eresp.Error.Code)
+	}
+
+	return nil
+}

--- a/api/machines.go
+++ b/api/machines.go
@@ -29,7 +29,7 @@ func (mr *machinesResource) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 
 	token, err := findNextPageToken(req.URL)
 	if err != nil {
-		rw.WriteHeader(http.StatusBadRequest)
+		sendError(rw, http.StatusBadRequest, err)
 		return
 	}
 

--- a/api/machines_test.go
+++ b/api/machines_test.go
@@ -57,12 +57,10 @@ func TestMachinesListBadNextPageToken(t *testing.T) {
 	}
 
 	resource.ServeHTTP(rw, req)
-	if rw.Code != http.StatusBadRequest {
-		t.Errorf("Expected 400, got %d", rw.Code)
-	}
 
-	if rw.Body.Len() != 0 {
-		t.Error("Received non-empty response body")
+	err = assertErrorResponse(rw, http.StatusBadRequest)
+	if err != nil {
+		t.Error(err.Error())
 	}
 }
 

--- a/api/serialization.go
+++ b/api/serialization.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/coreos/fleet/third_party/code.google.com/p/google-api-go-client/googleapi"
 	log "github.com/coreos/fleet/third_party/github.com/golang/glog"
 )
 
@@ -43,4 +44,16 @@ func sendResponse(rw http.ResponseWriter, resp interface{}) {
 	if err != nil {
 		log.Errorf("Failed sending HTTP response body: %v", err)
 	}
+}
+
+type errorResponse struct {
+	Error *googleapi.Error `json:"error"`
+}
+
+// sendError builds a googleapi.Error entity from the given arguments, serializing
+// the object into the provided http.ResponseWriter
+func sendError(rw http.ResponseWriter, code int, err error) {
+	resp := errorResponse{Error: &googleapi.Error{Code: code, Message: err.Error()}}
+	rw.WriteHeader(code)
+	sendResponse(rw, resp)
 }

--- a/api/serialization_test.go
+++ b/api/serialization_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,7 +43,6 @@ func TestSendResponseMarshalSuccess(t *testing.T) {
 	if body != expect {
 		t.Errorf("Expected body %q, got %q", expect, body)
 	}
-
 }
 
 func TestSendResponseMarshalFailure(t *testing.T) {
@@ -57,5 +57,20 @@ func TestSendResponseMarshalFailure(t *testing.T) {
 
 	if rw.Body.Len() != 0 {
 		t.Errorf("Expected empty response body")
+	}
+}
+
+func TestSendError(t *testing.T) {
+	rw := httptest.NewRecorder()
+	sendError(rw, http.StatusBadRequest, errors.New("sentinel"))
+
+	if rw.Code != http.StatusBadRequest {
+		t.Errorf("Expected 400, got %d", rw.Code)
+	}
+
+	body := rw.Body.String()
+	expect := `{"error":{"code":400,"message":"sentinel","Body":""}}`
+	if body != expect {
+		t.Errorf("Expected body %q, got %q", expect, body)
 	}
 }

--- a/api/units.go
+++ b/api/units.go
@@ -208,7 +208,7 @@ func (ur *unitsResource) get(rw http.ResponseWriter, req *http.Request, item str
 func (ur *unitsResource) list(rw http.ResponseWriter, req *http.Request) {
 	token, err := findNextPageToken(req.URL)
 	if err != nil {
-		rw.WriteHeader(http.StatusBadRequest)
+		sendError(rw, http.StatusBadRequest, err)
 		return
 	}
 

--- a/api/units_test.go
+++ b/api/units_test.go
@@ -69,12 +69,10 @@ func TestUnitsListBadNextPageToken(t *testing.T) {
 	}
 
 	resource.list(rw, req)
-	if rw.Code != http.StatusBadRequest {
-		t.Errorf("Expected 400, got %d", rw.Code)
-	}
 
-	if rw.Body.Len() != 0 {
-		t.Error("Received non-empty response body")
+	err = assertErrorResponse(rw, http.StatusBadRequest)
+	if err != nil {
+		t.Error(err.Error())
 	}
 }
 


### PR DESCRIPTION
This is the first major wart of the google discovery schema stuff. It defines this convention for serializing error entities, yet it does not serve the schema as part of the schema itself. It seems like we just have to live with this.
