### PR TITLE
Use data containers for all API requests & responses

### DIFF
--- a/Documentation/api-v1-alpha.md
+++ b/Documentation/api-v1-alpha.md
@@ -33,7 +33,7 @@ GET /cats HTTP/1.1
 
 HTTP/1.1 200 OK
 
-{"cats": [{"id": "baxter"}, {"id": "charlie"}], "nextPageToken": "8fefec2c"}
+{"data": {"items": [{"id": "baxter"}, {"id": "charlie"}], "nextPageToken": "8fefec2c"}}
 ```
 
 ```
@@ -42,7 +42,7 @@ GET /cats?nextPageToken=8fefec2c HTTP/1.1
 
 HTTP/1.1 200 OK
 
-{"cats": [{"id": "michael"}, {"id": "prescott"}], "nextPageToken": "cbb06916"}
+{"data": {"items": [{"id": "michael"}, {"id": "prescott"}], "nextPageToken": "cbb06916"}}
 ```
 
 ```
@@ -51,7 +51,7 @@ GET /cats?nextPageToken=cbb06916 HTTP/1.1
 
 HTTP/1.1 200 OK
 
-{"cats": [{"id":"timothy"}]}
+{"data": {"items": [{"id":"timothy"}]}}
 ```
 
 ## Error Communication
@@ -79,9 +79,9 @@ Content-Length: 80
 ### Unit Entity
 
 - **name**: unique identifier of entity
-- **desiredState**: state the user wishes the Unit to be in (inactive, loaded, or launched)
 - **fileContents**: base64-encoded contents of the Unit's file
 - **fileHash**: SHA1 hash of the Unit's file contents
+- **desiredState**: state the user wishes the Unit to be in (inactive, loaded, or launched)
 - **currentState**: last known state of the Unit (inactive, loaded, or launched)
 - **targetMachineID**: identifier of the Machine to which this Unit is currently scheduled
 - **sytemd**:
@@ -107,7 +107,7 @@ If the fileContents field is provided in a modification request, the server will
 The base datastructure looks like this:
 
 ```
-{"desiredState": <state>, "fileContents": <encoded-contents>}
+{"data": {"desiredState": <state>, "fileContents": <encoded-contents>}}
 ```
 
 For example, launching a new unit "foo.service" could be done like so: 
@@ -116,8 +116,10 @@ For example, launching a new unit "foo.service" could be done like so:
 PUT /units/foo.service HTTP/1.1
 
 {
-  "desiredState": "launched",
-  "fileContents": "W1NlcnZpY2VdCkV4ZWNTdGFydD0vdXNyL2Jpbi9zbGVlcCAzMDAwCg=="
+  "data": {
+    "desiredState": "launched",
+    "fileContents": "W1NlcnZpY2VdCkV4ZWNTdGFydD0vdXNyL2Jpbi9zbGVlcCAzMDAwCg=="
+  }
 }
 ```
 
@@ -127,7 +129,9 @@ Unloading an existing Unit called "bar.service" could look like this:
 PUT /units/bar.service HTTP/1.1
 
 {
-  "desiredState": "inactive"
+  "data": {
+    "desiredState": "inactive"
+  }
 }
 ```
 
@@ -137,8 +141,10 @@ The expected contents of "bar.service" could also be provided to make changes sa
 PUT /units/bar.service HTTP/1.1
 
 {
-  "desiredState": "inactive",
-  "fileContents": "W1NlcnZpY2VdDQpFeGVjU3RhcnQ9L3Vzci9iaW4vc2xlZXAgMWQNCg=="
+  "data": {
+    "desiredState": "inactive",
+    "fileContents": "W1NlcnZpY2VdDQpFeGVjU3RhcnQ9L3Vzci9iaW4vc2xlZXAgMWQNCg=="
+  }
 }
 ```
 
@@ -162,7 +168,44 @@ The request must not have a body.
 
 #### Response
 
-A successful response will contain a single page of zero or more Unit entities.
+A successful response will contain a single page of zero or more Unit entities. For example:
+
+```
+{
+  "data": {
+    "items": [
+      {
+        "name":"ping.service",
+        "fileContents": "W1VuaXRdCkRlc2NyaXB0aW9uPVBJTkcKCltTZXJ2aWNlXQpFeGVjU3RhcnQ9L2Jpbi9iYXNoIC1jICJ3aGlsZSB0cnVlOyBkbyBlY2hvIFwicGluZ1wiOyBzbGVlcCAxOyBkb25lIgo=",
+        "fileHash": "d9de011694dda111458a4fc9912ad629d86ad8af",
+        "desiredState": "launched",
+        "currentState": "launched",
+        "targetMachineID": "933fbdff1bdc4be0a7b64a9b58c3189d",
+        "systemd":{
+          "activeState": "active",
+          "loadState": "loaded",
+          "machineID": "933fbdff1bdc4be0a7b64a9b58c3189d",
+          "subState": "running"
+        }
+      },
+      {
+        "name": "pong.service",
+      "fileContents": "W1VuaXRdCkRlc2NyaXB0aW9uPVBPTkcKCltTZXJ2aWNlXQpFeGVjU3RhcnQ9L2Jpbi9iYXNoIC1jICJ3aGlsZSB0cnVlOyBkbyBlY2hvIFwicG9uZ1wiOyBzbGVlcCAxOyBkb25lIgoKW1gtRmxlZXRdClgtQ29uZGl0aW9uTWFjaGluZU9mPXBpbmcuc2VydmljZQo=",
+        "fileHash":"c555fd0e58a32ef0b290f4828757cef55ee39a88",
+        "desiredState": "loaded",
+        "currentState": "loaded",
+        "targetMachineID": "933fbdff1bdc4be0a7b64a9b58c3189d",
+        "systemd":{
+          "activeState": "active",
+          "loadState": "loaded",
+          "machineID": "933fbdff1bdc4be0a7b64a9b58c3189d",
+          "subState": "running"
+        }
+      }
+    ]
+  }
+}
+```
 
 ### Fetch Unit
 
@@ -178,7 +221,25 @@ The request must not have a body.
 
 #### Response
 
-A successful response will contain a single Unit entity.
+A successful response will contain a single Unit entity. For example:
+
+```
+{
+  "data": {
+    "name":"ping.service",
+    "currentState":"launched",
+    "fileContents":"W1VuaXRdCkRlc2NyaXB0aW9uPVBJTkcKCltTZXJ2aWNlXQpFeGVjU3RhcnQ9L2Jpbi9iYXNoIC1jICJ3aGlsZSB0cnVlOyBkbyBlY2hvIFwicGluZ1wiOyBzbGVlcCAxOyBkb25lIgo=",
+    "fileHash":"d9de011694dda111458a4fc9912ad629d86ad8af",
+    "targetMachineID":"933fbdff1bdc4be0a7b64a9b58c3189d",
+    "systemd": {
+      "activeState":"active",
+      "loadState":"loaded",
+      "subState":"running",
+      "machineID":"933fbdff1bdc4be0a7b64a9b58c3189d"
+    }
+}
+```
+
 If the indicated Unit does not exist, a `404 Not Found` will be returned.
 
 ### Destroy Units
@@ -195,7 +256,7 @@ The provided request body may contain a single optional field: "fileContents".
 If the fileContents field is provided, the server will ensure the contents match the existing unit before making any changes.
 
 ```
-{"fileContents": <encoded-contents>}
+{"data": {"fileContents": <encoded-contents>}}
 ```
 
 #### Response

--- a/api/machines.go
+++ b/api/machines.go
@@ -84,15 +84,15 @@ func extractMachinePage(all []machine.MachineState, tok PageToken) *schema.Machi
 
 func newMachinePage(items []machine.MachineState, tok *PageToken) *schema.MachinePage {
 	smp := schema.MachinePage{
-		Machines: make([]*schema.Machine, 0, len(items)),
+		Data: &schema.MachinePageData{Items: make([]*schema.Machine, 0, len(items))},
 	}
 
 	if tok != nil {
-		smp.NextPageToken = tok.Encode()
+		smp.Data.NextPageToken = tok.Encode()
 	}
 
 	for _, sm := range items {
-		smp.Machines = append(smp.Machines, mapMachineStateToSchema(&sm))
+		smp.Data.Items = append(smp.Data.Items, mapMachineStateToSchema(&sm))
 	}
 	return &smp
 }

--- a/api/machines_test.go
+++ b/api/machines_test.go
@@ -40,7 +40,7 @@ func TestMachinesList(t *testing.T) {
 		t.Error("Received nil response body")
 	} else {
 		body := rw.Body.String()
-		expected := `{"machines":[{"id":"XXX"},{"id":"YYY","metadata":{"ping":"pong"},"primaryIP":"1.2.3.4"}]}`
+		expected := `{"data":{"items":[{"id":"XXX"},{"id":"YYY","metadata":{"ping":"pong"},"primaryIP":"1.2.3.4"}]}}`
 		if body != expected {
 			t.Errorf("Expected body:\n%s\n\nReceived body:\n%s\n", expected, body)
 		}
@@ -82,33 +82,33 @@ func TestExtractMachinePage(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		page := extractMachinePage(all, tt.token)
+		resp := extractMachinePage(all, tt.token)
 		expectCount := (tt.idxEnd - tt.idxStart + 1)
-		if len(page.Machines) != expectCount {
-			t.Fatalf("case %d: expected page of %d, got %d", i, expectCount, len(page.Machines))
+		if len(resp.Data.Items) != expectCount {
+			t.Fatalf("case %d: expected page of %d, got %d", i, expectCount, len(resp.Data.Items))
 		}
 
-		first := page.Machines[0].Id
+		first := resp.Data.Items[0].Id
 		if first != strconv.FormatInt(int64(tt.idxStart), 10) {
 			t.Errorf("case %d: first element in page should have ID %d, got %d", i, tt.idxStart, first)
 		}
 
-		last := page.Machines[len(page.Machines)-1].Id
+		last := resp.Data.Items[len(resp.Data.Items)-1].Id
 		if last != strconv.FormatInt(int64(tt.idxEnd), 10) {
 			t.Errorf("case %d: first element in page should have ID %d, got %d", i, tt.idxEnd, last)
 		}
 
-		if tt.next == nil && page.NextPageToken != "" {
+		if tt.next == nil && resp.Data.NextPageToken != "" {
 			t.Errorf("case %d: did not expect NextPageToken", i)
 			continue
-		} else if page.NextPageToken == "" {
+		} else if resp.Data.NextPageToken == "" {
 			if tt.next != nil {
 				t.Errorf("case %d: did not receive expected NextPageToken", i)
 			}
 			continue
 		}
 
-		next, err := decodePageToken(page.NextPageToken)
+		next, err := decodePageToken(resp.Data.NextPageToken)
 		if err != nil {
 			t.Errorf("case %d: unable to parse NextPageToken: %v", i, err)
 			continue

--- a/client/http.go
+++ b/client/http.go
@@ -33,16 +33,16 @@ func (c *HTTPClient) Machines() ([]machine.MachineState, error) {
 	machines := make([]machine.MachineState, 0)
 	call := c.svc.Machines.List()
 	for call != nil {
-		page, err := call.Do()
+		resp, err := call.Do()
 		if err != nil {
 			return nil, err
 		}
 
-		machines = append(machines, mapMachinePageToMachineStates(page.Machines)...)
+		machines = append(machines, mapMachinePageToMachineStates(resp.Data.Items)...)
 
-		if len(page.NextPageToken) > 0 {
+		if len(resp.Data.NextPageToken) > 0 {
 			call = c.svc.Machines.List()
-			call.NextPageToken(page.NextPageToken)
+			call.NextPageToken(resp.Data.NextPageToken)
 		} else {
 			call = nil
 		}
@@ -86,21 +86,21 @@ func (c *HTTPClient) Jobs() ([]job.Job, error) {
 	var jobs []job.Job
 	call := c.svc.Units.List()
 	for call != nil {
-		page, err := call.Do()
+		resp, err := call.Do()
 		if err != nil {
 			return nil, err
 		}
 
-		units, err := mapUnitPageToJobs(page.Units, mm)
+		units, err := mapUnitPageToJobs(resp.Data.Items, mm)
 		if err != nil {
 			return nil, err
 		}
 
 		jobs = append(jobs, units...)
 
-		if len(page.NextPageToken) > 0 {
+		if len(resp.Data.NextPageToken) > 0 {
 			call = c.svc.Units.List()
-			call.NextPageToken(page.NextPageToken)
+			call.NextPageToken(resp.Data.NextPageToken)
 		} else {
 			call = nil
 		}
@@ -132,7 +132,7 @@ func (c *HTTPClient) Job(name string) (*job.Job, error) {
 		mm[m.ID] = &m
 	}
 
-	return mapUnitToJob(u, mm)
+	return mapUnitFieldsToJob(u.Data, mm)
 }
 
 func (c *HTTPClient) JobTarget(name string) (string, error) {
@@ -141,14 +141,14 @@ func (c *HTTPClient) JobTarget(name string) (string, error) {
 		return "", err
 	}
 
-	return u.TargetMachineID, nil
+	return u.Data.TargetMachineID, nil
 }
 
-func mapUnitPageToJobs(entities []*schema.Unit, mm map[string]*machine.MachineState) ([]job.Job, error) {
+func mapUnitPageToJobs(entities []*schema.UnitFields, mm map[string]*machine.MachineState) ([]job.Job, error) {
 	jobs := make([]job.Job, len(entities))
 	for i, _ := range entities {
 		entity := entities[i]
-		j, err := mapUnitToJob(entity, mm)
+		j, err := mapUnitFieldsToJob(entity, mm)
 		if err != nil {
 			return nil, err
 		}
@@ -160,7 +160,7 @@ func mapUnitPageToJobs(entities []*schema.Unit, mm map[string]*machine.MachineSt
 	return jobs, nil
 }
 
-func mapUnitToJob(entity *schema.Unit, mm map[string]*machine.MachineState) (*job.Job, error) {
+func mapUnitFieldsToJob(entity *schema.UnitFields, mm map[string]*machine.MachineState) (*job.Job, error) {
 	contents, err := base64.StdEncoding.DecodeString(entity.FileContents)
 	if err != nil {
 		return nil, err
@@ -201,24 +201,30 @@ func mapUnitToJob(entity *schema.Unit, mm map[string]*machine.MachineState) (*jo
 
 func (c *HTTPClient) DestroyJob(name string) error {
 	req := schema.DeletableUnit{
-		Name: name,
+		Data: &schema.DeletableUnitData{
+			Name: name,
+		},
 	}
 	return c.svc.Units.Delete(name, &req).Do()
 }
 
 func (c *HTTPClient) CreateJob(j *job.Job) error {
 	req := schema.DesiredUnitState{
-		Name:         j.Name,
-		DesiredState: string(job.JobStateInactive),
-		FileContents: base64.StdEncoding.EncodeToString([]byte(j.Unit.Raw)),
+		Data: &schema.DesiredUnitStateData{
+			Name:         j.Name,
+			DesiredState: string(job.JobStateInactive),
+			FileContents: base64.StdEncoding.EncodeToString([]byte(j.Unit.Raw)),
+		},
 	}
 	return c.svc.Units.Set(j.Name, &req).Do()
 }
 
 func (c *HTTPClient) SetJobTargetState(name string, state job.JobState) error {
 	req := schema.DesiredUnitState{
-		Name:         name,
-		DesiredState: string(state),
+		Data: &schema.DesiredUnitStateData{
+			Name:         name,
+			DesiredState: string(state),
+		},
 	}
 	return c.svc.Units.Set(name, &req).Do()
 }

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -15,11 +15,11 @@ func TestMapUnitEntityToJob(t *testing.T) {
 	loaded := job.JobStateLoaded
 
 	tests := []struct {
-		input  schema.Unit
+		input  schema.UnitFields
 		expect *job.Job
 	}{
 		{
-			schema.Unit{
+			schema.UnitFields{
 				Name:         "XXX",
 				CurrentState: "loaded",
 				Systemd: &schema.SystemdState{
@@ -52,7 +52,7 @@ func TestMapUnitEntityToJob(t *testing.T) {
 
 		// Lack of LoadState should result in a nil UnitState
 		{
-			schema.Unit{
+			schema.UnitFields{
 				Name:         "XXX",
 				CurrentState: "loaded",
 				FileContents: "W1NlcnZpY2VdCkV4ZWNTdGFydD0vdXNyL2Jpbi9zbGVlcCAzMDAwCg==",
@@ -75,7 +75,7 @@ func TestMapUnitEntityToJob(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		output, err := mapUnitToJob(&tt.input, nil)
+		output, err := mapUnitFieldsToJob(&tt.input, nil)
 		if err != nil {
 			t.Errorf("case %d: err=%v", i, err)
 			continue
@@ -87,9 +87,9 @@ func TestMapUnitEntityToJob(t *testing.T) {
 }
 
 func TestMapUnitEntityToJobFailure(t *testing.T) {
-	units := []schema.Unit{
+	units := []schema.UnitFields{
 		// Poorly-formatted FileContents should result in an error
-		schema.Unit{
+		schema.UnitFields{
 			Name:         "XXX",
 			CurrentState: "loaded",
 			Systemd: &schema.SystemdState{
@@ -104,7 +104,7 @@ func TestMapUnitEntityToJobFailure(t *testing.T) {
 	}
 
 	for i, u := range units {
-		output, err := mapUnitToJob(&u, nil)
+		output, err := mapUnitFieldsToJob(&u, nil)
 		if err == nil {
 			t.Errorf("case %d: expected non-nil error", i)
 		}
@@ -116,11 +116,11 @@ func TestMapUnitEntityToJobFailure(t *testing.T) {
 
 func TestMapUnitEntityToJobMachineFields(t *testing.T) {
 	tests := []struct {
-		input  schema.Unit
+		input  schema.UnitFields
 		expect *job.Job
 	}{
 		{
-			schema.Unit{
+			schema.UnitFields{
 				Systemd: &schema.SystemdState{
 					LoadState:   "loaded",
 					ActiveState: "active",
@@ -140,7 +140,7 @@ func TestMapUnitEntityToJobMachineFields(t *testing.T) {
 
 		// Missing MachineState in map does not result in loss of Machine ID
 		{
-			schema.Unit{
+			schema.UnitFields{
 				Systemd: &schema.SystemdState{
 					LoadState:   "loaded",
 					ActiveState: "active",
@@ -164,7 +164,7 @@ func TestMapUnitEntityToJobMachineFields(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		output, err := mapUnitToJob(&tt.input, mm)
+		output, err := mapUnitFieldsToJob(&tt.input, mm)
 		if err != nil {
 			t.Errorf("case %d: err=%v", i, err)
 			continue

--- a/schema/v1-alpha-gen.go
+++ b/schema/v1-alpha-gen.go
@@ -78,12 +78,20 @@ type UnitsService struct {
 }
 
 type DeletableUnit struct {
+	Data *DeletableUnitData `json:"data,omitempty"`
+}
+
+type DeletableUnitData struct {
 	FileContents string `json:"fileContents,omitempty"`
 
 	Name string `json:"name,omitempty"`
 }
 
 type DesiredUnitState struct {
+	Data *DesiredUnitStateData `json:"data,omitempty"`
+}
+
+type DesiredUnitStateData struct {
 	DesiredState string `json:"desiredState,omitempty"`
 
 	FileContents string `json:"fileContents,omitempty"`
@@ -100,7 +108,11 @@ type Machine struct {
 }
 
 type MachinePage struct {
-	Machines []*Machine `json:"machines,omitempty"`
+	Data *MachinePageData `json:"data,omitempty"`
+}
+
+type MachinePageData struct {
+	Items []*Machine `json:"items,omitempty"`
 
 	NextPageToken string `json:"nextPageToken,omitempty"`
 }
@@ -116,6 +128,10 @@ type SystemdState struct {
 }
 
 type Unit struct {
+	Data *UnitFields `json:"data,omitempty"`
+}
+
+type UnitFields struct {
 	CurrentState string `json:"currentState,omitempty"`
 
 	DesiredState string `json:"desiredState,omitempty"`
@@ -132,9 +148,13 @@ type Unit struct {
 }
 
 type UnitPage struct {
-	NextPageToken string `json:"nextPageToken,omitempty"`
+	Data *UnitPageData `json:"data,omitempty"`
+}
 
-	Units []*Unit `json:"units,omitempty"`
+type UnitPageData struct {
+	Items []*UnitFields `json:"items,omitempty"`
+
+	NextPageToken string `json:"nextPageToken,omitempty"`
 }
 
 // method id "fleet.Machine.List":

--- a/schema/v1-alpha.json
+++ b/schema/v1-alpha.json
@@ -46,20 +46,24 @@
       "id": "MachinePage",
       "type": "object",
       "properties": {
-        "machines": {
-          "type": "array",
-          "required": true,
-          "items": {
-            "$ref": "Machine"
+        "data": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "Machine"
+              }
+            },
+            "nextPageToken": {
+              "type": "string"
+            }
           }
-        },
-        "nextPageToken": {
-          "type": "string"
         }
       }
     },
-    "Unit": {
-      "id": "Unit",
+    "UnitFields": {
+      "id": "UnitFields",
       "type": "object",
       "properties": {
         "name": {
@@ -100,20 +104,6 @@
         }
       }
     },
-    "DeletableUnit": {
-      "id": "DeletableUnit",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "required": true
-        },
-        "fileContents": {
-          "type": "string",
-          "format": "byte"
-        }
-      }
-    },
     "SystemdState": {
       "id": "SystemdState",
       "type": "object",
@@ -136,15 +126,48 @@
       "id": "UnitPage",
       "type": "object",
       "properties": {
-        "units": {
-          "type": "array",
-          "required": true,
-          "items": {
-            "$ref": "Unit"
+        "data": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "array",
+              "required": true,
+              "items": {
+                "$ref": "UnitFields"
+              }
+            },
+            "nextPageToken": {
+              "type": "string"
+            }
           }
-        },
-        "nextPageToken": {
-          "type": "string"
+        }
+      }
+    },
+    "Unit": {
+      "id": "Unit",
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "UnitFields"
+        }
+      }
+    },
+    "DeletableUnit": {
+      "id": "DeletableUnit",
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "required": true
+            },
+            "fileContents": {
+              "type": "string",
+              "format": "byte"
+            }
+          }
         }
       }
     },
@@ -152,22 +175,27 @@
       "id": "DesiredUnitState",
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string",
-          "required": true
-        },
-        "desiredState": {
-          "type": "string",
-          "required": true,
-          "enum": [
-            "inactive",
-            "loaded",
-            "launched"
-          ]
-        },
-        "fileContents": {
-          "type": "string",
-          "format": "byte"
+        "data": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "required": true
+            },
+            "desiredState": {
+              "type": "string",
+              "required": true,
+              "enum": [
+                "inactive",
+                "loaded",
+                "launched"
+              ]
+            },
+            "fileContents": {
+              "type": "string",
+              "format": "byte"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
The Google JSON Style Guide says we should put actual request/response in a top-level "data" container: http://google-styleguide.googlecode.com/svn/trunk/jsoncstyleguide.xml?showone=data#data
