### PR TITLE
fix(API): Send correct Content-Type with error entities

### DIFF
--- a/api/machines.go
+++ b/api/machines.go
@@ -45,7 +45,7 @@ func (mr *machinesResource) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	sendResponse(rw, page)
+	sendResponse(rw, http.StatusOK, page)
 }
 
 func getMachinePage(reg registry.Registry, tok PageToken) (*schema.MachinePage, error) {

--- a/api/serialization.go
+++ b/api/serialization.go
@@ -30,7 +30,7 @@ func validateContentType(req *http.Request) error {
 
 // sendResponse attempts to marshal an arbitrary thing to JSON then write
 // it to the http.ResponseWriter
-func sendResponse(rw http.ResponseWriter, resp interface{}) {
+func sendResponse(rw http.ResponseWriter, code int, resp interface{}) {
 	enc, err := json.Marshal(resp)
 	if err != nil {
 		log.Errorf("Failed JSON-encoding HTTP response: %v", err)
@@ -39,6 +39,7 @@ func sendResponse(rw http.ResponseWriter, resp interface{}) {
 	}
 
 	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(code)
 
 	_, err = rw.Write(enc)
 	if err != nil {
@@ -54,6 +55,5 @@ type errorResponse struct {
 // the object into the provided http.ResponseWriter
 func sendError(rw http.ResponseWriter, code int, err error) {
 	resp := errorResponse{Error: &googleapi.Error{Code: code, Message: err.Error()}}
-	rw.WriteHeader(code)
-	sendResponse(rw, resp)
+	sendResponse(rw, code, resp)
 }

--- a/api/serialization_test.go
+++ b/api/serialization_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
@@ -32,7 +33,7 @@ func TestValidateContentType(t *testing.T) {
 
 func TestSendResponseMarshalSuccess(t *testing.T) {
 	rw := httptest.NewRecorder()
-	sendResponse(rw, nil)
+	sendResponse(rw, http.StatusOK, nil)
 
 	if rw.Code != http.StatusOK {
 		t.Errorf("Expected 200, got %d", rw.Code)
@@ -49,7 +50,7 @@ func TestSendResponseMarshalFailure(t *testing.T) {
 	rw := httptest.NewRecorder()
 
 	// channels are not JSON-serializable
-	sendResponse(rw, make(chan bool))
+	sendResponse(rw, http.StatusOK, make(chan bool))
 
 	if rw.Code != http.StatusInternalServerError {
 		t.Errorf("Expected 500, got %d", rw.Code)
@@ -72,5 +73,11 @@ func TestSendError(t *testing.T) {
 	expect := `{"error":{"code":400,"message":"sentinel","Body":""}}`
 	if body != expect {
 		t.Errorf("Expected body %q, got %q", expect, body)
+	}
+
+	ctypes := rw.HeaderMap["Content-Type"]
+	expectCTypes := []string{"application/json"}
+	if !reflect.DeepEqual(ctypes, expectCTypes) {
+		t.Errorf("Expected header Content-Type to be %v, got %v", expectCTypes, ctypes)
 	}
 }

--- a/api/units.go
+++ b/api/units.go
@@ -202,7 +202,7 @@ func (ur *unitsResource) get(rw http.ResponseWriter, req *http.Request, item str
 	u := mapJobToSchema(j)
 	u.TargetMachineID = tgt
 
-	sendResponse(rw, *u)
+	sendResponse(rw, http.StatusOK, *u)
 }
 
 func (ur *unitsResource) list(rw http.ResponseWriter, req *http.Request) {
@@ -224,7 +224,7 @@ func (ur *unitsResource) list(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	sendResponse(rw, page)
+	sendResponse(rw, http.StatusOK, page)
 }
 
 func getUnitPage(reg registry.Registry, tok PageToken) (*schema.UnitPage, error) {


### PR DESCRIPTION
`rw.WriteHeader` was being called in `sendError` before the `Content-Type: application/json` was actually being set.
