### PR TITLE
refactor(API): Use custom errorResponse struct

### DIFF
--- a/api/serialization.go
+++ b/api/serialization.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/coreos/fleet/third_party/code.google.com/p/google-api-go-client/googleapi"
 	log "github.com/coreos/fleet/third_party/github.com/golang/glog"
 )
 
@@ -47,14 +46,23 @@ func sendResponse(rw http.ResponseWriter, code int, resp interface{}) {
 	}
 }
 
-type errorResponse struct {
-	Error *googleapi.Error `json:"error"`
+// errorEntity is a fork of "code.google.com/p/google-api-go-client/googleapi".Error
+type errorEntity struct {
+	// Code is the HTTP response status code and will always be populated.
+	Code int `json:"code"`
+	// Message is the server response message and is only populated when
+	// explicitly referenced by the JSON server response.
+	Message string `json:"message"`
 }
 
-// sendError builds a googleapi.Error entity from the given arguments, serializing
+type errorResponse struct {
+	Error errorEntity `json:"error"`
+}
+
+// sendError builds an errorResponse entity from the given arguments, serializing
 // the object into the provided http.ResponseWriter
 func sendError(rw http.ResponseWriter, code int, err error) {
-	resp := errorResponse{Error: &googleapi.Error{Code: code}}
+	resp := errorResponse{Error: errorEntity{Code: code}}
 	if err != nil {
 		resp.Error.Message = err.Error()
 	}

--- a/api/serialization_test.go
+++ b/api/serialization_test.go
@@ -70,7 +70,7 @@ func TestSendError(t *testing.T) {
 	}
 
 	body := rw.Body.String()
-	expect := `{"error":{"code":400,"message":"sentinel","Body":""}}`
+	expect := `{"error":{"code":400,"message":"sentinel"}}`
 	if body != expect {
 		t.Errorf("Expected body %q, got %q", expect, body)
 	}
@@ -87,7 +87,7 @@ func TestSendNilError(t *testing.T) {
 	sendError(rw, http.StatusBadRequest, nil)
 
 	body := rw.Body.String()
-	expect := `{"error":{"code":400,"message":"","Body":""}}`
+	expect := `{"error":{"code":400,"message":""}}`
 	if body != expect {
 		t.Errorf("Expected body %q, got %q", expect, body)
 	}


### PR DESCRIPTION
The googleapi pkg provides an Error entity, but it
unnecessaryily serializes a field we do not use.
Creating an equivalent struct that we maintain
works around the problem while retaining the ability
for the client bindings to use googleapi.Error.
