### PR TITLE
refactor(job): Drop Job.UnitHash field

### DIFF
--- a/api/units.go
+++ b/api/units.go
@@ -283,7 +283,7 @@ func newUnitPage(reg registry.Registry, items []job.Job, tok *PageToken) (*schem
 func mapJobToSchema(j *job.Job) (*schema.Unit, error) {
 	su := schema.Unit{
 		Name:            j.Name,
-		FileHash:        j.UnitHash.String(),
+		FileHash:        j.Unit.Hash().String(),
 		FileContents:    encodeUnitContents(&j.Unit),
 		TargetMachineID: j.TargetMachineID,
 	}

--- a/api/units_test.go
+++ b/api/units_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -172,7 +171,6 @@ func TestMapJobToSchema(t *testing.T) {
 				TargetState:     &launched,
 				TargetMachineID: "ZZZ",
 				Unit:            unit.Unit{Raw: "[Service]\nExecStart=/usr/bin/sleep 3000\n"},
-				UnitHash:        unit.Hash([sha1.Size]byte{36, 139, 153, 125, 107, 236, 238, 27, 131, 91, 126, 199, 217, 200, 230, 141, 125, 210, 70, 35}),
 				UnitState: &unit.UnitState{
 					LoadState:    "loaded",
 					ActiveState:  "active",

--- a/client/http.go
+++ b/client/http.go
@@ -163,10 +163,9 @@ func mapUnitToJob(entity *schema.Unit, mm map[string]*machine.MachineState) (*jo
 
 	js := job.JobState(entity.CurrentState)
 	j := job.Job{
-		Name:     entity.Name,
-		State:    &js,
-		Unit:     *u,
-		UnitHash: u.Hash(),
+		Name:  entity.Name,
+		State: &js,
+		Unit:  *u,
 	}
 
 	// populate a UnitState object only if the entity

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"crypto/sha1"
 	"reflect"
 	"testing"
 
@@ -41,7 +40,6 @@ func TestMapUnitEntityToJob(t *testing.T) {
 						},
 					},
 				},
-				UnitHash: unit.Hash([sha1.Size]byte{36, 139, 153, 125, 107, 236, 238, 27, 131, 91, 126, 199, 217, 200, 230, 141, 125, 210, 70, 35}),
 				UnitState: &unit.UnitState{
 					LoadState:   "loaded",
 					ActiveState: "active",
@@ -69,7 +67,6 @@ func TestMapUnitEntityToJob(t *testing.T) {
 						},
 					},
 				},
-				UnitHash: unit.Hash([sha1.Size]byte{36, 139, 153, 125, 107, 236, 238, 27, 131, 91, 126, 199, 217, 200, 230, 141, 125, 210, 70, 35}),
 			},
 		},
 	}

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -509,7 +509,7 @@ func lazyCreateJobs(args []string, signAndVerify bool) error {
 func warnOnDifferentLocalUnit(name string, j *job.Job) {
 	if _, err := os.Stat(name); !os.IsNotExist(err) {
 		unit, err := getUnitFromFile(name)
-		if err == nil && unit.Hash() != j.UnitHash {
+		if err == nil && unit.Hash() != j.Unit.Hash() {
 			fmt.Fprintf(os.Stderr, "WARNING: Job(%s) in Registry differs from local Unit(%s)\n", j.Name, name)
 			return
 		}
@@ -518,7 +518,7 @@ func warnOnDifferentLocalUnit(name string, j *job.Job) {
 		file := path.Join(path.Dir(name), uni.Template)
 		if _, err := os.Stat(file); !os.IsNotExist(err) {
 			tmpl, err := getUnitFromFile(file)
-			if err == nil && tmpl.Hash() != j.UnitHash {
+			if err == nil && tmpl.Hash() != j.Unit.Hash() {
 				fmt.Fprintf(os.Stderr, "WARNING: Job(%s) in Registry differs from local template Unit(%s)\n", j.Name, uni.Template)
 			}
 		}

--- a/fleetctl/list_units.go
+++ b/fleetctl/list_units.go
@@ -80,9 +80,9 @@ Or, choose the columns to display:
 		},
 		"hash": func(j *job.Job, full bool) string {
 			if !full {
-				return j.UnitHash.Short()
+				return j.Unit.Hash().Short()
 			}
-			return j.UnitHash.String()
+			return j.Unit.Hash().String()
 		},
 	}
 )

--- a/job/job.go
+++ b/job/job.go
@@ -55,7 +55,6 @@ type Job struct {
 	TargetState     *JobState
 	TargetMachineID string
 	Unit            unit.Unit
-	UnitHash        unit.Hash
 	UnitState       *unit.UnitState
 }
 
@@ -69,7 +68,6 @@ func NewJob(name string, unit unit.Unit) *Job {
 		TargetState:     nil,
 		TargetMachineID: "",
 		Unit:            unit,
-		UnitHash:        unit.Hash(),
 		UnitState:       nil,
 	}
 }

--- a/registry/job.go
+++ b/registry/job.go
@@ -224,7 +224,7 @@ func (r *EtcdRegistry) CreateJob(j *job.Job) (err error) {
 
 	jm := jobModel{
 		Name:     j.Name,
-		UnitHash: j.UnitHash,
+		UnitHash: j.Unit.Hash(),
 	}
 	json, err := marshal(jm)
 	if err != nil {

--- a/registry/offer.go
+++ b/registry/offer.go
@@ -26,7 +26,7 @@ func (r *EtcdRegistry) CreateJobOffer(jo *job.JobOffer) error {
 	jom := jobOfferModel{
 		Job: jobModel{
 			Name:     jo.Job.Name,
-			UnitHash: jo.Job.UnitHash,
+			UnitHash: jo.Job.Unit.Hash(),
 		},
 		MachineIDs: jo.MachineIDs,
 	}


### PR DESCRIPTION
This is unnecessary, as it can be derived from the Unit where necessary. This also makes the meaning of a Job object much clearer, removing the possibility for a Job's Unit and UnitHash to diverge.
