### PR TITLE
Use a value, not pointer, for Job.TargetState field

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -105,13 +105,13 @@ func (a *Agent) Initialize() uint64 {
 			continue
 		}
 
-		if j.TargetState == nil || *j.TargetState == job.JobStateInactive {
+		if j.TargetState == job.JobStateInactive {
 			continue
 		}
 
 		loaded[j.Name] = j
 
-		if *j.TargetState != job.JobStateLaunched {
+		if j.TargetState != job.JobStateLaunched {
 			continue
 		}
 
@@ -624,7 +624,7 @@ func (a *Agent) JobScheduledLocally(jobName string) {
 	log.Infof("Bidding for all possible peers of Job(%s)", j.Name)
 	a.bidForPossiblePeers(j.Name)
 
-	if j.TargetState == nil || *j.TargetState != job.JobStateLaunched {
+	if j.TargetState != job.JobStateLaunched {
 		return
 	}
 

--- a/api/units.go
+++ b/api/units.go
@@ -286,6 +286,7 @@ func mapJobToSchema(j *job.Job) (*schema.Unit, error) {
 		FileHash:        j.Unit.Hash().String(),
 		FileContents:    encodeUnitContents(&j.Unit),
 		TargetMachineID: j.TargetMachineID,
+		DesiredState:    string(j.TargetState),
 	}
 
 	if j.State != nil {
@@ -301,10 +302,6 @@ func mapJobToSchema(j *job.Job) (*schema.Unit, error) {
 		if j.UnitState.MachineState != nil {
 			su.Systemd.MachineID = j.UnitState.MachineState.ID
 		}
-	}
-
-	if j.TargetState != nil {
-		su.DesiredState = string(*j.TargetState)
 	}
 
 	return &su, nil

--- a/api/units_test.go
+++ b/api/units_test.go
@@ -158,7 +158,6 @@ func TestExtractUnitPage(t *testing.T) {
 
 func TestMapJobToSchema(t *testing.T) {
 	loaded := job.JobStateLoaded
-	launched := job.JobStateLaunched
 
 	tests := []struct {
 		input  job.Job
@@ -168,7 +167,7 @@ func TestMapJobToSchema(t *testing.T) {
 			job.Job{
 				Name:            "XXX",
 				State:           &loaded,
-				TargetState:     &launched,
+				TargetState:     job.JobStateLaunched,
 				TargetMachineID: "ZZZ",
 				Unit:            unit.Unit{Raw: "[Service]\nExecStart=/usr/bin/sleep 3000\n"},
 				UnitState: &unit.UnitState{
@@ -459,10 +458,8 @@ func TestUnitsSetDesiredState(t *testing.T) {
 				t.Errorf("case %d: fetched nil Job(%s), expected non-nil", i, name)
 			}
 
-			if j.TargetState == nil {
-				t.Errorf("case %d: got nil target state for Job(%s), expected non-nil", i, name)
-			} else if *j.TargetState != expect {
-				t.Errorf("case %d: expect Job(%s) target state %q, got %q", i, name, expect, *j.TargetState)
+			if j.TargetState != expect {
+				t.Errorf("case %d: expect Job(%s) target state %q, got %q", i, name, expect, j.TargetState)
 			}
 		}
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -47,14 +47,14 @@ func (e *Engine) CheckForWork() {
 
 	jobs, _ := e.registry.Jobs()
 	for _, j := range jobs {
-		if j.TargetState == nil || j.State == nil || *j.TargetState == *j.State {
+		if j.State == nil || j.TargetState == *j.State {
 			continue
 		}
 
 		if *j.State == job.JobStateInactive {
 			log.Infof("Offering Job(%s)", j.Name)
 			e.OfferJob(j)
-		} else if *j.TargetState == job.JobStateInactive {
+		} else if j.TargetState == job.JobStateInactive {
 			log.Infof("Unscheduling Job(%s)", j.Name)
 			e.registry.ClearJobTarget(j.Name, j.TargetMachineID)
 		}

--- a/engine/event.go
+++ b/engine/event.go
@@ -59,7 +59,7 @@ func (eh *EventHandler) HandleEventJobUnscheduled(ev event.Event) {
 		return
 	}
 
-	if j.TargetState == nil || *j.TargetState == job.JobStateInactive {
+	if j.TargetState == job.JobStateInactive {
 		return
 	}
 

--- a/job/job.go
+++ b/job/job.go
@@ -1,6 +1,7 @@
 package job
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -41,18 +42,22 @@ const (
 	fleetFlagMachineMetadata = "MachineMetadata"
 )
 
-func ParseJobState(s string) *JobState {
+func ParseJobState(s string) (JobState, error) {
 	js := JobState(s)
+
+	var err error
 	if js != JobStateInactive && js != JobStateLoaded && js != JobStateLaunched {
-		return nil
+		err = fmt.Errorf("invalid value %q for JobState", s)
+		js = JobStateInactive
 	}
-	return &js
+
+	return js, err
 }
 
 type Job struct {
 	Name            string
 	State           *JobState
-	TargetState     *JobState
+	TargetState     JobState
 	TargetMachineID string
 	Unit            unit.Unit
 	UnitState       *unit.UnitState
@@ -65,7 +70,7 @@ func NewJob(name string, unit unit.Unit) *Job {
 	return &Job{
 		Name:            name,
 		State:           nil,
-		TargetState:     nil,
+		TargetState:     JobStateInactive,
 		TargetMachineID: "",
 		Unit:            unit,
 		UnitState:       nil,

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -318,3 +318,26 @@ func TestInstanceUnitPrintf(t *testing.T) {
 		}
 	}
 }
+
+func TestParseJobState(t *testing.T) {
+	tests := []struct {
+		in  string
+		out JobState
+		err bool
+	}{
+		{"inactive", JobStateInactive, false},
+		{"loaded", JobStateLoaded, false},
+		{"launched", JobStateLaunched, false},
+		{"active", JobStateInactive, true},
+	}
+
+	for i, tt := range tests {
+		out, err := ParseJobState(tt.in)
+		if (err != nil) != tt.err {
+			t.Errorf("case %d: expected error=%t, got %v", i, tt.err, err)
+		}
+		if out != tt.out {
+			t.Errorf("case %d: expected JobState=%v, got %v", i, tt.out, out)
+		}
+	}
+}

--- a/registry/fake.go
+++ b/registry/fake.go
@@ -155,7 +155,7 @@ func (f *FakeRegistry) SetJobTargetState(name string, target job.JobState) error
 		return errors.New("job does not exist")
 	}
 
-	j.TargetState = &target
+	j.TargetState = target
 	f.jobs[name] = j
 
 	return nil


### PR DESCRIPTION
This field should always have a value, so it should not be a pointer. It is currently a pointer because it used to be fetched independently from the Registry where the value could simply not exist. In the event that the value is not set in the registry, the default value is "inactive", so let's just provide that and centralize the logic in one place.
