### PR TITLE
etcd: GET with consistent=true

### DIFF
--- a/etcd/action.go
+++ b/etcd/action.go
@@ -161,6 +161,7 @@ func (g *Get) HTTPRequest() (*http.Request, error) {
 	endpoint := v2URL(g.Key)
 
 	params := endpoint.Query()
+	params.Add("consistent", "true")
 	params.Add("sorted", strconv.FormatBool(g.Sorted))
 	params.Add("recursive", strconv.FormatBool(g.Recursive))
 	endpoint.RawQuery = params.Encode()

--- a/etcd/action_test.go
+++ b/etcd/action_test.go
@@ -14,13 +14,13 @@ func TestGetHTTPRequest(t *testing.T) {
 		{
 			&Get{Key: "/foo"},
 			"GET",
-			"/v2/keys/foo?recursive=false&sorted=false",
+			"/v2/keys/foo?consistent=true&recursive=false&sorted=false",
 			"",
 		},
 		{
 			&Get{Key: "/foo", Sorted: true, Recursive: true},
 			"GET",
-			"/v2/keys/foo?recursive=true&sorted=true",
+			"/v2/keys/foo?consistent=true&recursive=true&sorted=true",
 			"",
 		},
 	}

--- a/etcd/client_test.go
+++ b/etcd/client_test.go
@@ -216,7 +216,7 @@ func assertClientSteps(t *testing.T, c *client, act Action, steps []clientStep, 
 func TestClientRedirectsFollowed(t *testing.T) {
 	steps := []clientStep{
 		{
-			"GET", "http://192.0.2.1:4001/v2/keys/foo?recursive=false&sorted=false",
+			"GET", "http://192.0.2.1:4001/v2/keys/foo?consistent=true&recursive=false&sorted=false",
 			http.Response{
 				StatusCode: http.StatusTemporaryRedirect,
 				Header: http.Header{
@@ -256,7 +256,7 @@ func TestClientRedirectsFollowed(t *testing.T) {
 func TestClientRedirectsAndAlternateEndpoints(t *testing.T) {
 	steps := []clientStep{
 		{
-			"GET", "http://192.0.2.1:4001/v2/keys/foo?recursive=false&sorted=false",
+			"GET", "http://192.0.2.1:4001/v2/keys/foo?consistent=true&recursive=false&sorted=false",
 			http.Response{
 				StatusCode: http.StatusTemporaryRedirect,
 				Header: http.Header{
@@ -271,7 +271,7 @@ func TestClientRedirectsAndAlternateEndpoints(t *testing.T) {
 			},
 		},
 		{
-			"GET", "http://192.0.2.2:4002/v2/keys/foo?recursive=false&sorted=false",
+			"GET", "http://192.0.2.2:4002/v2/keys/foo?consistent=true&recursive=false&sorted=false",
 			http.Response{
 				StatusCode: http.StatusOK,
 				Header:     http.Header{"X-Etcd-Index": {"123"}},


### PR DESCRIPTION
Partially fix #582

This is not the best solution, but it reverts the change in behavior from the go-etcd rewrite.
