### PR TITLE
etcd: fix leaking fds

### DIFF
--- a/etcd/client.go
+++ b/etcd/client.go
@@ -254,6 +254,9 @@ func (ar *actionResolver) Resolve(cancel <-chan bool) (*Result, error) {
 		log.Infof("Failed getting response from %v: %v", ar.endpoint, err)
 		return nil, nil
 	}
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 
 	hdlr, ok := handlers[resp.StatusCode]
 	if !ok {
@@ -277,7 +280,6 @@ func (ar *actionResolver) exhaust(cancel <-chan bool) (resp *http.Response, body
 		if err != nil {
 			return nil, nil, err
 		}
-
 		req, err = ar.next(resp)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
When etcd redirects to a leader - which happens every time fleet makes a request to a standby - it never closes the body of the response.

WARNING: This has not been tested, but it builds. We're waiting to see if this actually fixes the problem in production. Stay tuned.
