### PR TITLE
Basic resource reservations

### DIFF
--- a/machine/coreos.go
+++ b/machine/coreos.go
@@ -59,8 +59,7 @@ func (m *CoreOSMachine) Refresh() {
 	m.RLock()
 	defer m.RUnlock()
 
-	ms := m.currentState()
-	m.dynamicState = &ms
+	m.dynamicState = m.currentState()
 }
 
 // PeriodicRefresh updates the current state of the CoreOSMachine at the
@@ -81,7 +80,7 @@ func (m *CoreOSMachine) PeriodicRefresh(interval time.Duration, stop chan bool) 
 
 // currentState generates a MachineState object with the values read from
 // the local system
-func (m *CoreOSMachine) currentState() MachineState {
+func (m *CoreOSMachine) currentState() *MachineState {
 	id := readLocalMachineID("/")
 	publicIP := getLocalIP()
 	// TODO(jonboulle): clarify failure behaviour when unable to retrieve resources/units
@@ -95,7 +94,7 @@ func (m *CoreOSMachine) currentState() MachineState {
 		log.Errorf("Error retrieving local units: %v\n", err)
 		units = []string{}
 	}
-	return MachineState{
+	return &MachineState{
 		ID:             id,
 		PublicIP:       publicIP,
 		Metadata:       make(map[string]string, 0),
@@ -104,11 +103,7 @@ func (m *CoreOSMachine) currentState() MachineState {
 	}
 }
 
-// IsLocalMachineState checks whether machine state matches the state of local machine
-func IsLocalMachineState(ms *MachineState) bool {
-	return ms.ID == readLocalMachineID("/")
-}
-
+// IsLocalMachineID returns whether the given machine ID is equal to that of the local machine
 func IsLocalMachineID(mID string) bool {
 	return mID == readLocalMachineID("/")
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -1,6 +1,6 @@
 package resource
 
-// ResourceTuple groups together cpu, memory and disk space. This could be
+// ResourceTuple groups together CPU, memory and disk space. This could be
 // total, available or consumed. It could also be used by job resource requirements.
 type ResourceTuple struct {
 	// in hundreds, ie 100=1core, 50=0.5core, 200=2cores, etc
@@ -9,4 +9,38 @@ type ResourceTuple struct {
 	Memory int
 	// in MB
 	Disk int
+}
+
+const (
+	// TODO(jonboulle): make these configurable
+	HostCores  = 100
+	HostMemory = 256
+	HostDisk   = 0
+)
+
+// HostResources represents a set of resources that fleet considers reserved
+// for the host, i.e. outside of any units it is running
+var HostResources = ResourceTuple{
+	HostCores,
+	HostMemory,
+	HostDisk,
+}
+
+// Sum aggregates a number of ResourceTuples into a single entity
+func Sum(resources ...ResourceTuple) (res ResourceTuple) {
+	for _, r := range resources {
+		res.Cores += r.Cores
+		res.Memory += r.Memory
+		res.Disk += r.Disk
+	}
+	return
+}
+
+// Sub returns a ResourceTuple representing the difference between two
+// ResourceTuples
+func Sub(r1, r2 ResourceTuple) (res ResourceTuple) {
+	res.Cores = r1.Cores - r2.Cores
+	res.Memory = r1.Memory - r2.Memory
+	res.Disk = r1.Disk - r2.Disk
+	return
 }

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -1,0 +1,58 @@
+package resource
+
+import "reflect"
+import "testing"
+
+func TestSum(t *testing.T) {
+	for i, tt := range []struct {
+		in   []ResourceTuple
+		want ResourceTuple
+	}{
+		{
+			[]ResourceTuple{ResourceTuple{10, 24, 1024}},
+			ResourceTuple{10, 24, 1024},
+		},
+		{
+			[]ResourceTuple{ResourceTuple{10, 24, 1024}, ResourceTuple{10, 24, 1024}},
+			ResourceTuple{20, 48, 2048},
+		},
+		{
+			[]ResourceTuple{},
+			ResourceTuple{0, 0, 0},
+		},
+	} {
+		got := Sum(tt.in...)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("case %d: got %v, want %v", i, got, tt.want)
+		}
+	}
+}
+
+func TestSub(t *testing.T) {
+	for i, tt := range []struct {
+		r1   ResourceTuple
+		r2   ResourceTuple
+		want ResourceTuple
+	}{
+		{
+			ResourceTuple{10, 24, 1024},
+			ResourceTuple{10, 24, 1024},
+			ResourceTuple{0, 0, 0},
+		},
+		{
+			ResourceTuple{20, 48, 2048},
+			ResourceTuple{15, 36, 2048},
+			ResourceTuple{5, 12, 0},
+		},
+		{
+			ResourceTuple{0, 0, 0},
+			ResourceTuple{0, 0, 0},
+			ResourceTuple{0, 0, 0},
+		},
+	} {
+		got := Sub(tt.r1, tt.r2)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("case %d: got %v, want %v", i, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Building on #616 (so relevant commit = 917ae9052c2ca45ce7f9dc6ddfc5f6c41736e909), this exposes basic resource reservation information in MachineState. The current approach for calculating free resources is extremely simple: assume a fixed block of resources (HostResources) is reserved for usage outside of fleet units (e.g. by system processes and fleet itself), and subtract the aggregate resources that have been reserved explicitly using fleet directives.

Note that this is a proof of concept/strawman trying to explore how best to integrate this information.
