### PR TITLE
-l is deprecated && long options are more readable

### DIFF
--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -49,7 +49,7 @@ func runJournal(args []string) (exit int) {
 		return 1
 	}
 
-	command := fmt.Sprintf("journalctl -u %s --no-pager -l -n %d", jobName, flagLines)
+	command := fmt.Sprintf("journalctl --unit %s --no-pager -n %d", jobName, flagLines)
 	if flagFollow {
 		command += " -f"
 	}


### PR DESCRIPTION
in last doc (http://www.freedesktop.org/software/systemd/man/journalctl.html) we can read : 

> The old options -l/--full are not useful anymore, except to undo --no-full.

with systemd 204-14 that generate this error : 

```
invalid option -- 'l'
```
