### PR TITLE
"Engine completed reconciliation in..." too noisy

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -95,7 +95,13 @@ func (e *Engine) Reconcile() {
 
 	start := time.Now()
 	defer func() {
-		log.Infof("Engine completed reconciliation in %s", time.Now().Sub(start))
+		elapsed := time.Now().Sub(start)
+		logFunc := log.V(1).Infof
+		// If the reconciliation time is slow, elevate the log level
+		if elapsed > reconcileInterval {
+			logFunc = log.Warningf
+		}
+		logFunc("Engine completed reconciliation in %s", time.Now().Sub(start))
 	}()
 
 	jobs, err := e.registry.Jobs()


### PR DESCRIPTION
Maybe we should log this at V(1)?

```
Jul 11 02:30:56 core-01 fleet[1013]: I0711 02:30:56.937990 01013 engine.go:98] Engine completed reconciliation in 2.345317ms
Jul 11 02:30:58 core-01 fleet[1013]: I0711 02:30:58.934859 01013 engine.go:98] Engine completed reconciliation in 5.102629ms
Jul 11 02:31:00 core-01 fleet[1013]: I0711 02:31:00.933334 01013 engine.go:98] Engine completed reconciliation in 7.903558ms
Jul 11 02:31:02 core-01 fleet[1013]: I0711 02:31:02.933346 01013 engine.go:98] Engine completed reconciliation in 8.3272ms
Jul 11 02:31:04 core-01 fleet[1013]: I0711 02:31:04.932959 01013 engine.go:98] Engine completed reconciliation in 7.789008ms
Jul 11 02:31:06 core-01 fleet[1013]: I0711 02:31:06.933703 01013 engine.go:98] Engine completed reconciliation in 7.734072ms
Jul 11 02:31:08 core-01 fleet[1013]: I0711 02:31:08.936978 01013 engine.go:98] Engine completed reconciliation in 10.665683ms
Jul 11 02:31:10 core-01 fleet[1013]: I0711 02:31:10.937356 01013 engine.go:98] Engine completed reconciliation in 8.997889ms
Jul 11 02:31:12 core-01 fleet[1013]: I0711 02:31:12.931974 01013 engine.go:98] Engine completed reconciliation in 6.23224ms
Jul 11 02:31:14 core-01 fleet[1013]: I0711 02:31:14.936108 01013 engine.go:98] Engine completed reconciliation in 6.231551ms
Jul 11 02:31:16 core-01 fleet[1013]: I0711 02:31:16.934211 01013 engine.go:98] Engine completed reconciliation in 5.088524ms
Jul 11 02:31:18 core-01 fleet[1013]: I0711 02:31:18.930175 01013 engine.go:98] Engine completed reconciliation in 3.59756ms
Jul 11 02:31:20 core-01 fleet[1013]: I0711 02:31:20.933408 01013 engine.go:98] Engine completed reconciliation in 4.362663ms
Jul 11 02:31:22 core-01 fleet[1013]: I0711 02:31:22.932584 01013 engine.go:98] Engine completed reconciliation in 7.458903ms
```
