### PR TITLE
registry: replace missing event generator

### DIFF
--- a/registry/event.go
+++ b/registry/event.go
@@ -29,6 +29,7 @@ func (es *EventStream) Stream(idx uint64, sendFunc func(*event.Event), stop chan
 		filterEventJobDestroyed,
 		filterEventJobScheduled,
 		filterEventJobUnscheduled,
+		es.filterJobTargetStateChanges,
 		es.filterEventJobOffered,
 	}
 


### PR DESCRIPTION
The CommandStartJob and CommandStopJob events were being used by the
agent when they were dropped in commit 7881fd9. Return them to their
former glory.
