### PR TITLE
panic in hydrateJob

### DIFF
--- a/registry/job.go
+++ b/registry/job.go
@@ -42,7 +42,7 @@ func (r *EtcdRegistry) Jobs() ([]job.Job, error) {
 			}
 
 			j, err := r.getJobFromJSON(node.Value)
-			if err != nil {
+			if j == nil || err != nil {
 				log.Infof("Unable to parse Job in Registry at key %s", node.Key)
 				continue
 			}


### PR DESCRIPTION
Running fleet v0.5.3. 

```
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: I0713 01:08:08.920127 02102 client.go:274] Failed getting response from http://localhost:4001/: cancelled
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: panic: runtime error: invalid memory address or nil pointer dereference
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: [signal 0xb code=0x1 addr=0x0 pc=0x47c1a0]
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: goroutine 325 [running]:
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: runtime.panic(0x7092a0, 0xb58248)
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: /usr/local/go/src/pkg/runtime/panic.c:266 +0xb6
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: github.com/coreos/fleet/registry.(*EtcdRegistry).hydrateJob(0xc210093420, 0x0, 0x78, 0x0)
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: /home/core/fleet/scripts/fleet/gopath/src/github.com/coreos/fleet/registry/job.go:126 +0x150
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: github.com/coreos/fleet/registry.(*EtcdRegistry).Jobs(0xc210093420, 0x7c13f0, 0x24, 0x0, 0x0, ...)
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: /home/core/fleet/scripts/fleet/gopath/src/github.com/coreos/fleet/registry/job.go:50 +0x608
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: github.com/coreos/fleet/engine.(*Engine).Reconcile(0xc2100c29f0)
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: /home/core/fleet/scripts/fleet/gopath/src/github.com/coreos/fleet/engine/engine.go:60 +0x7f
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: github.com/coreos/fleet/engine.func<C2><B7>001()
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: /home/core/fleet/scripts/fleet/gopath/src/github.com/coreos/fleet/engine/engine.go:40 +0x1a2
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: github.com/coreos/fleet/engine.(*Engine).Run(0xc2100c29f0, 0xc2101542a0)
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: /home/core/fleet/scripts/fleet/gopath/src/github.com/coreos/fleet/engine/engine.go:50 +0x25a
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: created by github.com/coreos/fleet/server.(*Server).Run
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: /home/core/fleet/scripts/fleet/gopath/src/github.com/coreos/fleet/server/server.go:182 +0x238
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: goroutine 1 [chan receive]:
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: main.listenForSignals(0xc210072bd0)
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: /home/core/fleet/scripts/fleet/gopath/src/github.com/coreos/fleet/fleet.go:177 +0x12c
Jul 13 01:08:08 ip-10-123-139-220 fleet[2102]: main.main()
```
