### PR TITLE
registry: fix Jobs ordering in FakeRegistry

### DIFF
--- a/registry/fake.go
+++ b/registry/fake.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"errors"
+	"sort"
 	"sync"
 
 	"github.com/coreos/fleet/Godeps/_workspace/src/github.com/coreos/go-semver/semver"
@@ -86,10 +87,17 @@ func (f *FakeRegistry) Jobs() ([]job.Job, error) {
 	f.RLock()
 	defer f.RUnlock()
 
-	jobs := make([]job.Job, 0, len(f.jobs))
+	var sorted sort.StringSlice
 	for _, j := range f.jobs {
-		jobs = append(jobs, j)
+		sorted = append(sorted, j.Name)
 	}
+	sorted.Sort()
+
+	jobs := make([]job.Job, 0, len(f.jobs))
+	for _, jName := range sorted {
+		jobs = append(jobs, f.jobs[jName])
+	}
+
 	return jobs, nil
 }
 

--- a/registry/job.go
+++ b/registry/job.go
@@ -17,7 +17,7 @@ const (
 	jobPrefix = "job"
 )
 
-// Jobs lists all Jobs known by the Registry
+// Jobs lists all Jobs known by the Registry, ordered by job name
 func (r *EtcdRegistry) Jobs() ([]job.Job, error) {
 	var jobs []job.Job
 


### PR DESCRIPTION
This was the cause of the spurious

```
--- FAIL: TestUnitsList (0.00 seconds)
    units_test.go:73: Received incorrect UnitPage entity: { [0xc20802a850 0xc20802a8c0]}
```

on go1.3.
