### PR TITLE
Enable SSL Certificate authentication for etcd endpoint

### DIFF
--- a/etcd/client.go
+++ b/etcd/client.go
@@ -69,8 +69,8 @@ func setDefaultPath(u *url.URL) {
 // filterURL raises an error if the provided url.URL has any
 // questionable attributes
 func filterURL(u *url.URL) error {
-	if u.Scheme != "http" {
-		return fmt.Errorf("unable to use endpoint scheme %s, http only", u.Scheme)
+	if !(u.Scheme == "http" || u.Scheme == "https") {
+		return fmt.Errorf("unable to use endpoint scheme %s, http/https only", u.Scheme)
 	}
 
 	if u.Path != "/" {

--- a/etcd/client_test.go
+++ b/etcd/client_test.go
@@ -87,6 +87,9 @@ func TestFilterURL(t *testing.T) {
 		// hostname
 		{"http://example.com/", true},
 
+		// https scheme
+		{"https://192.0.2.3:4002/", true},
+
 		// no host info
 		{"http:///foo/bar", false},
 
@@ -104,9 +107,6 @@ func TestFilterURL(t *testing.T) {
 
 		// non-http scheme
 		{"boots://192.0.2.3:4002/", false},
-
-		// https scheme fails for now
-		{"https://192.0.2.3:4002/", false},
 
 		// no slash after scheme (url.URL.Opaque)
 		{"http:192.0.2.3/", false},


### PR DESCRIPTION
This pull request allows to connect etcd with certificate authentication. 

Some code could be factored between etcd and fleet... but I need this functionality now. 
Could you merge before refactoring?
