### PR TITLE
fleetctl: add list-unit-files command

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -106,6 +106,7 @@ func init() {
 		cmdHelp,
 		cmdJournal,
 		cmdListMachines,
+		cmdListUnitFiles,
 		cmdListUnits,
 		cmdLoadUnits,
 		cmdSSH,

--- a/fleetctl/list_unit_files.go
+++ b/fleetctl/list_unit_files.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/coreos/fleet/job"
+)
+
+const (
+	defaultListUnitFilesFields = "unit,hash,dstate"
+)
+
+var (
+	listUnitFilesFieldsFlag string
+	cmdListUnitFiles        = &Command{
+		Name:        "list-unit-files",
+		Summary:     "List the units that exist in the cluster.",
+		Usage:       "[--fields]",
+		Description: `Lists all unit files that exist in the cluster (whether or not they are loaded onto a machine).`,
+		Run:         runListUnitFiles,
+	}
+	listUnitFilesFields = map[string]jobToField{
+		"unit": func(j *job.Job, full bool) string {
+			return j.Name
+		},
+		"dstate": func(j *job.Job, full bool) string {
+			return string(j.TargetState)
+		},
+		"hash": func(j *job.Job, full bool) string {
+			if !full {
+				return j.Unit.Hash().Short()
+			}
+			return j.Unit.Hash().String()
+		},
+	}
+)
+
+func init() {
+	cmdListUnitFiles.Flags.BoolVar(&sharedFlags.Full, "full", false, "Do not ellipsize fields on output")
+	cmdListUnitFiles.Flags.BoolVar(&sharedFlags.NoLegend, "no-legend", false, "Do not print a legend (column headers)")
+	cmdListUnitFiles.Flags.StringVar(&listUnitFilesFieldsFlag, "fields", defaultListUnitFilesFields, fmt.Sprintf("Columns to print for each Unit file. Valid fields are %q", strings.Join(jobToFieldKeys(listUnitFilesFields), ",")))
+}
+
+func runListUnitFiles(args []string) (exit int) {
+	if listUnitFilesFieldsFlag == "" {
+		fmt.Fprintf(os.Stderr, "Must define output format\n")
+		return 1
+	}
+
+	cols := strings.Split(listUnitFilesFieldsFlag, ",")
+	for _, s := range cols {
+		if _, ok := listUnitFilesFields[s]; !ok {
+			fmt.Fprintf(os.Stderr, "Invalid key in output format: %q\n", s)
+			return 1
+		}
+	}
+
+	jobs, err := cAPI.Jobs()
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error retrieving list of units from repository: %v\n", err)
+		return 1
+	}
+	if !sharedFlags.NoLegend {
+		fmt.Fprintln(out, strings.ToUpper(strings.Join(cols, "\t")))
+	}
+
+	for _, j := range jobs {
+		j := j
+		var f []string
+		for _, c := range cols {
+			f = append(f, listUnitFilesFields[c](&j, sharedFlags.Full))
+		}
+		fmt.Fprintln(out, strings.Join(f, "\t"))
+	}
+
+	out.Flush()
+	return
+}

--- a/fleetctl/list_unit_files_test.go
+++ b/fleetctl/list_unit_files_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestListUnitFilesFieldsToStrings(t *testing.T) {
+	j := newTestJobFromUnitContents(t, `[Unit]
+Description=some description`)
+
+	f := listUnitFilesFields["unit"](j, false)
+	assertEqual(t, "unit", j.Name, f)
+
+	uh := "f035b2f14edc4d23572e5f3d3d4cb4f78d0e53c3"
+	fuh := listUnitFilesFields["hash"](j, true)
+	suh := listUnitFilesFields["hash"](j, false)
+	assertEqual(t, "hash", uh, fuh)
+	assertEqual(t, "hash", uh[:7], suh)
+}

--- a/fleetctl/list_units.go
+++ b/fleetctl/list_units.go
@@ -17,9 +17,9 @@ var (
 	listUnitsFieldsFlag string
 	cmdListUnits        = &Command{
 		Name:    "list-units",
-		Summary: "Enumerate units loaded in the cluster",
-		Usage:   "[--no-legend] [-l|--full]",
-		Description: `Lists all units submitted or started on the cluster.
+		Summary: "List the current state of units in the cluster",
+		Usage:   "[--no-legend] [-l|--full] [--fields]",
+		Description: `Lists the state of all units in the cluster loaded onto a machine.
 
 For easily parsable output, you can remove the column headers:
 	fleetctl list-units --no-legend
@@ -152,7 +152,7 @@ func runListUnits(args []string) (exit int) {
 }
 
 func jobToFieldKeys(m map[string]jobToField) (keys []string) {
-	for k, _ := range m {
+	for k := range m {
 		keys = append(keys, k)
 	}
 	return


### PR DESCRIPTION
This is functionally equivalent to `fleetctl list-units --fields
unit,hash,dstate` for now; it will start to make more sense as the registry
API and `fleetctl list-units` receive their own changes.

Not really sure on good descriptions so open to suggestions.
