### PR TITLE
registry: use pkg.Set to communicate bids

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -322,11 +322,8 @@ func (a *Agent) bidForPossibleJobs() {
 // Submit a bid for the given Job
 func (a *Agent) bid(jobName string) {
 	log.Infof("Submitting JobBid for Job(%s)", jobName)
-
-	jb := job.NewBid(jobName, a.Machine.State().ID)
-	a.registry.SubmitJobBid(jb)
-
-	a.state.TrackBid(jb.JobName)
+	a.registry.SubmitJobBid(jobName, a.Machine.State().ID)
+	a.state.TrackBid(jobName)
 }
 
 // verifyJobSignature attempts to verify the integrity of the given Job by checking the

--- a/engine/dumb-reconciler.go
+++ b/engine/dumb-reconciler.go
@@ -101,18 +101,18 @@ func (r *dumbReconciler) Reconcile() {
 			return err
 		}
 
-		if len(bids) == 0 {
+		if bids.Length() == 0 {
 			log.Infof("No bids found for unresolved JobOffer(%s), unable to resolve", jName)
 			return nil
 		}
 
-		choice := bids[0]
+		choice := bids.Values()[0]
 
-		err = r.registry.ScheduleJob(jName, choice.MachineID)
+		err = r.registry.ScheduleJob(jName, choice)
 		if err != nil {
-			log.Errorf("Failed scheduling Job(%s) to Machine(%s): %v", choice.JobName, choice.MachineID, err)
+			log.Errorf("Failed scheduling Job(%s) to Machine(%s): %v", jName, choice, err)
 		} else {
-			log.Infof("Scheduled Job(%s) to Machine(%s)", jName, choice.MachineID)
+			log.Infof("Scheduled Job(%s) to Machine(%s)", jName, choice)
 		}
 
 		return err

--- a/engine/reconciler.go
+++ b/engine/reconciler.go
@@ -120,13 +120,13 @@ func (r *wipReconciler) Reconcile() {
 			return err
 		}
 
-		if len(bids) == 0 {
+		if bids.Length() == 0 {
 			log.Infof("No bids found for unresolved JobOffer(%s), unable to resolve", jName)
 			return nil
 		}
 
-		choice := bids[0]
-		return scheduleJob(jName, choice.MachineID)
+		choice := bids.Values()[0]
+		return scheduleJob(jName, choice)
 	}
 
 	// offerExists returns true if the referenced Job has a corresponding

--- a/job/offer.go
+++ b/job/offer.go
@@ -29,12 +29,3 @@ func (jo *JobOffer) OfferedTo(machineID string) bool {
 	k := sort.SearchStrings(jo.MachineIDs, machineID)
 	return k < len(jo.MachineIDs) && jo.MachineIDs[k] == machineID
 }
-
-type JobBid struct {
-	JobName   string
-	MachineID string
-}
-
-func NewBid(jobName string, machID string) *JobBid {
-	return &JobBid{jobName, machID}
-}

--- a/registry/interface.go
+++ b/registry/interface.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/coreos/fleet/job"
 	"github.com/coreos/fleet/machine"
+	"github.com/coreos/fleet/pkg"
 	"github.com/coreos/fleet/sign"
 	"github.com/coreos/fleet/unit"
 )
 
 type Registry interface {
-	Bids(jb *job.JobOffer) ([]job.JobBid, error)
+	Bids(jb *job.JobOffer) (pkg.Set, error)
 	CheckJobPulse(jobName string) (string, bool)
 	ClearJobHeartbeat(jobName string)
 	ClearJobTarget(jobName, machID string) error
@@ -35,7 +36,7 @@ type Registry interface {
 	ScheduleJob(jobName string, machID string) error
 	SetJobTargetState(jobName string, state job.JobState) error
 	SetMachineState(ms machine.MachineState, ttl time.Duration) (uint64, error)
-	SubmitJobBid(jb *job.JobBid)
+	SubmitJobBid(jName, machID string)
 	UnresolvedJobOffers() ([]job.JobOffer, error)
 }
 


### PR DESCRIPTION
The JobBid struct is unnecessary. Using a simple string means
we can use pkg.Set to communicate a collection of bids, too.
