### PR TITLE
heart: remove machine state in Heart

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -155,11 +155,6 @@ func (a *Agent) Purge() {
 		log.Infof("Unscheduling Job(%s) from local machine", jobName)
 		a.registry.ClearJobTarget(jobName, machID)
 	}
-
-	log.Info("Removing Agent from Registry")
-	if err := a.registry.RemoveMachineState(machID); err != nil {
-		log.Errorf("Failed to remove Machine %s from Registry: %s", machID, err.Error())
-	}
 }
 
 func (a *Agent) heartbeatJobs(ttl time.Duration, stop chan bool) {

--- a/heart/heart.go
+++ b/heart/heart.go
@@ -9,6 +9,7 @@ import (
 
 type Heart interface {
 	Beat(time.Duration) (uint64, error)
+	Clear() error
 }
 
 func New(reg registry.Registry, mach machine.Machine) Heart {
@@ -22,4 +23,8 @@ type machineHeart struct {
 
 func (h *machineHeart) Beat(ttl time.Duration) (uint64, error) {
 	return h.reg.SetMachineState(h.mach.State(), ttl)
+}
+
+func (h *machineHeart) Clear() error {
+	return h.reg.RemoveMachineState(h.mach.State().ID)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -211,6 +211,7 @@ func (s *Server) Stop() {
 func (s *Server) Purge() {
 	s.agent.Purge()
 	s.engine.Purge()
+	s.hrt.Clear()
 }
 
 func (s *Server) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Since the Agent is no longer responsible for maintaining machine-level presence, it should not be responsible for clearing the last-published state on shutdown.
