### PR TITLE
Deprecate signed units

### DIFF
--- a/fleet.go
+++ b/fleet.go
@@ -162,6 +162,10 @@ func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error
 		AuthorizedKeysFile: (*flagset.Lookup("authorized_keys_file")).Value.(flag.Getter).Get().(string),
 	}
 
+	if cfg.VerifyUnits {
+		log.Warning("WARNING: The signed/verified units feature is DEPRECATED and should not be used. It will be completely removed from fleet and fleetctl.")
+	}
+
 	config.UpdateLoggingFlagsFromConfig(flag.CommandLine, &cfg)
 
 	return &cfg, nil

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -191,6 +191,10 @@ func main() {
 		os.Exit(2)
 	}
 
+	if sharedFlags.Sign {
+		fmt.Fprintln(os.Stderr, "WARNING: The signed/verified units feature is DEPRECATED and should not be used. It will be completely removed from fleet and fleetctl.")
+	}
+
 	if cmd.Name != "help" && cmd.Name != "version" {
 		var err error
 		cAPI, err = getClient()

--- a/fleetctl/verify.go
+++ b/fleetctl/verify.go
@@ -7,14 +7,17 @@ import (
 
 var cmdVerifyUnit = &Command{
 	Name:    "verify",
-	Summary: "Verify unit file signatures using local SSH identities",
+	Summary: "DEPRECATED - Verify unit file signatures using local SSH identities",
 	Usage:   "UNIT",
-	Description: `Outputs whether or not unit file fits its signature. Useful to secure
+	Description: `This command is deprecated - it is being removed from fleetctl.
+	
+Outputs whether or not unit file fits its signature. Useful to secure
 the data of a unit.`,
 	Run: runVerifyUnit,
 }
 
 func runVerifyUnit(args []string) (exit int) {
+	fmt.Fprintln(os.Stderr, "WARNING: The signed/verified units feature is DEPRECATED and should not be used. It will be completely removed from fleet and fleetctl.")
 
 	if len(args) != 1 {
 		fmt.Fprintln(os.Stderr, "One unit file must be provided.")


### PR DESCRIPTION
This sends us down the path of deprecation for the signed & verified units functionality. Next up will be removal of functionality while providing nice failure messages for the existing flags/commands. We'll wait on that for some arbitrary amount of time to give people enough notice.
