### PR TITLE
engine: rename task ScheduleJob -> AttemptScheduleJob

### DIFF
--- a/engine/dumb_reconciler.go
+++ b/engine/dumb_reconciler.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	taskTypeOfferJob      = "OfferJob"
-	taskTypeResolveOffer  = "ResolveOffer"
-	taskTypeUnscheduleJob = "UnscheduleJob"
-	taskTypeScheduleJob   = "ScheduleJob"
+	taskTypeOfferJob           = "OfferJob"
+	taskTypeResolveOffer       = "ResolveOffer"
+	taskTypeUnscheduleJob      = "UnscheduleJob"
+	taskTypeAttemptScheduleJob = "AttemptScheduleJob"
 )
 
 type task struct {
@@ -98,7 +98,7 @@ func calculateClusterTasks(taskchan chan *task, clust *clusterState) {
 			continue
 		}
 
-		taskchan <- newTask(taskTypeScheduleJob, reason, j)
+		taskchan <- newTask(taskTypeAttemptScheduleJob, reason, j)
 		clust.forgetOffer(j.Name)
 	}
 
@@ -118,7 +118,7 @@ func doTask(t *task, e *Engine) (err error) {
 		err = e.resolveJobOffer(t.Job.Name)
 	case taskTypeUnscheduleJob:
 		err = e.unscheduleJob(t.Job.Name, t.Job.TargetMachineID)
-	case taskTypeScheduleJob:
+	case taskTypeAttemptScheduleJob:
 		if e.attemptScheduleJob(t.Job.Name) {
 			err = e.resolveJobOffer(t.Job.Name)
 		}

--- a/engine/dumb_reconciler_test.go
+++ b/engine/dumb_reconciler_test.go
@@ -244,7 +244,7 @@ func TestCalculateClusterTasks(t *testing.T) {
 			),
 			tasks: []*task{
 				&task{
-					Type:   taskTypeScheduleJob,
+					Type:   taskTypeAttemptScheduleJob,
 					Reason: "target state launched and Job not scheduled",
 					Job: &job.Job{
 						Name:        "foo.service",


### PR DESCRIPTION
The ScheduleJob task can be completed many times before
a given Job is actually scheduled to an Agent. This is
incredibly confusing to see in the logs. Renaming it to
AttemptScheduleJob hopefully clears this up a bit.
