### PR TITLE
registry: update job when migrating legacy payload

### DIFF
--- a/registry/offer.go
+++ b/registry/offer.go
@@ -52,8 +52,8 @@ func (r *EtcdRegistry) getJobOfferFromJSON(val string) *job.JobOffer {
 		return nil
 	}
 
-	j := r.getJobFromModel(jom.Job)
-	if j == nil {
+	j, err := r.Job(jom.Job.Name)
+	if j == nil || err != nil {
 		return nil
 	}
 


### PR DESCRIPTION
In order to drop the legacy payload code, we need to update the job models stored in etcd with the hash of the new units. This is the last step before we can drop legacy payload support altogether.
