### PR TITLE
agent: Support globs for X-ConditionMachineOf options

### DIFF
--- a/agent/reconcile_test.go
+++ b/agent/reconcile_test.go
@@ -99,6 +99,17 @@ func TestAbleToRun(t *testing.T) {
 			want:   true,
 		},
 
+		{
+			dState: &agentState{
+				jobs: map[string]*job.Job{
+					"ping.pong.service": &job.Job{Name: "ping.pong.service"},
+				},
+			},
+			mState: &machine.MachineState{ID: "123"},
+			job:    newTestJobWithXFleetValues(t, "X-ConditionMachineOf=ping.*.service"),
+			want:   true,
+		},
+
 		// multiple peers scheduled locally
 		{
 			dState: &agentState{

--- a/agent/state.go
+++ b/agent/state.go
@@ -16,8 +16,13 @@ func newAgentState() *agentState {
 	return &agentState{jobs: make(map[string]*job.Job)}
 }
 
-func (as *agentState) jobScheduled(jName string) bool {
-	return as.jobs[jName] != nil
+func (as *agentState) jobScheduled(pJobName string) bool {
+	for jName, _ := range as.jobs {
+		if globMatches(pJobName, jName) {
+			return true
+		}
+	}
+	return false
 }
 
 // hasConflict determines whether there are any known conflicts with the given Job


### PR DESCRIPTION
Treat peer job name conditions as standard unix globs when attempting to
schedule jobs. Changes the X-ConditionMachineOf option matching to
behave the same as an X-Conflicts option.
