### PR TITLE
api: s/machine/machineID/

### DIFF
--- a/Documentation/api-v1-alpha.md
+++ b/Documentation/api-v1-alpha.md
@@ -82,7 +82,7 @@ Content-Length: 80
 - **options**: list of UnitOption entities
 - **desiredState**: state the user wishes the Unit to be in ("inactive", "loaded", or "launched")
 - **currentState**: (readonly) state the Unit is currently in (same possible values as desiredState)
-- **machine**: ID of machine to which the Unit is scheduled
+- **machineID**: ID of machine to which the Unit is scheduled
 
 A UnitOption represents a single option in a systemd unit file.
 

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -623,11 +623,11 @@ func assertUnitState(name string, js job.JobState, out io.Writer) (ret bool) {
 	ret = true
 	msg := fmt.Sprintf("Unit %s %s", name, u.CurrentState)
 
-	if u.Machine == "" {
+	if u.MachineID == "" {
 		return
 	}
 
-	ms := cachedMachineState(u.Machine)
+	ms := cachedMachineState(u.MachineID)
 	if ms != nil {
 		msg = fmt.Sprintf("%s on %s", msg, machineFullLegend(*ms, false))
 	}

--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -56,5 +56,5 @@ func runJournal(args []string) (exit int) {
 		command += " -f"
 	}
 
-	return runCommand(command, u.Machine)
+	return runCommand(command, u.MachineID)
 }

--- a/fleetctl/list_unit_files.go
+++ b/fleetctl/list_unit_files.go
@@ -34,12 +34,12 @@ var (
 			return u.DesiredState
 		},
 		"tmachine": func(u schema.Unit, full bool) string {
-			if u.Machine == "" {
+			if u.MachineID == "" {
 				return "-"
 			}
-			ms := cachedMachineState(u.Machine)
+			ms := cachedMachineState(u.MachineID)
 			if ms == nil {
-				ms = &machine.MachineState{ID: u.Machine}
+				ms = &machine.MachineState{ID: u.MachineID}
 			}
 
 			return machineFullLegend(*ms, full)

--- a/fleetctl/list_unit_files_test.go
+++ b/fleetctl/list_unit_files_test.go
@@ -47,11 +47,11 @@ func TestListUnitFilesFieldsToStrings(t *testing.T) {
 	// machineStates must be initialized since cAPI is not set
 	machineStates = map[string]*machine.MachineState{}
 
-	u.Machine = "some-id"
+	u.MachineID = "some-id"
 	ms := listUnitFilesFields["tmachine"](u, true)
 	assertEqual(t, "machine", "some-id", ms)
 
-	u.Machine = "other-id"
+	u.MachineID = "other-id"
 	machineStates = map[string]*machine.MachineState{
 		"other-id": &machine.MachineState{
 			ID:       "other-id",

--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -171,7 +171,7 @@ func findAddressInRunningUnits(name string) (string, bool) {
 	if u == nil {
 		return "", false
 	}
-	m := cachedMachineState(u.Machine)
+	m := cachedMachineState(u.MachineID)
 	if m != nil && m.PublicIP != "" {
 		return m.PublicIP, true
 	}

--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -54,5 +54,5 @@ func printUnitStatus(name string) int {
 	}
 
 	cmd := fmt.Sprintf("systemctl status -l %s", name)
-	return runCommand(cmd, u.Machine)
+	return runCommand(cmd, u.MachineID)
 }

--- a/schema/mapper.go
+++ b/schema/mapper.go
@@ -50,7 +50,7 @@ func MapUnitToSchemaUnit(u *job.Unit, su *job.ScheduledUnit) *Unit {
 	}
 
 	if su != nil {
-		s.Machine = su.TargetMachineID
+		s.MachineID = su.TargetMachineID
 		if su.State != nil {
 			s.CurrentState = string(*su.State)
 		}
@@ -147,7 +147,7 @@ func MapSchemaUnitToScheduledUnit(entity *Unit) *job.ScheduledUnit {
 	return &job.ScheduledUnit{
 		Name:            entity.Name,
 		State:           &cs,
-		TargetMachineID: entity.Machine,
+		TargetMachineID: entity.MachineID,
 	}
 }
 

--- a/schema/v1-alpha-gen.go
+++ b/schema/v1-alpha-gen.go
@@ -108,7 +108,7 @@ type Unit struct {
 
 	DesiredState string `json:"desiredState,omitempty"`
 
-	Machine string `json:"machine,omitempty"`
+	MachineID string `json:"machineID,omitempty"`
 
 	Name string `json:"name,omitempty"`
 

--- a/schema/v1-alpha.json
+++ b/schema/v1-alpha.json
@@ -108,7 +108,7 @@
             "launched"
           ]
         },
-        "machine": {
+        "machineID": {
           "type": "string",
           "required": true
         }


### PR DESCRIPTION
Rather than having a `machine` field and a `machineID` field on different entities that represent the same value, standardize on `machineID`.
