### PR TITLE
registry: remove job and jobs from EtcdRegistry entirely

### DIFF
--- a/registry/job.go
+++ b/registry/job.go
@@ -99,7 +99,7 @@ func (r *EtcdRegistry) units() ([]job.Unit, error) {
 	for _, dir := range res.Node.Nodes {
 		u, err := r.dirToUnit(&dir)
 		if err != nil {
-			log.Errorf("Error distilling Unit from node: %v", err)
+			log.Errorf("Failed to parse Unit from etcd: %v", err)
 			continue
 		}
 		if u == nil {


### PR DESCRIPTION
Continuing the good work mostly done in #770, this removes the job/jobs calls
internally from the Registry and implements the new unit-specific functionality
as first-class functions
