### PR TITLE
agent/reconcile: remove State from desired state

### DIFF
--- a/agent/reconcile.go
+++ b/agent/reconcile.go
@@ -203,7 +203,6 @@ func (ar *AgentReconciler) desiredAgentState(units []job.Unit, sUnits []job.Sche
 			Unit:            u.Unit,
 			TargetState:     u.TargetState,
 			TargetMachineID: sUnit.TargetMachineID,
-			State:           sUnit.State,
 		}
 	}
 
@@ -289,11 +288,6 @@ func (ar *AgentReconciler) calculateTasksForJob(dState, cState *AgentState, jNam
 
 	if cJob.State == nil {
 		log.Errorf("Current state of Job(%s) unknown, unable to reconcile", jName)
-		return
-	}
-
-	if dJob.State == nil {
-		log.Errorf("Desired state of Job(%s) unknown, unable to reconcile", jName)
 		return
 	}
 


### PR DESCRIPTION
The State field is not required or useful when calculating the desired state
for what an agent is running; rather, we simply use the 
TargetState/DesiredState of a Unit.
