### PR TITLE
engine/agent: change reconciler ticker behaviours

### DIFF
--- a/agent/reconcile.go
+++ b/agent/reconcile.go
@@ -30,8 +30,6 @@ type AgentReconciler struct {
 // channel is closed. Run will also reconcile in reaction to calls to Trigger.
 // While a reconciliation is being attempted, calls to Trigger are ignored.
 func (ar *AgentReconciler) Run(a *Agent, stop chan bool) {
-	ticker := time.Tick(reconcileInterval)
-
 	reconcile := func() {
 		start := time.Now()
 		ar.Reconcile(a)
@@ -59,15 +57,18 @@ func (ar *AgentReconciler) Run(a *Agent, stop chan bool) {
 		}
 	}()
 
+	ticker := time.After(reconcileInterval)
 	for {
 		select {
 		case <-stop:
 			log.V(1).Info("AgentReconciler exiting due to stop signal")
 			return
 		case <-ticker:
+			ticker = time.After(reconcileInterval)
 			log.V(1).Info("AgentReconciler tick")
 			reconcile()
 		case <-trigger:
+			ticker = time.After(reconcileInterval)
 			log.V(1).Info("AgentReconciler triggered by rStream event")
 			reconcile()
 		}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -32,7 +32,6 @@ func New(reg registry.Registry, rStream registry.EventStream, mach machine.Machi
 
 func (e *Engine) Run(ival time.Duration, stop chan bool) {
 	leaseTTL := ival * 5
-	ticker := time.Tick(ival)
 	machID := e.machine.State().ID
 
 	reconcile := func() {
@@ -86,15 +85,18 @@ func (e *Engine) Run(ival time.Duration, stop chan bool) {
 		}
 	}()
 
+	ticker := time.After(ival)
 	for {
 		select {
 		case <-stop:
 			log.V(1).Info("Engine exiting due to stop signal")
 			return
 		case <-ticker:
+			ticker = time.After(ival)
 			log.V(1).Info("Engine tick")
 			reconcile()
 		case <-trigger:
+			ticker = time.After(ival)
 			log.V(1).Info("Engine reconcilation triggered by job state change")
 			reconcile()
 		}


### PR DESCRIPTION
The engine/agent currently reconcile every $reconcileInterval, irrespective of
whether any reconcilations occurred for other reasons
(i.e. were triggered) within that period.

A better semantic is for the tick to occur every $reconcileInterval
_after the previous reconciliation was triggered_. To accomplish this, reset
the ticker every time a reconciliation is about to commence.
