### PR TITLE
Fix fleetctl-inject-ssh.sh script

### DIFF
--- a/contrib/fleetctl-inject-ssh.sh
+++ b/contrib/fleetctl-inject-ssh.sh
@@ -10,6 +10,6 @@ shift 1
 
 pubkey=$(cat)
 
-for machine in $(fleetctl $@ list-machines --no-legend | awk '{ print $1;}'); do
+for machine in $(fleetctl $@ list-machines --no-legend --full | awk '{ print $1;}'); do
 	fleetctl $@ ssh $machine "echo '${pubkey}' | update-ssh-keys -a $name -n"
 done


### PR DESCRIPTION
The fleetctl-inject-ssh.sh script currently tries to identify machines with their truncated name, which now ends in '...'. Example: '6efa03e8...'.

When SSHing, the error 'Requested machine could not be found.' is returned. This PR fixes that error.
