### PR TITLE
global units: do some agent-level validation

### DIFF
--- a/agent/reconcile.go
+++ b/agent/reconcile.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coreos/fleet/job"
 	"github.com/coreos/fleet/log"
+	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/pkg"
 	"github.com/coreos/fleet/registry"
 )
@@ -126,6 +127,11 @@ func desiredAgentState(a *Agent, reg registry.Registry) (*AgentState, error) {
 
 	for _, u := range units {
 		u := u
+		md := u.RequiredTargetMetadata()
+		if u.IsGlobal() && !machine.HasMetadata(&ms, md) {
+			log.V(1).Infof("Agent unable to run global unit %s: missing required metadata", u.Name)
+			continue
+		}
 		if !u.IsGlobal() {
 			sUnit, ok := sUnitMap[u.Name]
 			if !ok || sUnit.TargetMachineID == "" || sUnit.TargetMachineID != ms.ID {

--- a/agent/state_test.go
+++ b/agent/state_test.go
@@ -9,6 +9,20 @@ import (
 	"github.com/coreos/fleet/unit"
 )
 
+func fleetUnit(t *testing.T, opts ...string) unit.UnitFile {
+	contents := "[X-Fleet]"
+	for _, v := range opts {
+		contents = fmt.Sprintf("%s\n%s", contents, v)
+	}
+
+	u, err := unit.NewUnitFile(contents)
+	if u == nil || err != nil {
+		t.Fatalf("Failed creating test unit: unit=%v, err=%v", u, err)
+	}
+
+	return *u
+}
+
 func TestHasConflicts(t *testing.T) {
 	tests := []struct {
 		cState   *AgentState


### PR DESCRIPTION
When launching global units, the agent should perform a minimal amount of validation to ensure it can actually run the unit. This should probably be nothing more than checking for metadata requirements. Specifically, any other kind of scheduling requirements (like Peers or Conflicts) are NOT supported.

Related: #659 
