### PR TITLE
Fix link to templates on fleet example page.

### DIFF
--- a/Documentation/examples/example-deployment.md
+++ b/Documentation/examples/example-deployment.md
@@ -41,7 +41,7 @@ CMD /bin/elb-presence
 
 With the docker images available over the public internet, systemd can simply run the containers. 
 
-The following unit files are [templates](https://github.com/coreos/fleet/Documentation/unit-files-and-scheduling#template-unit-files), which means they can be run multiple times by referencing them with full instance names. You can find these unit files in the [unit-examples](https://github.com/coreos/unit-examples/tree/master/blog-fleet-intro) repository. To save time, clone the repo on the machine from which you are controlling fleet.
+The following unit files are [templates](https://github.com/coreos/fleet/blob/master/Documentation/unit-files-and-scheduling.md#template-unit-files), which means they can be run multiple times by referencing them with full instance names. You can find these unit files in the [unit-examples](https://github.com/coreos/unit-examples/tree/master/blog-fleet-intro) repository. To save time, clone the repo on the machine from which you are controlling fleet.
 
 **`subgun-http@.service`**
 


### PR DESCRIPTION
In the `Service Files` section of https://coreos.com/docs/launching-containers/launching/fleet-example-deployment/ there is a link to templates which points at a Github link that 404's. This moves the link to the documentation site to what I believe is the intended location.
