### PR TITLE
Fix json api schema for UnitOption

### DIFF
--- a/schema/v1-alpha.json
+++ b/schema/v1-alpha.json
@@ -229,7 +229,7 @@
           }
         },
         "Delete": {
-          "id": "fleet.DesiredState.Delete",
+          "id": "fleet.Unit.Delete",
           "description": "Delete the referenced Unit object.",
           "httpMethod": "DELETE",
           "path": "units/{unitName}",


### PR DESCRIPTION
The api returns UnitOption values without a :value field.  This makes the json 
correspond to the actual API.
