### PR TITLE
machine: Ensure that the local IP address is global unicast

### DIFF
--- a/machine/coreos.go
+++ b/machine/coreos.go
@@ -132,9 +132,9 @@ func getLocalIP() string {
 
 	for _, addr := range addrs {
 		// Attempt to parse the address in CIDR notation
-		// and assert it is IPv4
+		// and assert that it is IPv4 and global unicast
 		ip, _, err := net.ParseCIDR(addr.String())
-		if err == nil && ip.To4() != nil {
+		if err == nil && ip.To4() != nil && ip.IsGlobalUnicast() {
 			return ip.String()
 		}
 	}


### PR DESCRIPTION
Advertising that address doesn't do much good if it isn't routable.
