### PR TITLE
agent: log task chain properly

### DIFF
--- a/agent/reconcile.go
+++ b/agent/reconcile.go
@@ -261,7 +261,7 @@ func (ar *AgentReconciler) calculateTaskChainForJob(dState *AgentState, cState u
 }
 
 func (ar *AgentReconciler) launchTaskChain(tc taskChain, a *Agent) {
-	log.V(1).Infof("AgentReconciler attempting task chain: %s", tc)
+	log.V(1).Infof("AgentReconciler attempting task chain %s", tc)
 	reschan, err := ar.tManager.Do(tc, a)
 	if err != nil {
 		log.Infof("AgentReconciler task chain failed: chain=%s err=%v", tc, err)

--- a/agent/task.go
+++ b/agent/task.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/coreos/fleet/job"
 	"github.com/coreos/fleet/pkg"
@@ -36,6 +37,14 @@ func newTaskChain(u *job.Unit, t ...task) taskChain {
 
 func (tc *taskChain) Add(t task) {
 	tc.tasks = append(tc.tasks, t)
+}
+
+func (tc taskChain) String() (out string) {
+	tasks := make([]string, len(tc.tasks))
+	for i, t := range tc.tasks {
+		tasks[i] = fmt.Sprintf("(%s, %q)", t.typ, t.reason)
+	}
+	return fmt.Sprintf("{%s %s}", tc.unit.Name, strings.Join(tasks, ", "))
 }
 
 type task struct {


### PR DESCRIPTION
Rather than this:

```
Sep 03 23:44:43 core-01 fleetd[1467]: INFO reconcile.go:267: AgentReconciler task chain failed: chain={%!s(*job.Unit=&{foo.service {map[] []} }) [{UnloadUnit purging agent}]} err=task already in flight
```

This PR logs this:

```
Sep 03 23:44:43 core-01 fleetd[1467]: INFO reconcile.go:267: AgentReconciler task chain failed: chain={foo.service (UnloadUnit, "purging agent")} err=task already in flight
```
