### PR TITLE
api: drop 'required' from schema properties

### DIFF
--- a/schema/v1-alpha-json.go
+++ b/schema/v1-alpha-json.go
@@ -32,15 +32,13 @@ const DiscoveryJSON = `{
       "type": "object",
       "properties": {
         "id": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "primaryIP": {
           "type": "string"
         },
         "metadata": {
           "type": "object",
-          "required": true,
           "properties": {},
           "additionalProperties": {
             "type": "string"
@@ -54,7 +52,6 @@ const DiscoveryJSON = `{
       "properties": {
         "machines": {
           "type": "array",
-          "required": true,
           "items": {
             "$ref": "Machine"
           }
@@ -69,16 +66,13 @@ const DiscoveryJSON = `{
       "type": "object",
       "properties": {
         "section": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "value": {
-          "type": "string",
-          "required": true
+          "type": "string"
         }
       }
     },
@@ -87,8 +81,7 @@ const DiscoveryJSON = `{
       "type": "object",
       "properties": {
         "name": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "options": {
           "type": "array",
@@ -98,7 +91,6 @@ const DiscoveryJSON = `{
         },
         "desiredState": {
           "type": "string",
-          "required": true,
           "enum": [
             "inactive",
             "loaded",
@@ -107,7 +99,6 @@ const DiscoveryJSON = `{
         },
         "currentState": {
           "type": "string",
-          "required": true,
           "enum": [
             "inactive",
             "loaded",
@@ -126,7 +117,6 @@ const DiscoveryJSON = `{
       "properties": {
         "units": {
           "type": "array",
-          "required": true,
           "items": {
             "$ref": "Unit"
           }
@@ -141,16 +131,13 @@ const DiscoveryJSON = `{
       "type": "object",
       "properties": {
         "name": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "hash": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "machineID": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "systemdLoadState": {
           "type": "string"
@@ -169,7 +156,6 @@ const DiscoveryJSON = `{
       "properties": {
         "states": {
           "type": "array",
-          "required": true,
           "items": {
             "$ref": "UnitState"
           }

--- a/schema/v1-alpha.json
+++ b/schema/v1-alpha.json
@@ -26,15 +26,13 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "primaryIP": {
           "type": "string"
         },
         "metadata": {
           "type": "object",
-          "required": true,
           "properties": {},
           "additionalProperties": {
             "type": "string"
@@ -48,7 +46,6 @@
       "properties": {
         "machines": {
           "type": "array",
-          "required": true,
           "items": {
             "$ref": "Machine"
           }
@@ -63,16 +60,13 @@
       "type": "object",
       "properties": {
         "section": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "value": {
-          "type": "string",
-          "required": true
+          "type": "string"
         }
       }
     },
@@ -81,8 +75,7 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "options": {
           "type": "array",
@@ -92,7 +85,6 @@
         },
         "desiredState": {
           "type": "string",
-          "required": true,
           "enum": [
             "inactive",
             "loaded",
@@ -101,7 +93,6 @@
         },
         "currentState": {
           "type": "string",
-          "required": true,
           "enum": [
             "inactive",
             "loaded",
@@ -120,7 +111,6 @@
       "properties": {
         "units": {
           "type": "array",
-          "required": true,
           "items": {
             "$ref": "Unit"
           }
@@ -135,16 +125,13 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "hash": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "machineID": {
-          "type": "string",
-          "required": true
+          "type": "string"
         },
         "systemdLoadState": {
           "type": "string"
@@ -163,7 +150,6 @@
       "properties": {
         "states": {
           "type": "array",
-          "required": true,
           "items": {
             "$ref": "UnitState"
           }


### PR DESCRIPTION
This treats the symptoms experienced by @hugoduncan in https://github.com/coreos/fleet/pull/846. This is not the best fix, but it gets us out of the woods for now.
