### PR TITLE
fleet: add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM deis/go:latest
+
+WORKDIR /go/src/github.com/coreos/fleet
+ENV PATH /go/src/github.com/coreos/fleet/bin:$PATH
+ADD . /go/src/github.com/coreos/fleet
+RUN ./build


### PR DESCRIPTION
This Dockerfile builds the fleet project from scratch, allowing
us to containerize the project with

```
$ docker build -t coreos/fleet .
```

You can interact with fleetctl via

```
$ docker run coreos/fleet fleetctl help
```

It probably doesn't make sense to containerize `fleet` itself since it relies on systemd but just throwing it out there.

Source code for `deis/go` can be found here: https://github.com/deis/dockerfiles/tree/master/go
