### PR TITLE
scripts: remove superfluous install in test script

### DIFF
--- a/test
+++ b/test
@@ -37,7 +37,6 @@ split=(${TEST// / })
 TEST=${split[@]/#/${REPO_PATH}/}
 
 echo "Running tests..."
-go test -i ${TEST}
 go test ${COVER} $@ ${TEST}
 
 echo "Checking gofmt..."


### PR DESCRIPTION
is there a reason I'm missing that we did this?
