### PR TITLE
Prevent users from using "{}" in template names

### DIFF
--- a/api/units.go
+++ b/api/units.go
@@ -71,7 +71,7 @@ func (ur *unitsResource) set(rw http.ResponseWriter, req *http.Request, item str
 		sendError(rw, http.StatusBadRequest, fmt.Errorf("name in URL %q differs from unit name in request body %q", item, su.Name))
 		return
 	}
-	if err := validateName(su.Name); err != nil {
+	if err := ValidateName(su.Name); err != nil {
 		sendError(rw, http.StatusBadRequest, err)
 		return
 	}
@@ -130,10 +130,10 @@ var validUnitTypes = pkg.NewUnsafeSet(
 	"scope",
 )
 
-// validateName ensures that a given unit name is valid; if not, an error is
+// ValidateName ensures that a given unit name is valid; if not, an error is
 // returned describing the first issue encountered.
 // systemd reference: `unit_name_is_valid` in `unit-name.c`
-func validateName(name string) error {
+func ValidateName(name string) error {
 	length := len(name)
 	if length == 0 {
 		return errors.New("unit name cannot be empty")

--- a/api/units_test.go
+++ b/api/units_test.go
@@ -657,7 +657,7 @@ func TestValidateName(t *testing.T) {
 		"@this.mount",
 	}
 	for _, name := range badTestCases {
-		if err := validateName(name); err == nil {
+		if err := ValidateName(name); err == nil {
 			t.Errorf("name %q: validation did not fail as expected!", name)
 		}
 	}
@@ -676,7 +676,7 @@ func TestValidateName(t *testing.T) {
 		fmt.Sprintf("%0"+strconv.Itoa(unitNameMax)+"s", ".service"),
 	}
 	for _, name := range goodTestCases {
-		if err := validateName(name); err != nil {
+		if err := ValidateName(name); err != nil {
 			t.Errorf("name %q: validation failed unexpectedly! err=%v", name, err)
 		}
 	}

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -424,6 +424,9 @@ func createUnit(name string, uf *unit.UnitFile) (*schema.Unit, error) {
 	// redundant with the check in api.unitsResource.set, but it is a
 	// workaround to implementing the same check in the RegistryClient. It
 	// will disappear once RegistryClient is deprecated.
+	if err := api.ValidateName(name); err != nil {
+		return nil, err
+	}
 	if err := api.ValidateOptions(u.Options); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I was experimenting with unit file templating and built a small tool to generate templates and then start services using {1,2,3} syntax. But accidentally somehow my shell escaped the {} making fleetctl to submit an actual unit named @{1,2,3}.service.

This made me have to go through all sorts of hidden keys and places to clean it up. In some places it actually  fleet took it as 1,2 and 3 but in some places not. Maybe there should be some checks for this?
