### PR TITLE
fleet: add build-docker script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ After you have machines configured (check `fleetctl list-machines`), get to work
 
 ### Building
 
-fleet must be built with Go 1.2 on a Linux machine, or in a [Go docker container](https://index.docker.io/u/miksago/ubuntu-go/). Simply run `./build` and then copy the binaries out of bin/ onto each of your machines. The tests can similarly be run by simply invoking `./test`.
+fleet must be built with Go 1.2+ on a Linux machine. Simply run `./build` and then copy the binaries out of bin/ onto each of your machines. The tests can similarly be run by simply invoking `./test`.
+
+If you're on a machine without Go 1.2+ but you have Docker installed, run `./build-docker` to compile the binaries instead.
 
 ## Project Details
 

--- a/build-docker
+++ b/build-docker
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+docker run -v $PWD:/opt/fleet google/golang:1.3.1 /bin/bash -c "cd /opt/fleet && ./build"


### PR DESCRIPTION
Allows the user to build fleet from inside a container.

pulled out from the conversation in #885
