### PR TITLE
fleetctl: support for arbitrary usernames

### DIFF
--- a/Documentation/using-the-client.md
+++ b/Documentation/using-the-client.md
@@ -32,6 +32,14 @@ One can also provide `--tunnel` through the environment variable `FLEETCTL_TUNNE
 When using `--tunnel` and `--endpoint` together, it is important to note that all etcd requests will be made through the SSH tunnel. 
 The address in the `--endpoint` flag must be routable from the server hosting the tunnel.
 
+If the external host requires a username other than `core`, the `--ssh-username` flag can be used to set an alternative username.
+
+    fleetctl --ssh-username=elroy list-units
+
+Or
+
+    FLEETCTL_SSH_USERNAME=elroy fleetctl list-units
+
 Be sure to install one of the [tagged releases](https://github.com/coreos/fleet/releases) of `fleetctl` that matches the version of fleet running on the CoreOS machine. 
 Find the version on the server with:
 

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -64,6 +64,7 @@ var (
 		StrictHostKeyChecking bool
 		Tunnel                string
 		RequestTimeout        float64
+		SSHUserName           string
 	}{}
 
 	// flags used by multiple commands
@@ -97,6 +98,7 @@ func init() {
 	globalFlagset.BoolVar(&globalFlags.StrictHostKeyChecking, "strict-host-key-checking", true, "Verify host keys presented by remote machines before initiating SSH connections.")
 	globalFlagset.StringVar(&globalFlags.Tunnel, "tunnel", "", "Establish an SSH tunnel through the provided address for communication with fleet and etcd.")
 	globalFlagset.Float64Var(&globalFlags.RequestTimeout, "request-timeout", 3.0, "Amount of time in seconds to allow a single request before considering it failed.")
+	globalFlagset.StringVar(&globalFlags.SSHUserName, "ssh-username", "core", "Username to use when connecting to CoreOS instance.")
 }
 
 type Command struct {
@@ -272,7 +274,7 @@ func getHTTPClient() (client.API, error) {
 	tunnelFunc := net.Dial
 	tun := getTunnelFlag()
 	if tun != "" {
-		sshClient, err := ssh.NewSSHClient("core", tun, getChecker(), false)
+		sshClient, err := ssh.NewSSHClient(globalFlags.SSHUserName, tun, getChecker(), false)
 		if err != nil {
 			return nil, fmt.Errorf("failed initializing SSH client: %v", err)
 		}
@@ -313,7 +315,7 @@ func getRegistryClient() (client.API, error) {
 	var dial func(string, string) (net.Conn, error)
 	tun := getTunnelFlag()
 	if tun != "" {
-		sshClient, err := ssh.NewSSHClient("core", tun, getChecker(), false)
+		sshClient, err := ssh.NewSSHClient(globalFlags.SSHUserName, tun, getChecker(), false)
 		if err != nil {
 			return nil, fmt.Errorf("failed initializing SSH client: %v", err)
 		}


### PR DESCRIPTION
Implements --ssh-username to allow fleetctl users to specify arbitrary
usernames on upstream servers.

Fixes #536
