### PR TITLE
api: Fix an incorrect status code; 406 -> 415

### DIFF
--- a/api/units.go
+++ b/api/units.go
@@ -53,7 +53,7 @@ func (ur *unitsResource) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 func (ur *unitsResource) set(rw http.ResponseWriter, req *http.Request, item string) {
 	if validateContentType(req) != nil {
-		sendError(rw, http.StatusNotAcceptable, errors.New("application/json is only supported Content-Type"))
+		sendError(rw, http.StatusUnsupportedMediaType, errors.New("application/json is only supported Content-Type"))
 		return
 	}
 


### PR DESCRIPTION
"406 Not Acceptable" is not proper because it is for a request whose
Accept header is not acceptable. Use "415 Unsupported Media Type"
instead.

See http://tools.ietf.org/html/rfc7231#section-6.5.6 for "406 Not
Acceptable" and http://tools.ietf.org/html/rfc7231#section-6.5.13 for
"415 Unsupported Media Type".

(I am very sorry that I couldn't test it. I made this patch while I'm reading your code by just curiosity as a web programmer because @jonboulle told me you have web api. :smiley: Feel free to merge it or not)
