### PR TITLE
call "daemon-reload" only when necessary

### DIFF
--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -70,9 +70,6 @@ func (m *systemdUnitManager) Unload(name string) {
 	defer m.mutex.Unlock()
 	delete(m.hashes, name)
 	m.removeUnit(name)
-	if m.unitRequiresDaemonReload(name) {
-		m.daemonReload()
-	}
 }
 
 // TriggerStart asynchronously starts the unit identified by the given name.


### PR DESCRIPTION
Turns out invoking daemon-reload on systemd is _really_ expensive. Work out how we can minimize calls to what is absolutely necessary.
