### PR TITLE
fleet: run tests in a docker container

### DIFF
--- a/test-docker
+++ b/test-docker
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+docker run -v $PWD:/opt/fleet google/golang:1.3.1 /bin/bash -c "cd /opt/fleet && ./test"


### PR DESCRIPTION
For parity with build-docker.  Requires #947 to be merged.
