### PR TITLE
fleetctl: unload should print to stdout

### DIFF
--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -47,7 +47,7 @@ func runUnloadUnit(args []string) (exit int) {
 	}
 
 	if !sharedFlags.NoBlock {
-		errchan := waitForUnitStates(wait, job.JobStateInactive, sharedFlags.BlockAttempts, os.Stderr)
+		errchan := waitForUnitStates(wait, job.JobStateInactive, sharedFlags.BlockAttempts, os.Stdout)
 		for err := range errchan {
 			stderr("Error waiting for units: %v", err)
 			exit = 1


### PR DESCRIPTION
unload is currently inconsistent with all other commands that use
waitForUnitStates; seems this was introduced by accident.
