### PR TITLE
api: s/discovery.json/discovery/

### DIFF
--- a/Documentation/api-v1.md
+++ b/Documentation/api-v1.md
@@ -207,7 +207,7 @@ A successful response will contain a page of zero or more Machine entities.
 ## Capability Discovery
 
 The v1 fleet API is described by a [discovery document][disco]. Users should generate their client bindings from this document using the appropriate language generator.
-This document is available in the [fleet source][schema] and served directly from the API itself, at the `/discovery.json` endpoint.
+This document is available in the [fleet source][schema] and served directly from the API itself, at the `/discovery` endpoint.
 Note that this discovery document intentionally ships with an unusable `rootUrl`; clients *must* initialize this as appropriate.
 
 An extremely simplified example client can be found [here][example].

--- a/Documentation/examples/api.py
+++ b/Documentation/examples/api.py
@@ -22,7 +22,7 @@ import pprint
 
 # Step 1: Fetch Discovery document.
 ROOT_URL = "http://localhost:8080/"
-DISCOVERY_URI = ROOT_URL + "fleet/v1/discovery.json"
+DISCOVERY_URI = ROOT_URL + "fleet/v1/discovery"
 h = httplib2.Http()
 resp, content = h.request(DISCOVERY_URI)
 discovery = json.loads(content)

--- a/api/discovery.go
+++ b/api/discovery.go
@@ -26,7 +26,7 @@ import (
 )
 
 func wireUpDiscoveryResource(mux *http.ServeMux, prefix string) {
-	base := path.Join(prefix, "discovery.json")
+	base := path.Join(prefix, "discovery")
 	dr := discoveryResource{}
 	mux.Handle(base, &dr)
 }

--- a/api/discovery_test.go
+++ b/api/discovery_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestDiscoveryJson(t *testing.T) {
-	url := "http://example.com/discovery.json"
+	url := "http://example.com/discovery"
 	for _, verb := range []string{"POST", "PUT", "DELETE"} {
 		res := &discoveryResource{}
 		rw := httptest.NewRecorder()


### PR DESCRIPTION
The google discovery service hosts discovery documents at paths that look like so: `https://www.googleapis.com/discovery/v1/apis/<api-name>/v1/rest`. We chose `discovery` over `rest`, but I cannot live with the unnecessary `.json` on the end of our resource. Since we aren't encouraged to keep it by the googs, I would like to see it removed.
