### PR TITLE
cli-option: Add command line option for ssh-timeout

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -83,6 +83,7 @@ var (
 		StrictHostKeyChecking bool
 		Tunnel                string
 		RequestTimeout        float64
+		SSHTimeout            float64
 	}{}
 
 	// flags used by multiple commands
@@ -119,6 +120,7 @@ func init() {
 	globalFlagset.BoolVar(&globalFlags.StrictHostKeyChecking, "strict-host-key-checking", true, "Verify host keys presented by remote machines before initiating SSH connections.")
 	globalFlagset.StringVar(&globalFlags.Tunnel, "tunnel", "", "Establish an SSH tunnel through the provided address for communication with fleet and etcd.")
 	globalFlagset.Float64Var(&globalFlags.RequestTimeout, "request-timeout", 3.0, "Amount of time in seconds to allow a single request before considering it failed.")
+	globalFlagset.Float64Var(&globalFlags.SSHTimeout, "ssh-timeout", 10.0, "Amount of time in seconds to allow for SSH connection initialization before failing.")
 }
 
 type Command struct {
@@ -295,9 +297,10 @@ func getHTTPClient() (client.API, error) {
 	}
 
 	tunnelFunc := net.Dial
+	sshTimeout := time.Duration(globalFlags.SSHTimeout*1000) * time.Millisecond
 	tun := getTunnelFlag()
 	if tun != "" {
-		sshClient, err := ssh.NewSSHClient("core", tun, getChecker(), false)
+		sshClient, err := ssh.NewSSHClient("core", tun, getChecker(), false, sshTimeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed initializing SSH client: %v", err)
 		}
@@ -349,9 +352,10 @@ func getHTTPClient() (client.API, error) {
 
 func getRegistryClient() (client.API, error) {
 	var dial func(string, string) (net.Conn, error)
+	sshTimeout := time.Duration(globalFlags.SSHTimeout*1000) * time.Millisecond
 	tun := getTunnelFlag()
 	if tun != "" {
-		sshClient, err := ssh.NewSSHClient("core", tun, getChecker(), false)
+		sshClient, err := ssh.NewSSHClient("core", tun, getChecker(), false, sshTimeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed initializing SSH client: %v", err)
 		}

--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/pkg"
@@ -105,10 +106,11 @@ func runSSH(args []string) (exit int) {
 	args = pkg.TrimToDashes(args)
 
 	var sshClient *ssh.SSHForwardingClient
+	timeout := time.Duration(globalFlags.SSHTimeout*1000) * time.Millisecond
 	if tun := getTunnelFlag(); tun != "" {
-		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr, getChecker(), flagSSHAgentForwarding)
+		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr, getChecker(), flagSSHAgentForwarding, timeout)
 	} else {
-		sshClient, err = ssh.NewSSHClient("core", addr, getChecker(), flagSSHAgentForwarding)
+		sshClient, err = ssh.NewSSHClient("core", addr, getChecker(), flagSSHAgentForwarding, timeout)
 	}
 	if err != nil {
 		stderr("Failed building SSH client: %v", err)
@@ -248,10 +250,11 @@ func runLocalCommand(cmd string) (error, int) {
 // any error encountered and the exit status of the command
 func runRemoteCommand(cmd string, addr string) (err error, exit int) {
 	var sshClient *ssh.SSHForwardingClient
+	timeout := time.Duration(globalFlags.SSHTimeout*1000) * time.Millisecond
 	if tun := getTunnelFlag(); tun != "" {
-		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr, getChecker(), false)
+		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr, getChecker(), false, timeout)
 	} else {
-		sshClient, err = ssh.NewSSHClient("core", addr, getChecker(), false)
+		sshClient, err = ssh.NewSSHClient("core", addr, getChecker(), false, timeout)
 	}
 	if err != nil {
 		return err, -1


### PR DESCRIPTION
This allows for the timeout duration of an
ssh connection initiation to be set using --ssh-timeout.

Fixes #1009
