### PR TITLE
Fix loading templates

### DIFF
--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -246,7 +246,8 @@ func (m *systemdUnitManager) GetUnitStates(filter pkg.Set) (map[string]*unit.Uni
 
 		us, err := m.getUnitState(name)
 		if err != nil {
-			return nil, err
+			log.Errorf("Failed fetching current unit state for %s: %v", name, err)
+			continue
 		}
 		if h, ok := m.hashes[name]; ok {
 			us.UnitHash = h.String()

--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -244,10 +244,17 @@ func (m *systemdUnitManager) GetUnitStates(filter pkg.Set) (map[string]*unit.Uni
 			continue
 		}
 
-		us, err := m.getUnitState(name)
-		if err != nil {
-			log.Errorf("Failed fetching current unit state for %s: %v", name, err)
-			continue
+		var us *unit.UnitState
+		nu := unit.NewUnitNameInfo(name)
+		if nu.IsTemplate() {
+			// instances have no state
+			us = &unit.UnitState{}
+		} else {
+			us, err = m.getUnitState(name)
+			if err != nil {
+				log.Errorf("Failed fetching current unit state for %s: %v", name, err)
+				continue
+			}
 		}
 		if h, ok := m.hashes[name]; ok {
 			us.UnitHash = h.String()

--- a/unit/unit.go
+++ b/unit/unit.go
@@ -204,6 +204,12 @@ type UnitNameInfo struct {
 	Instance string // Instance name (e.g. bar)
 }
 
+// IsTemplate returns a boolean indicating whether the UnitNameInfo appears to be
+// a Template unit
+func (nu UnitNameInfo) IsTemplate() bool {
+	return len(nu.Template) > 0 && !nu.IsInstance()
+}
+
 // IsInstance returns a boolean indicating whether the UnitNameInfo appears to be
 // an Instance of a Template unit
 func (nu UnitNameInfo) IsInstance() bool {


### PR DESCRIPTION
This is a PR to fix #978

This contains 2 separate commits.
The first commit is to prevent fleet from hanging when getting the state of a unit fails. Previously every time `GetUnitStates` was called, it would return with an error when any of the units was invalid. So a single bad unit would prevent processing of other valid units.
The change simply makes it log a message and then skip that unit. Note however that the `fleetctl load` command which caused the issue will still hang as it perpetually waits for the unit to load. One option to fix this might be to create a fake `UnitState{LoadState: "Failed"}` if `getUnitState()` returns error.

The other commit is a direct fix for doing `fleetctl load foo@.service`. It causes `GetUnitStates()` to not attempt to get the state for a template unit.