### PR TITLE
compile fleetctl as a static binary

### DIFF
--- a/build
+++ b/build
@@ -21,4 +21,4 @@ else
 fi
 
 echo "Building fleetctl..."
-go install ${REPO_PATH}/fleetctl
+CGO_ENABLED=0 go install -a -ldflags '-s' ${REPO_PATH}/fleetctl


### PR DESCRIPTION
This allows it to be much more portable. It can be used in busybox
containers now, for example.
