### PR TITLE
fleetctl: new flag --ssh-timeout

### DIFF
--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/pkg"
@@ -105,10 +106,11 @@ func runSSH(args []string) (exit int) {
 	args = pkg.TrimToDashes(args)
 
 	var sshClient *ssh.SSHForwardingClient
+	timeout := time.Duration(globalFlags.SSHTimeout*1000) * time.Millisecond
 	if tun := getTunnelFlag(); tun != "" {
-		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr, getChecker(), flagSSHAgentForwarding)
+		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr, getChecker(), flagSSHAgentForwarding, timeout)
 	} else {
-		sshClient, err = ssh.NewSSHClient("core", addr, getChecker(), flagSSHAgentForwarding)
+		sshClient, err = ssh.NewSSHClient("core", addr, getChecker(), flagSSHAgentForwarding, timeout)
 	}
 	if err != nil {
 		stderr("Failed building SSH client: %v", err)
@@ -248,10 +250,11 @@ func runLocalCommand(cmd string) (error, int) {
 // any error encountered and the exit status of the command
 func runRemoteCommand(cmd string, addr string) (err error, exit int) {
 	var sshClient *ssh.SSHForwardingClient
+	timeout := time.Duration(globalFlags.SSHTimeout*1000) * time.Millisecond
 	if tun := getTunnelFlag(); tun != "" {
-		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr, getChecker(), false)
+		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr, getChecker(), false, timeout)
 	} else {
-		sshClient, err = ssh.NewSSHClient("core", addr, getChecker(), false)
+		sshClient, err = ssh.NewSSHClient("core", addr, getChecker(), false, timeout)
 	}
 	if err != nil {
 		return err, -1


### PR DESCRIPTION
This flag allows for configuration of the timeout
used during ssh connection initialization.

Fixes #1009
