### PR TITLE
docs: remove confusing version note

### DIFF
--- a/Documentation/unit-files-and-scheduling.md
+++ b/Documentation/unit-files-and-scheduling.md
@@ -51,7 +51,7 @@ Conflicts=monitor*
 
 ## Template unit files
 
-fleet provides support for using systemd's [instances](systemd instances) feature to dynamically create _instance_ units from a common _template_ unit file. This allows you to have a single unit configuration and easily and dynamically create new instances of the unit as necessary.
+fleet provides support for using systemd's [instances][systemd instances] feature to dynamically create _instance_ units from a common _template_ unit file. This allows you to have a single unit configuration and easily and dynamically create new instances of the unit as necessary.
 
 To use instance units, simply create a unit file whose name matches the `<name>@.<suffix>` format - for example, `hello@.service` - and submit it to fleet. You can then instantiate units by creating new units that match the instance pattern `<name>@<instance>.<suffix>` - in this case, for example, `hello@world.service` or `hello@1.service` - and fleet will automatically utilize the relevant template unit. For a detailed example, see the [example deployment].
 


### PR DESCRIPTION
Per an "I Wish", this version note is outdated, confusing and overlaps with etcd 0.5. I think it makes sense to remove it.

```
I wish this page explained what "New in version 0.5.0" meant. Which release channel does that correspond to? https://coreos.com/releases/ doesn't mention this version.
```
