### PR TITLE
log: fix impl of Warning

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -104,7 +104,7 @@ func Errorf(format string, v ...interface{}) {
 	logger.Output(calldepth, header("ERROR", fmt.Sprintf(format, v...)))
 }
 
-func Warning(format string, v ...interface{}) {
+func Warning(v ...interface{}) {
 	logger.Output(calldepth, header("WARN", fmt.Sprint(v...)))
 }
 


### PR DESCRIPTION
Bad copy/paste when this was originally implemented.
