### PR TITLE
panic due to double-close of channel

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -57,11 +57,11 @@ func (a *Agent) MarshalJSON() ([]byte, error) {
 
 // Heartbeat updates the Registry periodically with an acknowledgement of the
 // Jobs this Agent is expected to be running.
-func (a *Agent) Heartbeat(stop chan bool) {
+func (a *Agent) Heartbeat(stop <-chan struct{}) {
 	a.heartbeatJobs(a.ttl, stop)
 }
 
-func (a *Agent) heartbeatJobs(ttl time.Duration, stop chan bool) {
+func (a *Agent) heartbeatJobs(ttl time.Duration, stop <-chan struct{}) {
 	heartbeat := func() {
 		machID := a.Machine.State().ID
 		launched := a.cache.launchedJobs()

--- a/agent/reconcile.go
+++ b/agent/reconcile.go
@@ -48,7 +48,7 @@ type AgentReconciler struct {
 // Run periodically attempts to reconcile the provided Agent until the stop
 // channel is closed. Run will also reconcile in reaction to events on the
 // AgentReconciler's rStream.
-func (ar *AgentReconciler) Run(a *Agent, stop chan bool) {
+func (ar *AgentReconciler) Run(a *Agent, stop <-chan struct{}) {
 	reconcile := func() {
 		start := time.Now()
 		ar.Reconcile(a)

--- a/agent/unit_state.go
+++ b/agent/unit_state.go
@@ -70,7 +70,7 @@ type UnitStatePublisher struct {
 // Run caches all of the heartbeat objects from the provided channel, publishing
 // them to the Registry every 5s. Heartbeat objects are also published as they
 // are received on the channel.
-func (p *UnitStatePublisher) Run(beatchan <-chan *unit.UnitStateHeartbeat, stop chan bool) {
+func (p *UnitStatePublisher) Run(beatchan <-chan *unit.UnitStateHeartbeat, stop <-chan struct{}) {
 	go func() {
 		for {
 			select {

--- a/agent/unit_state_test.go
+++ b/agent/unit_state_test.go
@@ -319,7 +319,7 @@ func TestUnitStatePublisherRunTiming(t *testing.T) {
 	}
 
 	bc := make(chan *unit.UnitStateHeartbeat)
-	sc := make(chan bool)
+	sc := make(chan struct{})
 	go func() {
 		usp.Run(bc, sc)
 	}()
@@ -465,7 +465,7 @@ func TestUnitStatePublisherRunQueuing(t *testing.T) {
 		clock:           clockwork.NewFakeClock(),
 	}
 	bc := make(chan *unit.UnitStateHeartbeat)
-	sc := make(chan bool)
+	sc := make(chan struct{})
 	go func() {
 		usp.Run(bc, sc)
 	}()
@@ -595,7 +595,7 @@ func TestUnitStatePublisherRunWithDelays(t *testing.T) {
 	}
 
 	bc := make(chan *unit.UnitStateHeartbeat)
-	sc := make(chan bool)
+	sc := make(chan struct{})
 
 	wgs.Add(numPublishers)
 	wgf.Add(numPublishers)

--- a/api/server.go
+++ b/api/server.go
@@ -57,7 +57,7 @@ func (s *Server) Serve() {
 // Available switches the Server's HTTP handler from a generic 503 Unavailable
 // response to the actual API. Once the provided channel is closed, the API is
 // torn back down and 503 responses are served.
-func (s *Server) Available(stop chan bool) {
+func (s *Server) Available(stop <-chan struct{}) {
 	s.cur = s.api
 	<-stop
 	s.cur = unavailable

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -58,7 +58,7 @@ func New(reg *registry.EtcdRegistry, lManager lease.Manager, rStream pkg.EventSt
 	}
 }
 
-func (e *Engine) Run(ival time.Duration, stop chan bool) {
+func (e *Engine) Run(ival time.Duration, stop <-chan struct{}) {
 	leaseTTL := ival * 5
 	machID := e.machine.State().ID
 

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -106,7 +106,7 @@ func main() {
 		}
 
 		log.Infof("Restarting server components")
-		srv.Stop()
+		srv.Kill()
 
 		srv, err = server.New(*cfg)
 		if err != nil {
@@ -121,7 +121,7 @@ func main() {
 		srvMutex.Lock()
 		defer srvMutex.Unlock()
 
-		srv.Stop()
+		srv.Kill()
 		srv.Purge()
 		os.Exit(0)
 	}

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"github.com/coreos/fleet/Godeps/_workspace/src/github.com/rakyll/globalconf"
@@ -91,8 +92,13 @@ func main() {
 	}
 	srv.Run()
 
+	srvMutex := sync.Mutex{}
+
 	reconfigure := func() {
 		log.Infof("Reloading configuration from %s", *cfgPath)
+
+		srvMutex.Lock()
+		defer srvMutex.Unlock()
 
 		cfg, err := getConfig(cfgset, *cfgPath)
 		if err != nil {
@@ -111,6 +117,10 @@ func main() {
 
 	shutdown := func() {
 		log.Infof("Gracefully shutting down")
+
+		srvMutex.Lock()
+		defer srvMutex.Unlock()
+
 		srv.Stop()
 		srv.Purge()
 		os.Exit(0)
@@ -118,6 +128,9 @@ func main() {
 
 	writeState := func() {
 		log.Infof("Dumping server state")
+
+		srvMutex.Lock()
+		defer srvMutex.Unlock()
 
 		encoded, err := json.Marshal(srv)
 		if err != nil {

--- a/machine/coreos.go
+++ b/machine/coreos.go
@@ -84,7 +84,7 @@ func (m *CoreOSMachine) Refresh() {
 
 // PeriodicRefresh updates the current state of the CoreOSMachine at the
 // interval indicated. Operation ceases when the provided channel is closed.
-func (m *CoreOSMachine) PeriodicRefresh(interval time.Duration, stop chan bool) {
+func (m *CoreOSMachine) PeriodicRefresh(interval time.Duration, stop <-chan struct{}) {
 	ticker := time.NewTicker(interval)
 	for {
 		select {

--- a/pkg/reconcile.go
+++ b/pkg/reconcile.go
@@ -32,7 +32,7 @@ type EventStream interface {
 }
 
 type PeriodicReconciler interface {
-	Run(stop chan bool)
+	Run(stop <-chan struct{})
 }
 
 // NewPeriodicReconciler creates a PeriodicReconciler that will run recFunc at least every
@@ -53,7 +53,7 @@ type reconciler struct {
 	clock   clockwork.Clock
 }
 
-func (r *reconciler) Run(stop chan bool) {
+func (r *reconciler) Run(stop <-chan struct{}) {
 	trigger := make(chan struct{})
 	go func() {
 		abort := make(chan struct{})

--- a/pkg/reconcile_test.go
+++ b/pkg/reconcile_test.go
@@ -54,11 +54,11 @@ func TestPeriodicReconcilerRun(t *testing.T) {
 		clock:   fclock,
 	}
 	// launch the PeriodicReconciler in the background
-	prDone := make(chan bool)
-	stop := make(chan bool)
+	prDone := make(chan struct{})
+	stop := make(chan struct{})
 	go func() {
 		pr.Run(stop)
-		prDone <- true
+		close(prDone)
 	}()
 	// reconcile should have occurred once at start-up
 	select {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -37,7 +37,7 @@ type Monitor struct {
 // beats successfully. If the heartbeat check fails for any
 // reason, an error is returned. If the supplied channel is
 // closed, Monitor returns ErrShutdown.
-func (m *Monitor) Monitor(hrt heart.Heart, sdc <-chan bool) error {
+func (m *Monitor) Monitor(hrt heart.Heart, sdc <-chan struct{}) error {
 	ticker := time.Tick(m.ival)
 	for {
 		select {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -22,8 +22,6 @@ import (
 	"github.com/coreos/fleet/log"
 )
 
-var ErrShutdown = errors.New("monitor told to shut down")
-
 func NewMonitor(ttl time.Duration) *Monitor {
 	return &Monitor{ttl, ttl / 2}
 }
@@ -36,16 +34,16 @@ type Monitor struct {
 // Monitor periodically checks the given Heart to make sure it
 // beats successfully. If the heartbeat check fails for any
 // reason, an error is returned. If the supplied channel is
-// closed, Monitor returns ErrShutdown.
-func (m *Monitor) Monitor(hrt heart.Heart, sdc <-chan struct{}) error {
+// closed, Monitor returns true and a nil error.
+func (m *Monitor) Monitor(hrt heart.Heart, sdc <-chan struct{}) (bool, error) {
 	ticker := time.Tick(m.ival)
 	for {
 		select {
 		case <-sdc:
-			return ErrShutdown
+			return true, nil
 		case <-ticker:
 			if _, err := check(hrt, m.TTL); err != nil {
-				return err
+				return false, err
 			}
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -137,6 +137,7 @@ func New(cfg config.Config) (*Server, error) {
 		hrt:         hrt,
 		mon:         mon,
 		api:         apiServer,
+		killc:       make(chan struct{}),
 		stopc:       nil,
 		engineReconcileInterval: eIval,
 	}
@@ -189,6 +190,7 @@ func (s *Server) Run() {
 		func() { s.usGen.Run(beatc, s.stopc) },
 		func() { s.usPub.Run(beatc, s.stopc) },
 	} {
+		f := f
 		s.wg.Add(1)
 		go func() {
 			f()

--- a/server/server.go
+++ b/server/server.go
@@ -204,15 +204,11 @@ func (s *Server) Run() {
 // all components have finished shutting down or a timeout occurs; if this
 // happens, the Server will not automatically be restarted.
 func (s *Server) Supervise() {
-	err := s.mon.Monitor(s.hrt, s.killc)
-	switch {
-	case err == ErrShutdown:
-		log.Infof("Server monitor triggered: %v", err)
-		err = nil
-	case err != nil:
+	sd, err := s.mon.Monitor(s.hrt, s.killc)
+	if sd {
+		log.Infof("Server monitor triggered: told to shut down")
+	} else {
 		log.Errorf("Server monitor triggered: %v", err)
-	default:
-		panic("unexpected nil err from Monitor")
 	}
 	close(s.stopc)
 	done := make(chan struct{})
@@ -224,9 +220,9 @@ func (s *Server) Supervise() {
 	case <-done:
 	case <-time.After(shutdownTimeout):
 		log.Errorf("Timed out waiting for server to shut down")
-		err = nil
+		sd = true
 	}
-	if err != nil {
+	if !sd {
 		log.Infof("Restarting server")
 		s.Run()
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -217,7 +217,7 @@ func (s *Server) Supervise() {
 	close(s.stopc)
 	done := make(chan struct{})
 	go func() {
-		s.wg.Done()
+		s.wg.Wait()
 		close(done)
 	}()
 	select {

--- a/server/server.go
+++ b/server/server.go
@@ -228,8 +228,8 @@ func (s *Server) Supervise() {
 	}
 }
 
-// Stop is used to gracefully terminate the server by triggering the Monitor to shut down
-func (s *Server) Stop() {
+// Kill is used to gracefully terminate the server by triggering the Monitor to shut down
+func (s *Server) Kill() {
 	close(s.killc)
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -60,8 +60,8 @@ type Server struct {
 
 	engineReconcileInterval time.Duration
 
-	killc chan bool      // used to signal monitor to shutdown server
-	stopc chan bool      // used to terminate all other goroutines
+	killc chan struct{}  // used to signal monitor to shutdown server
+	stopc chan struct{}  // used to terminate all other goroutines
 	wg    sync.WaitGroup // used to co-ordinate shutdown
 }
 
@@ -176,7 +176,7 @@ func (s *Server) Run() {
 	go s.Supervise()
 
 	log.Infof("Starting server components")
-	s.stopc = make(chan bool)
+	s.stopc = make(chan struct{})
 	s.wg = sync.WaitGroup{}
 	beatc := make(chan *unit.UnitStateHeartbeat)
 

--- a/unit/generator.go
+++ b/unit/generator.go
@@ -53,7 +53,7 @@ func (g *UnitStateGenerator) MarshalJSON() ([]byte, error) {
 
 // Run periodically calls Generate and sends received *UnitStateHeartbeat
 // objects to the provided channel.
-func (g *UnitStateGenerator) Run(receiver chan<- *UnitStateHeartbeat, stop chan bool) {
+func (g *UnitStateGenerator) Run(receiver chan<- *UnitStateHeartbeat, stop <-chan struct{}) {
 	tick := time.Tick(time.Second)
 	for {
 		select {


### PR DESCRIPTION
I'm not sure what's going on here, but clearly fleet should never try to close an already-closed channel: From https://github.com/coreos/fleet/issues/1044:

```
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: ERROR server.go:169: Server monitor triggered: Monitor timed out before successful heartbeat
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: panic: runtime error: close of closed channel
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 11048 [running]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: runtime.panic(0x77e400, 0x9bf155)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/runtime/panic.c:279 +0xf5
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/server.(*Server).Monitor(0xc208455560)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/server/server.go:171 +0xfb
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: created by github.com/coreos/fleet/server.(*Server).Run
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/server/server.go:152 +0x10e
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 16 [chan receive]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: main.listenForSignals(0xc2080a5650)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/fleetd/fleet.go:189 +0x16d
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: main.main()
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/fleetd/fleet.go:121 +0xf2b
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 19 [finalizer wait]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: runtime.park(0x416b60, 0x9c3dd0, 0x9c2029)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/runtime/proc.c:1369 +0x89
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: runtime.parkunlock(0x9c3dd0, 0x9c2029)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/runtime/proc.c:1385 +0x3b
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: runfinq()
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/runtime/mgc0.c:2644 +0xcf
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: runtime.goexit()
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/runtime/proc.c:1445
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 20 [syscall]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: os/signal.loop()
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/os/signal/signal_unix.go:21 +0x1e
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: created by os/signal.init·1
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/os/signal/signal_unix.go:27 +0x32
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 21 [IO wait, 17 minutes]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.runtime_pollWait(0x7fef8134ac10, 0x72, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/runtime/netpoll.goc:146 +0x66
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*pollDesc).Wait(0xc208037f00, 0x72, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*pollDesc).WaitRead(0xc208037f00, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*netFD).readMsg(0xc208037ea0, 0xc2083a0570, 0x10, 0x10, 0xc20809f220, 0x1000, 0x1000, 0xffffffffffffffff, 0x0, 0x0, ...)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_unix.go:296 +0x47f
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*UnixConn).ReadMsgUnix(0xc2080480c0, 0xc2083a0570, 0x10, 0x10, 0xc20809f220, 0x1000, 0x1000, 0xc208234000, 0xb97a, 0xb97a, ...)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/unixsock_posix.go:154 +0x16c
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*oobReader).Read(0xc20809f200, 0xc2083a0570, 0x10, 0x10, 0x1, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/transport_unix.go:21 +0xc9
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: io.ReadAtLeast(0x7fef8134adf8, 0xc20809f200, 0xc2083a0570, 0x10, 0x10, 0x10, 0x0, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/io/io.go:289 +0xf7
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: io.ReadFull(0x7fef8134adf8, 0xc20809f200, 0xc2083a0570, 0x10, 0x10, 0xb97a, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/io/io.go:307 +0x71
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*unixTransport).ReadMessage(0xc208001730, 0xc20800f470, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/transport_unix.go:85 +0x198
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*Conn).inWorker(0xc208003e60)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/conn.go:241 +0x57
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: created by github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*Conn).Auth
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/auth.go:118 +0xd2a
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 22 [chan receive, 17 minutes]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*Conn).outWorker(0xc208003e60)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/conn.go:363 +0x54
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: created by github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*Conn).Auth
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/auth.go:119 +0xd45
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 23 [IO wait]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.runtime_pollWait(0x7fef8134ab60, 0x72, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/runtime/netpoll.goc:146 +0x66
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*pollDesc).Wait(0xc208036ae0, 0x72, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*pollDesc).WaitRead(0xc208036ae0, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*netFD).readMsg(0xc208036a80, 0xc2082bcd00, 0x10, 0x10, 0xc20813f620, 0x1000, 0x1000, 0xffffffffffffffff, 0x0, 0x0, ...)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_unix.go:296 +0x47f
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*UnixConn).ReadMsgUnix(0xc208048018, 0xc2082bcd00, 0x10, 0x10, 0xc20813f620, 0x1000, 0x1000, 0xc2081acb90, 0x49, 0x49, ...)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/unixsock_posix.go:154 +0x16c
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*oobReader).Read(0xc20813f600, 0xc2082bcd00, 0x10, 0x10, 0x1, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/transport_unix.go:21 +0xc9
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: io.ReadAtLeast(0x7fef8134adf8, 0xc20813f600, 0xc2082bcd00, 0x10, 0x10, 0x10, 0x0, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/io/io.go:289 +0xf7
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: io.ReadFull(0x7fef8134adf8, 0xc20813f600, 0xc2082bcd00, 0x10, 0x10, 0x49, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/io/io.go:307 +0x71
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*unixTransport).ReadMessage(0xc2080015f0, 0xc2080a6000, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/transport_unix.go:85 +0x198
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*Conn).inWorker(0xc20808e120)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/conn.go:241 +0x57
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: created by github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*Conn).Auth
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/auth.go:118 +0xd2a
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 24 [chan receive, 19 minutes]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*Conn).outWorker(0xc20808e120)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/conn.go:363 +0x54
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: created by github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*Conn).Auth
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/auth.go:119 +0xd45
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 25 [chan receive]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/Godeps/_workspace/src/github.com/coreos/go-systemd/dbus.func·001()
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/coreos/go-systemd/dbus/subscription.go:66 +0x60
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: created by github.com/coreos/fleet/Godeps/_workspace/src/github.com/coreos/go-systemd/dbus.(*Conn).dispatch
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/coreos/go-systemd/dbus/subscription.go:98 +0xc3
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 26 [IO wait, 19 minutes]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.runtime_pollWait(0x7fef8134aab0, 0x72, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/runtime/netpoll.goc:146 +0x66
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*pollDesc).Wait(0xc208037b80, 0x72, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*pollDesc).WaitRead(0xc208037b80, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*netFD).accept(0xc208037b20, 0x87c188, 0x0, 0x7fef81349440, 0xb)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_unix.go:419 +0x343
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*UnixListener).AcceptUnix(0xc2080b24a0, 0x18, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/unixsock_posix.go:293 +0x73
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*UnixListener).Accept(0xc2080b24a0, 0x0, 0x0, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/unixsock_posix.go:304 +0x4b
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net/http.(*Server).Serve(0xc208004300, 0x7fef8134b2b0, 0xc2080b24a0, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/http/server.go:1698 +0x91
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net/http.Serve(0x7fef8134b2b0, 0xc2080b24a0, 0x7fef8134c5b0, 0xc20804a000, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/http/server.go:1576 +0x7c
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/api.func·001()
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/api/server.go:35 +0x78
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: created by github.com/coreos/fleet/api.(*Server).Serve
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/api/server.go:39 +0xf5
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 11408 [select]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/agent.(*UnitStatePublisher).Run(0xc2084ed580, 0xc2084543c0, 0xc208454360)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/agent/unit_state.go:105 +0x287
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: created by github.com/coreos/fleet/server.(*Server).Run
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/server/server.go:161 +0x25f
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: goroutine 1463 [IO wait, 15 minutes]:
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.runtime_pollWait(0x7fef81354a28, 0x72, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/runtime/netpoll.goc:146 +0x66
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*pollDesc).Wait(0xc208587950, 0x72, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*pollDesc).WaitRead(0xc208587950, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*netFD).readMsg(0xc2085878f0, 0xc20851aae0, 0x10, 0x10, 0xc20837e020, 0x1000, 0x1000, 0xffffffffffffffff, 0x0, 0x0, ...)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/fd_unix.go:296 +0x47f
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: net.(*UnixConn).ReadMsgUnix(0xc20858c180, 0xc20851aae0, 0x10, 0x10, 0xc20837e020, 0x1000, 0x1000, 0xc2085d6000, 0x1, 0x30000000000b95e, ...)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /usr/lib/go/src/pkg/net/unixsock_posix.go:154 +0x16c
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus.(*oobReader).Read(0xc20837e000, 0xc20851aae0, 0x10, 0x10, 0x1, 0x0, 0x0)
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: /build/amd64-usr/var/tmp/portage/app-admin/fleet-0.8.3/work/fleet-0.8.3/gopath/src/github.com/coreos/fleet/Godeps/_workspace/src/github.com/godbus/dbus/transport_unix.go:21 +0xc9
Dec 02 18:26:05 ip-172-31-24-115.eu-west-1.compute.internal fleetd[570]: io.ReadAtLeast(0x7fef8134adf8, 0xc20837e000, 0xc20851aae0, 0x10, 0x10, 0x10, 0x0, 0x0, 0x0)

...
```