### PR TITLE
log: replace V-levels with Debug method

### DIFF
--- a/Documentation/deployment-and-configuration.md
+++ b/Documentation/deployment-and-configuration.md
@@ -74,7 +74,8 @@ $ FLEET_ETCD_SERVERS=http://192.0.2.12:4001 /usr/bin/fleetd
 
 #### verbosity
 
-Increase the amount of log information. Acceptable values are 0, 1, and 2 - higher values are more verbose.
+Enable debug logging by setting this to an integer value greater than zero.
+Only a single debug level exists, so all values greater than zero are considered equivalent.
 
 Default: 0
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -77,10 +77,10 @@ func (a *Agent) heartbeatJobs(ttl time.Duration, stop chan bool) {
 	for {
 		select {
 		case <-stop:
-			log.V(1).Info("HeartbeatJobs exiting due to stop signal")
+			log.Debug("HeartbeatJobs exiting due to stop signal")
 			return
 		case <-ticker:
-			log.V(1).Info("HeartbeatJobs tick")
+			log.Debug("HeartbeatJobs tick")
 			heartbeat()
 		}
 	}

--- a/agent/reconcile.go
+++ b/agent/reconcile.go
@@ -59,7 +59,7 @@ func (ar *AgentReconciler) Run(a *Agent, stop chan bool) {
 		if elapsed > reconcileInterval {
 			log.Warning(msg)
 		} else {
-			log.V(1).Info(msg)
+			log.Debug(msg)
 		}
 	}
 	reconciler := pkg.NewPeriodicReconciler(reconcileInterval, reconcile, ar.rStream)
@@ -145,7 +145,7 @@ func desiredAgentState(a *Agent, reg registry.Registry) (*AgentState, error) {
 		u := u
 		md := u.RequiredTargetMetadata()
 		if u.IsGlobal() && !machine.HasMetadata(&ms, md) {
-			log.V(1).Infof("Agent unable to run global unit %s: missing required metadata", u.Name)
+			log.Debugf("Agent unable to run global unit %s: missing required metadata", u.Name)
 			continue
 		}
 		if !u.IsGlobal() {
@@ -248,7 +248,7 @@ func (ar *AgentReconciler) calculateTaskChainForUnit(dState *AgentState, cState 
 	}
 
 	if cJHash != dJHash {
-		log.V(1).Infof("Desired hash %q differs to current hash %s of Job(%s) - unloading", dJHash, cJHash, jName)
+		log.Debugf("Desired hash %q differs to current hash %s of Job(%s) - unloading", dJHash, cJHash, jName)
 		tc := newTaskChain(u)
 		tc.Add(task{
 			typ:    taskTypeUnloadUnit,
@@ -273,7 +273,7 @@ func (ar *AgentReconciler) calculateTaskChainForUnit(dState *AgentState, cState 
 	}
 
 	if *cJState == dJob.TargetState {
-		log.V(1).Infof("Desired state %q matches current state of Job(%s), nothing to do", *cJState, jName)
+		log.Debugf("Desired state %q matches current state of Job(%s), nothing to do", *cJState, jName)
 		return nil
 	}
 
@@ -308,7 +308,7 @@ func (ar *AgentReconciler) calculateTaskChainForUnit(dState *AgentState, cState 
 }
 
 func (ar *AgentReconciler) launchTaskChain(tc taskChain, a *Agent) {
-	log.V(1).Infof("AgentReconciler attempting task chain %s", tc)
+	log.Debugf("AgentReconciler attempting task chain %s", tc)
 	reschan, err := ar.tManager.Do(tc, a)
 	if err != nil {
 		log.Infof("AgentReconciler task chain failed: chain=%s err=%v", tc, err)

--- a/agent/state.go
+++ b/agent/state.go
@@ -71,7 +71,7 @@ func (as *AgentState) hasConflict(pUnitName string, pConflicts []string) (found 
 func globMatches(pattern, target string) bool {
 	matched, err := path.Match(pattern, target)
 	if err != nil {
-		log.V(1).Infof("Received error while matching pattern '%s': %v", pattern, err)
+		log.Debugf("Received error while matching pattern '%s': %v", pattern, err)
 	}
 	return matched
 }

--- a/agent/unit_state.go
+++ b/agent/unit_state.go
@@ -200,7 +200,7 @@ func (p *UnitStatePublisher) Purge() {
 func newPublisher(reg registry.Registry, ttl time.Duration) publishFunc {
 	return func(name string, us *unit.UnitState) {
 		if us == nil {
-			log.V(1).Infof("Destroying UnitState(%s) in Registry", name)
+			log.Debugf("Destroying UnitState(%s) in Registry", name)
 			err := reg.RemoveUnitState(name)
 			if err != nil {
 				log.Errorf("Failed to destroy UnitState(%s) in Registry: %v", name, err)
@@ -217,7 +217,7 @@ func newPublisher(reg registry.Registry, ttl time.Duration) publishFunc {
 			if len(us.MachineID) == 0 {
 				log.Errorf("Refusing to push UnitState(%s), no MachineID: %#v", name, us)
 			} else {
-				log.V(1).Infof("Pushing UnitState(%s) to Registry: %#v", name, us)
+				log.Debugf("Pushing UnitState(%s) to Registry: %#v", name, us)
 				reg.SaveUnitState(name, us, ttl)
 			}
 		}

--- a/api/mux.go
+++ b/api/mux.go
@@ -51,7 +51,7 @@ type loggingMiddleware struct {
 }
 
 func (lm *loggingMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	log.V(1).Infof("HTTP %s %v", req.Method, req.URL)
+	log.Debugf("HTTP %s %v", req.Method, req.URL)
 	lm.next.ServeHTTP(rw, req)
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -115,7 +115,7 @@ func (e *Engine) Run(ival time.Duration, stop chan bool) {
 		if elapsed > ival {
 			log.Warning(msg)
 		} else {
-			log.V(1).Info(msg)
+			log.Debug(msg)
 		}
 	}
 
@@ -159,7 +159,7 @@ func ensureEngineVersionMatch(cReg registry.ClusterRegistry, expect int) bool {
 		}
 		log.Infof("Updated cluster engine version from %d to %d", v, expect)
 	} else if v > expect {
-		log.V(1).Infof("Cluster engine version higher than local engine version (%d > %d), unable to participate", v, expect)
+		log.Debugf("Cluster engine version higher than local engine version (%d > %d), unable to participate", v, expect)
 		return false
 	}
 
@@ -180,7 +180,7 @@ func acquireLeadership(lReg registry.LeaseRegistry, machID string, ver int, ttl 
 			log.Errorf("Engine leadership acquisition failed: %v", err)
 			return nil
 		} else if l == nil {
-			log.V(1).Infof("Unable to acquire engine leadership")
+			log.Debugf("Unable to acquire engine leadership")
 			return nil
 		}
 		log.Infof("Engine leadership acquired")
@@ -188,7 +188,7 @@ func acquireLeadership(lReg registry.LeaseRegistry, machID string, ver int, ttl 
 	}
 
 	if existing.Version() >= ver {
-		log.V(1).Infof("Lease already held by Machine(%s) operating at acceptable version %d", existing.MachineID(), existing.Version())
+		log.Debugf("Lease already held by Machine(%s) operating at acceptable version %d", existing.MachineID(), existing.Version())
 		return existing
 	}
 
@@ -198,7 +198,7 @@ func acquireLeadership(lReg registry.LeaseRegistry, machID string, ver int, ttl 
 		log.Errorf("Engine leadership steal failed: %v", err)
 		return nil
 	} else if l == nil {
-		log.V(1).Infof("Unable to steal engine leadership")
+		log.Debugf("Unable to steal engine leadership")
 		return nil
 	}
 
@@ -219,7 +219,7 @@ func renewLeadership(l registry.Lease, ttl time.Duration) registry.Lease {
 		return nil
 	}
 
-	log.V(1).Infof("Engine leadership renewed")
+	log.Debugf("Engine leadership renewed")
 	return l
 }
 

--- a/engine/reconciler.go
+++ b/engine/reconciler.go
@@ -50,7 +50,7 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) Reconcile(e *Engine, stop chan struct{}) {
-	log.V(1).Infof("Polling Registry for actionable work")
+	log.Debugf("Polling Registry for actionable work")
 
 	clust, err := e.clusterState()
 	if err != nil {
@@ -133,7 +133,7 @@ func (r *Reconciler) calculateClusterTasks(clust *clusterState, stopchan chan st
 
 			dec, err := r.sched.Decide(clust, j)
 			if err != nil {
-				log.V(1).Infof("Unable to schedule Job(%s): %v", j.Name, err)
+				log.Debugf("Unable to schedule Job(%s): %v", j.Name, err)
 				continue
 			}
 

--- a/etcd/client.go
+++ b/etcd/client.go
@@ -363,13 +363,13 @@ func (ar *actionResolver) next(resp *http.Response) (*http.Request, error) {
 }
 
 func (ar *actionResolver) one(req *http.Request, cancel <-chan struct{}) (resp *http.Response, body []byte, err error) {
-	log.V(1).Infof("etcd: sending HTTP request %s %s", req.Method, req.URL)
+	log.Debugf("etcd: sending HTTP request %s %s", req.Method, req.URL)
 	resp, body, err = ar.requestFunc(req, cancel)
 	if err != nil {
-		log.V(1).Infof("etcd: recv error response from %s %s: %v", req.Method, req.URL, err)
+		log.Debugf("etcd: recv error response from %s %s: %v", req.Method, req.URL, err)
 		return
 	}
 
-	log.V(1).Infof("etcd: recv response from %s %s: %s", req.Method, req.URL, resp.Status)
+	log.Debugf("etcd: recv response from %s %s: %s", req.Method, req.URL, resp.Status)
 	return
 }

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -225,7 +225,7 @@ func main() {
 	getFlagsFromEnv(cliName, globalFlagset)
 
 	if globalFlags.Debug {
-		log.SetVerbosity(1)
+		log.EnableDebug()
 	}
 
 	if globalFlags.Version {
@@ -337,7 +337,7 @@ func getHTTPClient() (client.API, error) {
 		if dialUnix {
 			tgt := ep.Path
 			tunnelFunc = func(string, string) (net.Conn, error) {
-				log.V(1).Infof("Establishing remote fleetctl proxy to %s", tgt)
+				log.Debugf("Establishing remote fleetctl proxy to %s", tgt)
 				cmd := fmt.Sprintf(`fleetctl fd-forward %s`, tgt)
 				return ssh.DialCommand(sshClient, cmd)
 			}
@@ -458,7 +458,7 @@ func getUnitFromFile(file string) (*unit.UnitFile, error) {
 	}
 
 	unitName := path.Base(file)
-	log.V(1).Infof("Unit(%s) found in local filesystem", unitName)
+	log.Debugf("Unit(%s) found in local filesystem", unitName)
 
 	return unit.NewUnitFile(string(out))
 }
@@ -547,7 +547,7 @@ func createUnit(name string, uf *unit.UnitFile) (*schema.Unit, error) {
 		return nil, fmt.Errorf("failed creating unit %s: %v", name, err)
 	}
 
-	log.V(1).Infof("Created Unit(%s) in Registry", name)
+	log.Debugf("Created Unit(%s) in Registry", name)
 	return &u, nil
 }
 
@@ -574,7 +574,7 @@ func lazyCreateUnits(args []string) error {
 			return fmt.Errorf("error retrieving Unit(%s) from Registry: %v", name, err)
 		}
 		if u != nil {
-			log.V(1).Infof("Found Unit(%s) in Registry, no need to recreate it", name)
+			log.Debugf("Found Unit(%s) in Registry, no need to recreate it", name)
 			warnOnDifferentLocalUnit(arg, u)
 			continue
 		}
@@ -680,11 +680,11 @@ func setTargetStateOfUnits(units []string, state job.JobState) ([]*schema.Unit, 
 		} else if u == nil {
 			return nil, fmt.Errorf("unable to find unit %s", name)
 		} else if job.JobState(u.DesiredState) == state {
-			log.V(1).Infof("Unit(%s) already %s, skipping.", u.Name, u.DesiredState)
+			log.Debugf("Unit(%s) already %s, skipping.", u.Name, u.DesiredState)
 			continue
 		}
 
-		log.V(1).Infof("Setting Unit(%s) target state to %s", u.Name, state)
+		log.Debugf("Setting Unit(%s) target state to %s", u.Name, state)
 		cAPI.SetUnitTargetState(u.Name, string(state))
 		triggered = append(triggered, u)
 	}

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -67,12 +67,12 @@ func runStopUnit(args []string) (exit int) {
 				stderr("Unable to stop unit %s in state %s", u.Name, job.JobStateInactive)
 				return 1
 			} else if job.JobState(u.CurrentState) == job.JobStateLoaded {
-				log.V(1).Infof("Unit(%s) already %s, skipping.", u.Name, job.JobStateLoaded)
+				log.Debugf("Unit(%s) already %s, skipping.", u.Name, job.JobStateLoaded)
 				continue
 			}
 		}
 
-		log.V(1).Infof("Setting target state of Unit(%s) to %s", u.Name, job.JobStateLoaded)
+		log.Debugf("Setting target state of Unit(%s) to %s", u.Name, job.JobStateLoaded)
 		cAPI.SetUnitTargetState(u.Name, string(job.JobStateLoaded))
 		if suToGlobal(u) {
 			stdout("Triggered global unit %s stop", u.Name)

--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -48,12 +48,12 @@ func runUnloadUnit(args []string) (exit int) {
 	for _, s := range units {
 		if !suToGlobal(s) {
 			if job.JobState(s.CurrentState) == job.JobStateInactive {
-				log.V(1).Infof("Target state of Unit(%s) already %s, skipping.", s.Name, job.JobStateInactive)
+				log.Debugf("Target state of Unit(%s) already %s, skipping.", s.Name, job.JobStateInactive)
 				continue
 			}
 		}
 
-		log.V(1).Infof("Setting target state of Unit(%s) to %s", s.Name, job.JobStateInactive)
+		log.Debugf("Setting target state of Unit(%s) to %s", s.Name, job.JobStateInactive)
 		cAPI.SetUnitTargetState(s.Name, string(job.JobStateInactive))
 		if suToGlobal(s) {
 			stdout("Triggered global unit %s unload", s.Name)

--- a/fleetd/fleet.go
+++ b/fleetd/fleet.go
@@ -78,7 +78,7 @@ func main() {
 		log.Fatalf(err.Error())
 	}
 
-	log.V(1).Infof("Creating Server")
+	log.Debugf("Creating Server")
 	srv, err := server.New(*cfg)
 	if err != nil {
 		log.Fatalf("Failed creating Server: %v", err.Error())
@@ -126,7 +126,7 @@ func main() {
 
 		os.Stdout.Write([]byte("\n"))
 
-		log.V(1).Infof("Finished dumping server state")
+		log.Debugf("Finished dumping server state")
 	}
 
 	signals := map[os.Signal]func(){
@@ -192,7 +192,10 @@ func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error
 		log.Error("Config option authorized_keys_file is no longer supported - ignoring")
 	}
 
-	log.SetVerbosity(cfg.Verbosity)
+	if cfg.Verbosity > 0 {
+		log.EnableDebug()
+	}
+
 	return &cfg, nil
 }
 

--- a/heart/monitor.go
+++ b/heart/monitor.go
@@ -39,7 +39,7 @@ func (m *Monitor) Monitor(hrt Heart, stop chan bool) error {
 	for {
 		select {
 		case <-stop:
-			log.V(1).Info("Monitor exiting due to stop signal")
+			log.Debug("Monitor exiting due to stop signal")
 			return nil
 		case <-ticker:
 			if _, err := m.check(hrt); err != nil {
@@ -67,7 +67,7 @@ func (m *Monitor) check(hrt Heart) (idx uint64, err error) {
 		case <-next:
 			idx, err = hrt.Beat(m.TTL)
 			if err != nil {
-				log.V(1).Infof("Monitor heartbeat function returned err, retrying in %v: %v", interval, err)
+				log.Debugf("Monitor heartbeat function returned err, retrying in %v: %v", interval, err)
 			}
 
 			next = time.After(interval)

--- a/log/log.go
+++ b/log/log.go
@@ -22,8 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
-	"sync/atomic"
 )
 
 const (
@@ -31,60 +29,27 @@ const (
 )
 
 var (
-	logger    = log.New(os.Stderr, "", 0)
-	verbosity = VLevel(0)
+	logger = log.New(os.Stderr, "", 0)
+	debug  = false
 )
 
 func EnableTimestamps() {
 	logger.SetFlags(logger.Flags() | log.Ldate | log.Ltime)
 }
 
-func SetVerbosity(lvl int) {
-	verbosity.set(int32(lvl))
+func EnableDebug() {
+	debug = true
 }
 
-type VLevel int32
-
-func (l *VLevel) get() VLevel {
-	return VLevel(atomic.LoadInt32((*int32)(l)))
-}
-
-func (l *VLevel) String() string {
-	return strconv.FormatInt(int64(*l), 10)
-}
-
-func (l *VLevel) Get() interface{} {
-	return l.get()
-}
-
-func (l *VLevel) Set(val string) error {
-	vi, err := strconv.Atoi(val)
-	if err != nil {
-		return err
-	}
-	l.set(int32(vi))
-	return nil
-}
-
-func (l *VLevel) set(lvl int32) {
-	atomic.StoreInt32((*int32)(l), lvl)
-}
-
-type VLogger bool
-
-func V(level VLevel) VLogger {
-	return VLogger(verbosity.get() >= level)
-}
-
-func (vl VLogger) Info(v ...interface{}) {
-	if vl {
-		logger.Output(calldepth, header("INFO", fmt.Sprint(v...)))
+func Debug(v ...interface{}) {
+	if debug {
+		logger.Output(calldepth, header("DEBUG", fmt.Sprint(v...)))
 	}
 }
 
-func (vl VLogger) Infof(format string, v ...interface{}) {
-	if vl {
-		logger.Output(calldepth, header("INFO", fmt.Sprintf(format, v...)))
+func Debugf(format string, v ...interface{}) {
+	if debug {
+		logger.Output(calldepth, header("DEBUG", fmt.Sprintf(format, v...)))
 	}
 }
 

--- a/machine/coreos.go
+++ b/machine/coreos.go
@@ -170,7 +170,7 @@ func usableAddress(ip net.IP) bool {
 }
 
 func getDefaultGatewayIface() *net.Interface {
-	log.Debugf("Attempting to retrieve IP route info from netlink")
+	log.Debug("Attempting to retrieve IP route info from netlink")
 
 	routes, err := netlink.NetworkGetRoutes()
 	if err != nil {

--- a/machine/coreos.go
+++ b/machine/coreos.go
@@ -36,7 +36,7 @@ const (
 )
 
 func NewCoreOSMachine(static MachineState, um unit.UnitManager) *CoreOSMachine {
-	log.V(1).Infof("Created CoreOSMachine with static state %s", static)
+	log.Debugf("Created CoreOSMachine with static state %s", static)
 	m := &CoreOSMachine{
 		staticState: static,
 		um:          um,
@@ -91,7 +91,7 @@ func (m *CoreOSMachine) PeriodicRefresh(interval time.Duration, stop chan bool) 
 	for {
 		select {
 		case <-stop:
-			log.V(1).Info("Halting CoreOSMachine.PeriodicRefresh")
+			log.Debug("Halting CoreOSMachine.PeriodicRefresh")
 			ticker.Stop()
 			return
 		case <-ticker.C:
@@ -170,29 +170,29 @@ func usableAddress(ip net.IP) bool {
 }
 
 func getDefaultGatewayIface() *net.Interface {
-	log.V(1).Infof("Attempting to retrieve IP route info from netlink")
+	log.Debugf("Attempting to retrieve IP route info from netlink")
 
 	routes, err := netlink.NetworkGetRoutes()
 	if err != nil {
-		log.V(1).Infof("Unable to detect default interface: %v", err)
+		log.Debugf("Unable to detect default interface: %v", err)
 		return nil
 	}
 
 	if len(routes) == 0 {
-		log.V(1).Infof("Netlink returned zero routes")
+		log.Debugf("Netlink returned zero routes")
 		return nil
 	}
 
 	for _, route := range routes {
 		if route.Default {
 			if route.Iface == nil {
-				log.V(1).Infof("Found default route but could not determine interface")
+				log.Debugf("Found default route but could not determine interface")
 			}
-			log.V(1).Infof("Found default route with interface %v", route.Iface.Name)
+			log.Debugf("Found default route with interface %v", route.Iface.Name)
 			return route.Iface
 		}
 	}
 
-	log.V(1).Infof("Unable to find default route")
+	log.Debugf("Unable to find default route")
 	return nil
 }

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -31,16 +31,16 @@ func HasMetadata(state *MachineState, metadata map[string]pkg.Set) bool {
 	for key, values := range metadata {
 		local, ok := state.Metadata[key]
 		if !ok {
-			log.V(1).Infof("No local values found for Metadata(%s)", key)
+			log.Debugf("No local values found for Metadata(%s)", key)
 			return false
 		}
 
-		log.V(1).Infof("Asserting local Metadata(%s) meets requirements", key)
+		log.Debugf("Asserting local Metadata(%s) meets requirements", key)
 
 		if values.Contains(local) {
-			log.V(1).Infof("Local Metadata(%s) meets requirement", key)
+			log.Debugf("Local Metadata(%s) meets requirement", key)
 		} else {
-			log.V(1).Infof("Local Metadata(%s) does not match requirement", key)
+			log.Debugf("Local Metadata(%s) does not match requirement", key)
 			return false
 		}
 	}

--- a/pkg/filepath.go
+++ b/pkg/filepath.go
@@ -40,7 +40,7 @@ func ParseFilepath(path string) string {
 		if home = os.Getenv("HOME"); home == "" {
 			usr, err := user.Current()
 			if err != nil {
-				log.V(1).Infof("Failed to get current home directory: %v", err)
+				log.Debugf("Failed to get current home directory: %v", err)
 				return path
 			}
 			home = usr.HomeDir
@@ -48,7 +48,7 @@ func ParseFilepath(path string) string {
 	} else {
 		usr, err := user.Lookup(path[1:i])
 		if err != nil {
-			log.V(1).Infof("Failed to get %v's home directory: %v", path[1:i], err)
+			log.Debugf("Failed to get %v's home directory: %v", path[1:i], err)
 			return path
 		}
 		home = usr.HomeDir

--- a/pkg/http.go
+++ b/pkg/http.go
@@ -27,10 +27,10 @@ type LoggingHTTPTransport struct {
 }
 
 func (lt *LoggingHTTPTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	log.V(1).Infof("HTTP %s %s", req.Method, req.URL.String())
+	log.Debugf("HTTP %s %s", req.Method, req.URL.String())
 	resp, err = lt.Transport.RoundTrip(req)
 	if err == nil {
-		log.V(1).Infof("HTTP %s %s %s", req.Method, req.URL.String(), resp.Status)
+		log.Debugf("HTTP %s %s %s", req.Method, req.URL.String(), resp.Status)
 	}
 	return
 }

--- a/pkg/reconcile.go
+++ b/pkg/reconcile.go
@@ -73,21 +73,21 @@ func (r *reconciler) Run(stop chan bool) {
 	ticker := r.clock.After(r.ival)
 
 	// When starting up, reconcile once immediately
-	log.V(1).Info("Initial reconciliation commencing")
+	log.Debug("Initial reconciliation commencing")
 	r.rFunc()
 
 	for {
 		select {
 		case <-stop:
-			log.V(1).Info("Reconciler exiting due to stop signal")
+			log.Debug("Reconciler exiting due to stop signal")
 			return
 		case <-ticker:
 			ticker = r.clock.After(r.ival)
-			log.V(1).Info("Reconciler tick")
+			log.Debug("Reconciler tick")
 			r.rFunc()
 		case <-trigger:
 			ticker = r.clock.After(r.ival)
-			log.V(1).Info("Reconciler triggered")
+			log.Debug("Reconciler triggered")
 			r.rFunc()
 		}
 	}

--- a/registry/event.go
+++ b/registry/event.go
@@ -90,7 +90,7 @@ func watch(client etcd.Client, key string, stop chan struct{}) (res *etcd.Result
 	for res == nil {
 		select {
 		case <-stop:
-			log.V(1).Infof("Gracefully closing etcd watch loop: key=%s", key)
+			log.Debugf("Gracefully closing etcd watch loop: key=%s", key)
 			return
 		default:
 			req := &etcd.Watch{
@@ -99,7 +99,7 @@ func watch(client etcd.Client, key string, stop chan struct{}) (res *etcd.Result
 				Recursive: true,
 			}
 
-			log.V(1).Infof("Creating etcd watcher: %v", req)
+			log.Debugf("Creating etcd watcher: %v", req)
 
 			var err error
 			res, err = client.Wait(req, stop)

--- a/ssh/known_hosts.go
+++ b/ssh/known_hosts.go
@@ -158,13 +158,13 @@ func (kc *HostKeyChecker) addrToHostPort(a string) (string, error) {
 	}
 	host, p, err := net.SplitHostPort(a)
 	if err != nil {
-		log.V(1).Infof("Unable to parse addr %s: %v", a, err)
+		log.Debugf("Unable to parse addr %s: %v", a, err)
 		return "", err
 	}
 
 	port, err := strconv.Atoi(p)
 	if err != nil {
-		log.V(1).Infof("Error parsing port %s: %v", p, err)
+		log.Debugf("Error parsing port %s: %v", p, err)
 		return "", err
 	}
 


### PR DESCRIPTION
We don't utilize the multi-leveled logs, so let's just drop that overly-complex code. Use `log.Debug[f]` instead.