### PR TITLE
Finish SSH Username Support

### DIFF
--- a/Documentation/using-the-client.md
+++ b/Documentation/using-the-client.md
@@ -32,6 +32,14 @@ One can also provide `--tunnel` through the environment variable `FLEETCTL_TUNNE
 When using `--tunnel` and `--endpoint` together, it is important to note that all etcd requests will be made through the SSH tunnel. 
 The address in the `--endpoint` flag must be routable from the server hosting the tunnel.
 
+If the external host requires a username other than `core`, the `--ssh-username` flag can be used to set an alternative username.
+
+    fleetctl --ssh-username=elroy list-units
+
+Or
+
+    FLEETCTL_SSH_USERNAME=elroy fleetctl list-units
+
 Be sure to install one of the [tagged releases](https://github.com/coreos/fleet/releases) of `fleetctl` that matches the version of fleet running on the CoreOS machine. 
 Find the version on the server with:
 

--- a/Documentation/using-the-client.md
+++ b/Documentation/using-the-client.md
@@ -40,7 +40,10 @@ Or
 
     FLEETCTL_SSH_USERNAME=elroy fleetctl list-units
 
-Be sure to install one of the [tagged releases](https://github.com/coreos/fleet/releases) of `fleetctl` that matches the version of fleet running on the CoreOS machine. 
+Note: Custom users are not by default part of the `systemd-journal` group which will cause you to see `No journal files were found.`
+To use the `journal` command please add your users to the `systemd-journal` group.
+
+Be sure to install one of the [tagged releases](https://github.com/coreos/fleet/releases) of `fleetctl` that matches the version of fleet running on the CoreOS machine.
 Find the version on the server with:
 
 ```

--- a/Documentation/using-the-client.md
+++ b/Documentation/using-the-client.md
@@ -41,7 +41,7 @@ Or
     FLEETCTL_SSH_USERNAME=elroy fleetctl list-units
 
 Note: Custom users are not by default part of the `systemd-journal` group which will cause you to see `No journal files were found.`
-To use the `journal` command please add your users to the `systemd-journal` group.
+To use the `journal` command please add your users to the `systemd-journal` group or use the `--sudo` flag with journal.
 
 Be sure to install one of the [tagged releases](https://github.com/coreos/fleet/releases) of `fleetctl` that matches the version of fleet running on the CoreOS machine.
 Find the version on the server with:

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -90,6 +90,7 @@ var (
 		KnownHostsFile        string
 		StrictHostKeyChecking bool
 		SSHTimeout            float64
+		SSHUserName           string
 
 		EtcdKeyPrefix string
 	}{}
@@ -131,6 +132,7 @@ func init() {
 	globalFlagset.Float64Var(&globalFlags.SSHTimeout, "ssh-timeout", 10.0, "Amount of time in seconds to allow for SSH connection initialization before failing.")
 	globalFlagset.StringVar(&globalFlags.Tunnel, "tunnel", "", "Establish an SSH tunnel through the provided address for communication with fleet and etcd.")
 	globalFlagset.Float64Var(&globalFlags.RequestTimeout, "request-timeout", 3.0, "Amount of time in seconds to allow a single request before considering it failed.")
+	globalFlagset.StringVar(&globalFlags.SSHUserName, "ssh-username", "core", "Username to use when connecting to CoreOS instance.")
 
 	// deprecated flags
 	globalFlagset.BoolVar(&globalFlags.ExperimentalAPI, "experimental-api", false, hidden)
@@ -329,7 +331,7 @@ func getHTTPClient() (client.API, error) {
 
 	tunnelFunc := net.Dial
 	if tunneling {
-		sshClient, err := ssh.NewSSHClient("core", tun, getChecker(), true, getSSHTimeoutFlag())
+		sshClient, err := ssh.NewSSHClient(globalFlags.SSHUserName, tun, getChecker(), true, getSSHTimeoutFlag())
 		if err != nil {
 			return nil, fmt.Errorf("failed initializing SSH client: %v", err)
 		}
@@ -399,7 +401,7 @@ func getRegistryClient() (client.API, error) {
 	var dial func(string, string) (net.Conn, error)
 	tun := getTunnelFlag()
 	if tun != "" {
-		sshClient, err := ssh.NewSSHClient("core", tun, getChecker(), false, getSSHTimeoutFlag())
+		sshClient, err := ssh.NewSSHClient(globalFlags.SSHUserName, tun, getChecker(), false, getSSHTimeoutFlag())
 		if err != nil {
 			return nil, fmt.Errorf("failed initializing SSH client: %v", err)
 		}

--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -48,7 +48,6 @@ func init() {
 	cmdJournal.Flags.BoolVar(&flagFollow, "follow", false, "Continuously print new entries as they are appended to the journal.")
 	cmdJournal.Flags.BoolVar(&flagFollow, "f", false, "Shorthand for --follow")
 	cmdJournal.Flags.BoolVar(&flagSudo, "sudo", false, "Execute journal command with sudo")
-	cmdJournal.Flags.BoolVar(&flagSudo, "s", false, "Shorthand for --sudo")
 }
 
 func runJournal(args []string) (exit int) {

--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -25,6 +25,7 @@ import (
 var (
 	flagLines  int
 	flagFollow bool
+	flagSudo   bool
 	cmdJournal = &Command{
 		Name:    "journal",
 		Summary: "Print the journal of a unit in the cluster to stdout",
@@ -46,6 +47,8 @@ func init() {
 	cmdJournal.Flags.IntVar(&flagLines, "lines", 10, "Number of recent log lines to return")
 	cmdJournal.Flags.BoolVar(&flagFollow, "follow", false, "Continuously print new entries as they are appended to the journal.")
 	cmdJournal.Flags.BoolVar(&flagFollow, "f", false, "Shorthand for --follow")
+	cmdJournal.Flags.BoolVar(&flagSudo, "sudo", false, "Execute journal command with sudo")
+	cmdJournal.Flags.BoolVar(&flagSudo, "s", false, "Shorthand for --sudo")
 }
 
 func runJournal(args []string) (exit int) {
@@ -71,6 +74,11 @@ func runJournal(args []string) (exit int) {
 	}
 
 	command := fmt.Sprintf("journalctl --unit %s --no-pager -n %d", name, flagLines)
+
+	if flagSudo {
+		command = "sudo " + command
+	}
+
 	if flagFollow {
 		command += " -f"
 	}

--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -33,6 +33,7 @@ var (
 	flagMachine            string
 	flagUnit               string
 	flagSSHAgentForwarding bool
+	flagSSHUserName        string
 	cmdSSH                 = &Command{
 		Name:    "ssh",
 		Summary: "Open interactive shell on a machine in the cluster",
@@ -68,6 +69,7 @@ func init() {
 	cmdSSH.Flags.StringVar(&flagUnit, "unit", "", "Open SSH connection to machine running provided unit.")
 	cmdSSH.Flags.BoolVar(&flagSSHAgentForwarding, "forward-agent", false, "Forward local ssh-agent to target machine.")
 	cmdSSH.Flags.BoolVar(&flagSSHAgentForwarding, "A", false, "Shorthand for --forward-agent")
+	cmdSSH.Flags.StringVar(&flagSSHUserName, "ssh-username", "core", "Username to use when connecting to CoreOS instance.")
 }
 
 func runSSH(args []string) (exit int) {
@@ -107,9 +109,9 @@ func runSSH(args []string) (exit int) {
 	var sshClient *ssh.SSHForwardingClient
 	timeout := getSSHTimeoutFlag()
 	if tun := getTunnelFlag(); tun != "" {
-		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr, getChecker(), flagSSHAgentForwarding, timeout)
+		sshClient, err = ssh.NewTunnelledSSHClient(flagSSHUserName, tun, addr, getChecker(), flagSSHAgentForwarding, timeout)
 	} else {
-		sshClient, err = ssh.NewSSHClient("core", addr, getChecker(), flagSSHAgentForwarding, timeout)
+		sshClient, err = ssh.NewSSHClient(flagSSHUserName, addr, getChecker(), flagSSHAgentForwarding, timeout)
 	}
 	if err != nil {
 		stderr("Failed building SSH client: %v", err)
@@ -251,9 +253,9 @@ func runRemoteCommand(cmd string, addr string) (err error, exit int) {
 	var sshClient *ssh.SSHForwardingClient
 	timeout := getSSHTimeoutFlag()
 	if tun := getTunnelFlag(); tun != "" {
-		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr, getChecker(), false, timeout)
+		sshClient, err = ssh.NewTunnelledSSHClient(flagSSHUserName, tun, addr, getChecker(), false, timeout)
 	} else {
-		sshClient, err = ssh.NewSSHClient("core", addr, getChecker(), false, timeout)
+		sshClient, err = ssh.NewSSHClient(flagSSHUserName, addr, getChecker(), false, timeout)
 	}
 	if err != nil {
 		return err, -1

--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -33,15 +33,14 @@ var (
 	flagMachine            string
 	flagUnit               string
 	flagSSHAgentForwarding bool
-	flagSSHUserName        string
 	cmdSSH                 = &Command{
 		Name:    "ssh",
 		Summary: "Open interactive shell on a machine in the cluster",
 		Usage:   "[-A|--forward-agent] [--machine|--unit] {MACHINE|UNIT}",
-		Description: `Open an interactive shell on a specific machine in the cluster or on the machine 
+		Description: `Open an interactive shell on a specific machine in the cluster or on the machine
 where the specified unit is located.
 
-fleetctl tries to detect whether your first argument is a machine or a unit. 
+fleetctl tries to detect whether your first argument is a machine or a unit.
 To skip this check use the --machine or --unit flags.
 
 Open a shell on a machine:
@@ -69,7 +68,6 @@ func init() {
 	cmdSSH.Flags.StringVar(&flagUnit, "unit", "", "Open SSH connection to machine running provided unit.")
 	cmdSSH.Flags.BoolVar(&flagSSHAgentForwarding, "forward-agent", false, "Forward local ssh-agent to target machine.")
 	cmdSSH.Flags.BoolVar(&flagSSHAgentForwarding, "A", false, "Shorthand for --forward-agent")
-	cmdSSH.Flags.StringVar(&flagSSHUserName, "ssh-username", "core", "Username to use when connecting to CoreOS instance.")
 }
 
 func runSSH(args []string) (exit int) {
@@ -109,9 +107,9 @@ func runSSH(args []string) (exit int) {
 	var sshClient *ssh.SSHForwardingClient
 	timeout := getSSHTimeoutFlag()
 	if tun := getTunnelFlag(); tun != "" {
-		sshClient, err = ssh.NewTunnelledSSHClient(flagSSHUserName, tun, addr, getChecker(), flagSSHAgentForwarding, timeout)
+		sshClient, err = ssh.NewTunnelledSSHClient(globalFlags.SSHUserName, tun, addr, getChecker(), flagSSHAgentForwarding, timeout)
 	} else {
-		sshClient, err = ssh.NewSSHClient(flagSSHUserName, addr, getChecker(), flagSSHAgentForwarding, timeout)
+		sshClient, err = ssh.NewSSHClient(globalFlags.SSHUserName, addr, getChecker(), flagSSHAgentForwarding, timeout)
 	}
 	if err != nil {
 		stderr("Failed building SSH client: %v", err)
@@ -253,9 +251,9 @@ func runRemoteCommand(cmd string, addr string) (err error, exit int) {
 	var sshClient *ssh.SSHForwardingClient
 	timeout := getSSHTimeoutFlag()
 	if tun := getTunnelFlag(); tun != "" {
-		sshClient, err = ssh.NewTunnelledSSHClient(flagSSHUserName, tun, addr, getChecker(), false, timeout)
+		sshClient, err = ssh.NewTunnelledSSHClient(globalFlags.SSHUserName, tun, addr, getChecker(), false, timeout)
 	} else {
-		sshClient, err = ssh.NewSSHClient(flagSSHUserName, addr, getChecker(), false, timeout)
+		sshClient, err = ssh.NewSSHClient(globalFlags.SSHUserName, addr, getChecker(), false, timeout)
 	}
 	if err != nil {
 		return err, -1


### PR DESCRIPTION
I needed this functionality and noticed everything seemed pretty close. My last commit here makes all commands work correctly for me.

There is one caveat that I documented in using-the-client. The `journal` command executes `journalctl` which needs permission to view the journald files. I added a `--sudo` flag to the journal command as a solution but I can't say I'm extremely happy with it but it should work by default since the sudo group is passwordless.

Linking:
Updates #1076 to fix [comment][1] from #904 and should finally close #536

[1]: https://github.com/coreos/fleet/pull/904#issuecomment-55839865