### PR TITLE
status: fix return code for stopped units

### DIFF
--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -81,7 +81,7 @@ func runStatusUnits(args []string) (exit int) {
 		}
 
 		cmd := fmt.Sprintf("systemctl status -l %s", name)
-		if exit := runCommand(cmd, uMap[name].MachineID); exit != 0 {
+		if exit = runCommand(cmd, uMap[name].MachineID); exit != 0 {
 			break
 		}
 	}


### PR DESCRIPTION
Fixes #1021 on github.
If the exit code of systemd is not 0, then return with that exit code.
Previous behavior was to break and return 0.

The github.com/coreos/fleet/ssh test fails on master (at least on arch linux), and my PR does nothing to change that.
I don't see any tests for status. Will any be necessary?