### PR TITLE
functional: ignore errors from poweroff

### DIFF
--- a/functional/platform/nspawn.go
+++ b/functional/platform/nspawn.go
@@ -471,7 +471,11 @@ func (nc *nspawnCluster) ReplaceMember(m Member) (Member, error) {
 	// the nspawn container, so we must use systemctl
 	cmd := fmt.Sprintf("systemctl -M %s poweroff", label)
 	if _, stderr, _ := run(cmd); !strings.Contains(stderr, "Success") {
-		return nil, fmt.Errorf("poweroff failed: %s", stderr)
+		if strings.Contains(stderr, "Warning! D-Bus connection terminated.") {
+			log.Printf("poweroff failed: %s", stderr)
+		} else {
+			return nil, fmt.Errorf("poweroff failed: %s", stderr)
+		}
 	}
 
 	var nm nspawnMember


### PR DESCRIPTION
A follow up to 529209534, tests are constantly failing with a dbus error
which is probably a bug in systemd or systemctl. Not worth spending lots
of time on right now so just ignore it. If the container really fails to
shutdown the wait will eventually time out instead.