### PR TITLE
Ordered task execution

### DIFF
--- a/agent/reconcile_test.go
+++ b/agent/reconcile_test.go
@@ -402,7 +402,7 @@ func TestCalculateTasksForJob(t *testing.T) {
 		cState unitStates
 		uName  string
 
-		chain *taskChain
+		want []task
 	}{
 
 		// nil agent state objects should result in no tasks
@@ -410,7 +410,7 @@ func TestCalculateTasksForJob(t *testing.T) {
 			dState: nil,
 			cState: nil,
 			uName:  "foo.service",
-			chain:  nil,
+			want:   nil,
 		},
 
 		// nil job should result in no tasks
@@ -418,7 +418,7 @@ func TestCalculateTasksForJob(t *testing.T) {
 			dState: NewAgentState(&machine.MachineState{ID: "XXX"}),
 			cState: unitStates{},
 			uName:  "foo.service",
-			chain:  nil,
+			want:   nil,
 		},
 
 		// no work needs to be done when current state == desired state
@@ -436,7 +436,7 @@ func TestCalculateTasksForJob(t *testing.T) {
 				},
 			},
 			uName: "foo.service",
-			chain: nil,
+			want:  nil,
 		},
 
 		// no work needs to be done when current state == desired state
@@ -454,7 +454,7 @@ func TestCalculateTasksForJob(t *testing.T) {
 				},
 			},
 			uName: "foo.service",
-			chain: nil,
+			want:  nil,
 		},
 
 		// when current state == desired state but hash differs, unit should be unloaded and then reloaded
@@ -472,23 +472,29 @@ func TestCalculateTasksForJob(t *testing.T) {
 				},
 			},
 			uName: "foo.service",
-			chain: &taskChain{
-				unit: &job.Unit{
-					Name: "foo.service",
-					Unit: unit.UnitFile{},
+			want: []task{
+				task{
+					typ:    taskTypeUnloadUnit,
+					reason: taskReasonLoadedButHashDiffers,
+					unit: &job.Unit{
+						Name: "foo.service",
+						Unit: unit.UnitFile{},
+					},
 				},
-				tasks: []task{
-					task{
-						typ:    taskTypeUnloadUnit,
-						reason: taskReasonLoadedButHashDiffers,
+				task{
+					typ:    taskTypeLoadUnit,
+					reason: taskReasonScheduledButUnloaded,
+					unit: &job.Unit{
+						Name: "foo.service",
+						Unit: unit.UnitFile{},
 					},
-					task{
-						typ:    taskTypeLoadUnit,
-						reason: taskReasonScheduledButUnloaded,
-					},
-					task{
-						typ:    taskTypeStartUnit,
-						reason: taskReasonLoadedDesiredStateLaunched,
+				},
+				task{
+					typ:    taskTypeStartUnit,
+					reason: taskReasonLoadedDesiredStateLaunched,
+					unit: &job.Unit{
+						Name: "foo.service",
+						Unit: unit.UnitFile{},
 					},
 				},
 			},
@@ -509,19 +515,21 @@ func TestCalculateTasksForJob(t *testing.T) {
 				},
 			},
 			uName: "foo.service",
-			chain: &taskChain{
-				unit: &job.Unit{
-					Name: "foo.service",
-					Unit: unit.UnitFile{},
-				},
-				tasks: []task{
-					task{
-						typ:    taskTypeUnloadUnit,
-						reason: taskReasonLoadedButHashDiffers,
+			want: []task{
+				task{
+					typ:    taskTypeUnloadUnit,
+					reason: taskReasonLoadedButHashDiffers,
+					unit: &job.Unit{
+						Name: "foo.service",
+						Unit: unit.UnitFile{},
 					},
-					task{
-						typ:    taskTypeLoadUnit,
-						reason: taskReasonScheduledButUnloaded,
+				},
+				task{
+					typ:    taskTypeLoadUnit,
+					reason: taskReasonScheduledButUnloaded,
+					unit: &job.Unit{
+						Name: "foo.service",
+						Unit: unit.UnitFile{},
 					},
 				},
 			},
@@ -542,23 +550,29 @@ func TestCalculateTasksForJob(t *testing.T) {
 				},
 			},
 			uName: "foo.service",
-			chain: &taskChain{
-				unit: &job.Unit{
-					Name: "foo.service",
-					Unit: unit.UnitFile{},
+			want: []task{
+				task{
+					typ:    taskTypeUnloadUnit,
+					reason: taskReasonLoadedButHashDiffers,
+					unit: &job.Unit{
+						Name: "foo.service",
+						Unit: unit.UnitFile{},
+					},
 				},
-				tasks: []task{
-					task{
-						typ:    taskTypeUnloadUnit,
-						reason: taskReasonLoadedButHashDiffers,
+				task{
+					typ:    taskTypeLoadUnit,
+					reason: taskReasonScheduledButUnloaded,
+					unit: &job.Unit{
+						Name: "foo.service",
+						Unit: unit.UnitFile{},
 					},
-					task{
-						typ:    taskTypeLoadUnit,
-						reason: taskReasonScheduledButUnloaded,
-					},
-					task{
-						typ:    taskTypeStartUnit,
-						reason: taskReasonLoadedDesiredStateLaunched,
+				},
+				task{
+					typ:    taskTypeStartUnit,
+					reason: taskReasonLoadedDesiredStateLaunched,
+					unit: &job.Unit{
+						Name: "foo.service",
+						Unit: unit.UnitFile{},
 					},
 				},
 			},
@@ -574,7 +588,7 @@ func TestCalculateTasksForJob(t *testing.T) {
 			},
 			cState: unitStates{},
 			uName:  "foo.service",
-			chain:  nil,
+			want:   nil,
 		},
 
 		// load jobs that have a loaded desired state
@@ -587,15 +601,13 @@ func TestCalculateTasksForJob(t *testing.T) {
 			},
 			cState: unitStates{},
 			uName:  "foo.service",
-			chain: &taskChain{
-				unit: &job.Unit{
-					Name: "foo.service",
-					Unit: unit.UnitFile{},
-				},
-				tasks: []task{
-					task{
-						typ:    taskTypeLoadUnit,
-						reason: taskReasonScheduledButUnloaded,
+			want: []task{
+				task{
+					typ:    taskTypeLoadUnit,
+					reason: taskReasonScheduledButUnloaded,
+					unit: &job.Unit{
+						Name: "foo.service",
+						Unit: unit.UnitFile{},
 					},
 				},
 			},
@@ -611,18 +623,19 @@ func TestCalculateTasksForJob(t *testing.T) {
 			},
 			cState: unitStates{},
 			uName:  "foo.service",
-			chain: &taskChain{
-				unit: &job.Unit{
-					Name: "foo.service",
-				},
-				tasks: []task{
-					task{
-						typ:    taskTypeLoadUnit,
-						reason: taskReasonScheduledButUnloaded,
+			want: []task{
+				task{
+					typ:    taskTypeLoadUnit,
+					reason: taskReasonScheduledButUnloaded,
+					unit: &job.Unit{
+						Name: "foo.service",
 					},
-					task{
-						typ:    taskTypeStartUnit,
-						reason: taskReasonLoadedDesiredStateLaunched,
+				},
+				task{
+					typ:    taskTypeStartUnit,
+					reason: taskReasonLoadedDesiredStateLaunched,
+					unit: &job.Unit{
+						Name: "foo.service",
 					},
 				},
 			},
@@ -638,14 +651,12 @@ func TestCalculateTasksForJob(t *testing.T) {
 				},
 			},
 			uName: "foo.service",
-			chain: &taskChain{
-				unit: &job.Unit{
-					Name: "foo.service",
-				},
-				tasks: []task{
-					task{
-						typ:    taskTypeUnloadUnit,
-						reason: taskReasonLoadedButNotScheduled,
+			want: []task{
+				task{
+					typ:    taskTypeUnloadUnit,
+					reason: taskReasonLoadedButNotScheduled,
+					unit: &job.Unit{
+						Name: "foo.service",
 					},
 				},
 			},
@@ -661,14 +672,12 @@ func TestCalculateTasksForJob(t *testing.T) {
 				},
 			},
 			uName: "foo.service",
-			chain: &taskChain{
-				unit: &job.Unit{
-					Name: "foo.service",
-				},
-				tasks: []task{
-					task{
-						typ:    taskTypeUnloadUnit,
-						reason: taskReasonLoadedButNotScheduled,
+			want: []task{
+				task{
+					typ:    taskTypeUnloadUnit,
+					reason: taskReasonLoadedButNotScheduled,
+					unit: &job.Unit{
+						Name: "foo.service",
 					},
 				},
 			},
@@ -691,14 +700,12 @@ func TestCalculateTasksForJob(t *testing.T) {
 				},
 			},
 			uName: "foo.service",
-			chain: &taskChain{
-				unit: &job.Unit{
-					Name: "foo.service",
-				},
-				tasks: []task{
-					task{
-						typ:    taskTypeUnloadUnit,
-						reason: taskReasonLoadedButNotScheduled,
+			want: []task{
+				task{
+					typ:    taskTypeUnloadUnit,
+					reason: taskReasonLoadedButNotScheduled,
+					unit: &job.Unit{
+						Name: "foo.service",
 					},
 				},
 			},
@@ -707,15 +714,9 @@ func TestCalculateTasksForJob(t *testing.T) {
 
 	for i, tt := range tests {
 		ar := NewReconciler(registry.NewFakeRegistry(), nil)
-		chain := ar.calculateTaskChainForUnit(tt.dState, tt.cState, tt.uName)
-		if !reflect.DeepEqual(tt.chain, chain) {
-			t.Errorf("case %d: calculated incorrect task chain\nexpected=%#v\nreceived=%#v\n", i, tt.chain, chain)
-			if c := tt.chain; c != nil {
-				t.Logf("expected Unit: %#v", *c.unit)
-			}
-			if c := chain; c != nil {
-				t.Logf("received Unit: %#v", *c.unit)
-			}
+		got := ar.calculateTasksForUnit(tt.dState, tt.cState, tt.uName)
+		if !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("case %d: calculated incorrect tasks\nexpected=%#v\nreceived=%#v\n", i, tt.want, got)
 		}
 	}
 }

--- a/agent/task_test.go
+++ b/agent/task_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 CoreOS, Inc.
+// Copyright 2015 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,96 +15,75 @@
 package agent
 
 import (
+	"reflect"
+	"sort"
 	"testing"
-	"time"
-
-	"github.com/coreos/fleet/job"
-	"github.com/coreos/fleet/pkg"
 )
 
-func TestTaskManagerTwoInFlight(t *testing.T) {
-	result := make(chan error)
-	testMapper := func(task, *job.Unit, *Agent) (exec func() error, err error) {
-		exec = func() error {
-			return <-result
+func TestTaskSorting(t *testing.T) {
+	tests := []struct {
+		tasks []task
+		want  []task
+	}{
+		// Unload before Load
+		{
+			tasks: []task{
+				task{typ: taskTypeLoadUnit, reason: "A"},
+				task{typ: taskTypeUnloadUnit, reason: "B"},
+			},
+			want: []task{
+				task{typ: taskTypeUnloadUnit, reason: "B"},
+				task{typ: taskTypeLoadUnit, reason: "A"},
+			},
+		},
+
+		// Load before Stop
+		{
+			tasks: []task{
+				task{typ: taskTypeStopUnit, reason: "A"},
+				task{typ: taskTypeLoadUnit, reason: "B"},
+			},
+			want: []task{
+				task{typ: taskTypeLoadUnit, reason: "B"},
+				task{typ: taskTypeStopUnit, reason: "A"},
+			},
+		},
+
+		// Stop before Start
+		{
+			tasks: []task{
+				task{typ: taskTypeStartUnit, reason: "A"},
+				task{typ: taskTypeStopUnit, reason: "B"},
+			},
+			want: []task{
+				task{typ: taskTypeStopUnit, reason: "B"},
+				task{typ: taskTypeStartUnit, reason: "A"},
+			},
+		},
+
+		// Relative ordering preserved when equivalent tasks present
+		{
+			tasks: []task{
+				task{typ: taskTypeLoadUnit, reason: "A"},
+				task{typ: taskTypeStartUnit, reason: "A"},
+				task{typ: taskTypeLoadUnit, reason: "B"},
+				task{typ: taskTypeStartUnit, reason: "B"},
+			},
+			want: []task{
+				task{typ: taskTypeLoadUnit, reason: "A"},
+				task{typ: taskTypeLoadUnit, reason: "B"},
+				task{typ: taskTypeStartUnit, reason: "A"},
+				task{typ: taskTypeStartUnit, reason: "B"},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		got := make([]task, len(tt.tasks))
+		copy(got, tt.tasks)
+		sort.Sort(sortableTasks(got))
+		if !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("case %d: want=%#v got=%#v", i, tt.want, got)
 		}
-		return
 	}
-
-	tm := taskManager{
-		processing: pkg.NewUnsafeSet(),
-		mapper:     testMapper,
-	}
-
-	errchan1, err := tm.Do(taskChain{unit: &job.Unit{Name: "foo"}, tasks: []task{task{typ: "test"}}}, nil)
-	if err != nil {
-		t.Fatalf("unable to start task: %v", err)
-	}
-
-	errchan2, err := tm.Do(taskChain{unit: &job.Unit{Name: "bar"}, tasks: []task{task{typ: "test"}}}, nil)
-	if err != nil {
-		t.Fatalf("unable to start task: %v", err)
-	}
-
-	close(result)
-
-	go func() {
-		<-time.After(time.Second)
-		t.Fatalf("expected errchans to be ready to receive within 1s")
-	}()
-
-	res := <-errchan1
-	if res.err != nil {
-		t.Fatalf("received unexpected error from task one: %v", res.err)
-	}
-
-	res = <-errchan2
-	if res.err != nil {
-		t.Fatalf("received unexpected error from task two: %v", res.err)
-	}
-}
-
-func TestTaskManagerUnitSerialization(t *testing.T) {
-	result := make(chan error)
-	testMapper := func(task, *job.Unit, *Agent) (exec func() error, err error) {
-		exec = func() error {
-			return <-result
-		}
-		return
-	}
-
-	tm := taskManager{
-		processing: pkg.NewUnsafeSet(),
-		mapper:     testMapper,
-	}
-
-	reschan, err := tm.Do(taskChain{unit: &job.Unit{Name: "foo"}, tasks: []task{task{typ: "test"}}}, nil)
-	if err != nil {
-		t.Fatalf("unable to start first task: %v", err)
-	}
-
-	// the first task should block the second, as it is still in progress
-	_, err = tm.Do(taskChain{unit: &job.Unit{Name: "foo"}, tasks: []task{task{typ: "test"}}}, nil)
-	if err == nil {
-		t.Fatalf("expected error from attempt to start second task, got nil")
-	}
-
-	result <- nil
-
-	select {
-	case res := <-reschan:
-		if res.err != nil {
-			t.Errorf("received unexpected error from first task: %v", err)
-		}
-	default:
-		t.Errorf("expected reschan to be ready to receive")
-	}
-
-	// since the first task completed, this third task can start
-	_, err = tm.Do(taskChain{unit: &job.Unit{Name: "foo"}, tasks: []task{task{typ: "test"}}}, nil)
-	if err != nil {
-		t.Fatalf("unable to start third task: %v", err)
-	}
-
-	close(result)
 }


### PR DESCRIPTION
On master, a given fleet agent reconciles its current state against the desired state by generating a set of taskChain objects. A taskChain is a series of tasks that should be executed against a given unit. For example, a new unit is started on an agent with a taskChain containing a LoadUnit and a StartUnit task. A unit file is replaced with a chain of UnloadUnit, LoadUnit, StartUnit. The flaw here, however, is that there isn't any ordering between the execution of the taskChains themselves. So if you have unit foo.service that BindsTo bar.service, fleet will race to start them both, and sometimes foo.service will fail with "No such file or directory" since bar.service may not have actually been written to disk yet.

The alternative proposed here is to throw the taskChain concept out the window in favor of an ordered set of tasks, where each task is executed in serial. Before starting execution, the tasks are sorted such that all LoadUnit tasks are executed before StartUnit tasks. This fixes the "No such file or directory" problems many folks have been running into by making sure all unit files are available on disk before taking any actions on them. The loss of concurrency should not be an issue as fleet already uses the DBus APIs for job control and doesn't actually block on completion.

Fix #900 
Fix #997 
Fix #1003 
Fix #1127 