### PR TITLE
fleetctl: Allow a custom SSH port

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -101,6 +101,7 @@ var (
 		NoBlock       bool
 		BlockAttempts int
 		Fields        string
+		SSHPort       int
 	}{}
 
 	// used to cache MachineStates

--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -27,7 +27,7 @@ var (
 	cmdJournal = &Command{
 		Name:    "journal",
 		Summary: "Print the journal of a unit in the cluster to stdout",
-		Usage:   "[--lines=N] [-f|--follow] <unit>",
+		Usage:   "[--lines=N] [--ssh-port=N] [-f|--follow] <unit>",
 		Run:     runJournal,
 		Description: `Outputs the journal of a unit by connecting to the machine that the unit occupies.
 
@@ -45,6 +45,7 @@ func init() {
 	cmdJournal.Flags.IntVar(&flagLines, "lines", 10, "Number of recent log lines to return")
 	cmdJournal.Flags.BoolVar(&flagFollow, "follow", false, "Continuously print new entries as they are appended to the journal.")
 	cmdJournal.Flags.BoolVar(&flagFollow, "f", false, "Shorthand for --follow")
+	cmdJournal.Flags.IntVar(&sharedFlags.SSHPort, "ssh-port", 22, "Connect to remote hosts over SSH using this TCP port")
 	cmdJournal.Flags.BoolVar(&flagSudo, "sudo", false, "Execute journal command with sudo")
 }
 

--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -24,7 +24,7 @@ import (
 var cmdStatusUnits = &Command{
 	Name:    "status",
 	Summary: "Output the status of one or more units in the cluster",
-	Usage:   "UNIT...",
+	Usage:   "[--ssh-port=N] UNIT...",
 	Description: `Output the status of one or more units currently running in the cluster.
 Supports glob matching of units in the current working directory or matches
 previously started units.
@@ -37,6 +37,10 @@ fleetctl status myservice/*
 
 This command does not work with global units.`,
 	Run: runStatusUnits,
+}
+
+func init() {
+	cmdStatusUnits.Flags.IntVar(&sharedFlags.SSHPort, "ssh-port", 22, "Connect to remote hosts over SSH using this TCP port.")
 }
 
 func runStatusUnits(args []string) (exit int) {


### PR DESCRIPTION
This allows end users to specify a custom SSH port with fleetctl when connecting to machines.

This is code that was split out from PR #961 by @ryandub