### PR TITLE
Use escape format ("%q") in fmt.Sprintf() in status command

### DIFF
--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -78,7 +78,7 @@ func runStatusUnits(args []string) (exit int) {
 			fmt.Printf("\n")
 		}
 
-		cmd := fmt.Sprintf("systemctl status -l %s", name)
+		cmd := fmt.Sprintf("systemctl status -l %q", name)
 		if exit = runCommand(cmd, uMap[name].MachineID); exit != 0 {
 			break
 		}


### PR DESCRIPTION
fixes #1154 allowing support for `systemd-escape`ed filenames in status command while tunneling.