### PR TITLE
Call DaemonReload after all Load/Unload operations complete

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -84,6 +84,10 @@ func (a *Agent) heartbeatJobs(ttl time.Duration, stop chan bool) {
 	}
 }
 
+func (a *Agent) reloadUnitFiles() error {
+	return a.um.ReloadUnitFiles()
+}
+
 func (a *Agent) loadUnit(u *job.Unit) error {
 	a.cache.setTargetState(u.Name, job.JobStateLoaded)
 	a.uGen.Subscribe(u.Name)

--- a/agent/reconcile.go
+++ b/agent/reconcile.go
@@ -176,7 +176,20 @@ func (ar *AgentReconciler) calculateTasksForUnits(dState *AgentState, cState uni
 		tasks = append(tasks, ar.calculateTasksForUnit(dState, cState, name)...)
 	}
 
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	reloadTask := task{typ: taskTypeReloadUnitFiles, reason: taskReasonAlwaysReloadUnitFiles}
+	tasks = append(tasks, reloadTask)
+
 	sort.Sort(sortableTasks(tasks))
+
+	// reload unnecessary if no UnloadUnit/LoadUnit tasks
+	if tasks[0].typ == taskTypeReloadUnitFiles {
+		tasks = tasks[1:]
+	}
+
 	return tasks
 }
 
@@ -305,10 +318,15 @@ func (ar *AgentReconciler) launchTasks(tasks []task, a *Agent) {
 	log.Debugf("AgentReconciler attempting tasks %s", tasks)
 	results := ar.tManager.Do(tasks, a)
 	for _, res := range results {
+		unitName := "N/A"
+		if res.task.unit != nil {
+			unitName = res.task.unit.Name
+		}
+
 		if res.err == nil {
-			log.Infof("AgentReconciler completed task: type=%s job=%s reason=%q", res.task.typ, res.task.unit.Name, res.task.reason)
+			log.Infof("AgentReconciler completed task: type=%s job=%s reason=%q", res.task.typ, unitName, res.task.reason)
 		} else {
-			log.Infof("AgentReconciler task failed: type=%s job=%s reason=%q err=%v", res.task.typ, res.task.unit.Name, res.task.reason, res.err)
+			log.Infof("AgentReconciler task failed: type=%s job=%s reason=%q err=%v", res.task.typ, unitName, res.task.reason, res.err)
 		}
 	}
 }

--- a/agent/reconcile.go
+++ b/agent/reconcile.go
@@ -171,8 +171,11 @@ func (ar *AgentReconciler) calculateTasksForUnits(dState *AgentState, cState uni
 		jobs.Add(dName)
 	}
 
+	sorted := sort.StringSlice(jobs.Values())
+	sorted.Sort()
+
 	var tasks []task
-	for _, name := range jobs.Values() {
+	for _, name := range sorted {
 		tasks = append(tasks, ar.calculateTasksForUnit(dState, cState, name)...)
 	}
 

--- a/agent/task.go
+++ b/agent/task.go
@@ -21,10 +21,11 @@ import (
 )
 
 const (
-	taskTypeLoadUnit   = "LoadUnit"
-	taskTypeUnloadUnit = "UnloadUnit"
-	taskTypeStartUnit  = "StartUnit"
-	taskTypeStopUnit   = "StopUnit"
+	taskTypeLoadUnit        = "LoadUnit"
+	taskTypeUnloadUnit      = "UnloadUnit"
+	taskTypeStartUnit       = "StartUnit"
+	taskTypeStopUnit        = "StopUnit"
+	taskTypeReloadUnitFiles = "ReloadUnitFiles"
 
 	taskReasonScheduledButNotRunnable    = "unit scheduled locally but unable to run"
 	taskReasonScheduledButUnloaded       = "unit scheduled here but not loaded"
@@ -33,6 +34,7 @@ const (
 	taskReasonLoadedDesiredStateLaunched = "unit currently loaded but desired state is launched"
 	taskReasonLaunchedDesiredStateLoaded = "unit currently launched but desired state is loaded"
 	taskReasonPurgingAgent               = "purging agent"
+	taskReasonAlwaysReloadUnitFiles      = "always reload unit files"
 )
 
 type task struct {
@@ -42,10 +44,11 @@ type task struct {
 }
 
 var taskTypeSortOrder = map[string]int{
-	taskTypeUnloadUnit: 1,
-	taskTypeLoadUnit:   2,
-	taskTypeStopUnit:   3,
-	taskTypeStartUnit:  4,
+	taskTypeUnloadUnit:      1,
+	taskTypeLoadUnit:        2,
+	taskTypeReloadUnitFiles: 3,
+	taskTypeStopUnit:        4,
+	taskTypeStartUnit:       5,
 }
 
 type sortableTasks []task
@@ -106,6 +109,8 @@ func mapTaskToFunc(t task, a *Agent) (fn func() error, err error) {
 		fn = func() error { a.startUnit(t.unit.Name); return nil }
 	case taskTypeStopUnit:
 		fn = func() error { a.stopUnit(t.unit.Name); return nil }
+	case taskTypeReloadUnitFiles:
+		fn = func() error { return a.reloadUnitFiles() }
 	default:
 		err = fmt.Errorf("unrecognized task type %q", t.typ)
 	}

--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -109,7 +109,7 @@ func (m *systemdUnitManager) Load(name string, u unit.UnitFile) error {
 	}
 	m.hashes[name] = u.Hash()
 	if m.unitRequiresDaemonReload(name) {
-		return m.daemonReload()
+		return m.ReloadUnitFiles()
 	}
 	return nil
 }
@@ -192,7 +192,7 @@ func (m *systemdUnitManager) unitRequiresDaemonReload(name string) bool {
 	return prop.Value.Value().(bool)
 }
 
-func (m *systemdUnitManager) daemonReload() error {
+func (m *systemdUnitManager) ReloadUnitFiles() error {
 	log.Infof("Instructing systemd to reload units")
 	return m.systemd.Reload()
 }

--- a/unit/fake.go
+++ b/unit/fake.go
@@ -37,6 +37,10 @@ func (fum *FakeUnitManager) Load(name string, u UnitFile) error {
 	return nil
 }
 
+func (fum *FakeUnitManager) ReloadUnitFiles() error {
+	return nil
+}
+
 func (fum *FakeUnitManager) Unload(name string) {
 	fum.Lock()
 	defer fum.Unlock()

--- a/unit/manager.go
+++ b/unit/manager.go
@@ -21,6 +21,7 @@ import (
 type UnitManager interface {
 	Load(string, UnitFile) error
 	Unload(string)
+	ReloadUnitFiles() error
 
 	TriggerStart(string)
 	TriggerStop(string)


### PR DESCRIPTION
This eliminates the raciness of calling DaemonReload during reconciliation by making it an explicit task that gets executed after all LoadUnit & UnloadUnit tasks complete.

Fix #1158.