### PR TITLE
fleetctl: Add ssh-port info to ssh runCommand func

### DIFF
--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -226,7 +226,8 @@ func runCommand(cmd string, machID string) (retcode int) {
 		if err != nil || ms == nil {
 			stderr("Error getting machine IP: %v", err)
 		} else {
-			err, retcode = runRemoteCommand(cmd, ms.PublicIP)
+			addr := findSSHPort(ms.PublicIP)
+			err, retcode = runRemoteCommand(cmd, addr)
 			if err != nil {
 				stderr("Error running remote command: %v", err)
 			}


### PR DESCRIPTION
#1148 added in the `ssh-port` flag to fleetctl (thanks @hhoover !!). However, there was a slight omission in `ssh.go` to add the port context to `runCommand`. This adds that info so that `--ssh-port` works as expected.