### PR TITLE
api: be more specific when unavailable

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -66,5 +66,5 @@ func (s *Server) Available(stop chan bool) {
 type unavailableHdlr struct{}
 
 func (uh *unavailableHdlr) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	sendError(rw, http.StatusServiceUnavailable, errors.New("fleet server currently unavailable"))
+	sendError(rw, http.StatusServiceUnavailable, errors.New("fleet server unable to communicate with etcd"))
 }


### PR DESCRIPTION
This does not address all aspects of #1203, but it does take an important step towards directing the user to etcd. Here's what a user will see now:

```
Error retrieving list of active machines: googleapi: Error 503: fleet server unable to communicate with etcd
```