### PR TITLE
fleetd: support the version command

### DIFF
--- a/fleetd/fleet.go
+++ b/fleetd/fleet.go
@@ -48,7 +48,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *printVersion {
+	if *printVersion || userset.Args()[0] == "version" {
 		fmt.Println("fleetd version", version.Version)
 		os.Exit(0)
 	}


### PR DESCRIPTION
Now support "fleetd version" and "fleetd --version"

Fixes #1210