### PR TITLE
fleetd: fix support for "fleetd version"

### DIFF
--- a/fleetd/fleet.go
+++ b/fleetd/fleet.go
@@ -48,7 +48,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *printVersion || userset.Args()[0] == "version" {
+	args := userset.Args()
+	if len(args) == 1 && args[0] == "version" {
+		*printVersion = true
+	} else if len(args) != 0 {
+		userset.Usage()
+		os.Exit(1)
+	}
+
+	if *printVersion {
 		fmt.Println("fleetd version", version.Version)
 		os.Exit(0)
 	}


### PR DESCRIPTION
Commit 32a51814 broke fleetd, making "fleetd version" the *only* thing it
could do and causing a index error panic otherwise. Now in addition to
properly checking the number of unparsed args exit with a usage error if
given any other unknown arguments.

Simply exiting if there are any unparsed args would have been sufficient
to fix #1210 but on the other hand allowing "fleetd version" doesn't
hurt so might as well keep it.

Fixes #1214 and #1210