### PR TITLE
fleetctl: fix issue that status command cannot find unit name

### DIFF
--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -82,7 +82,7 @@ func runStatusUnits(args []string) (exit int) {
 			fmt.Printf("\n")
 		}
 
-		cmd := fmt.Sprintf("systemctl status -l %q", name)
+		cmd := fmt.Sprintf("systemctl status -l %s", name)
 		if exit = runCommand(cmd, uMap[name].MachineID); exit != 0 {
 			break
 		}


### PR DESCRIPTION
In func runStatusUnits, fmt.Sprintf("systemctl status -l %q", name)
will get the cmd as 'systemctl status -l \"name\"', there are
double quotation marks embrace unit name. When the whole command
got passed to systemd, in my pc is version 208, systemd cannot find
the unit file as per the name because of the double quotation marks.
It gives error as below:
[root@localhost fleet-0.10.1]# fleetctl --endpoint="http://127.0.0.1:4001" 
status hello.service
   \x22hello.service\x22.service
   Loaded: not-found (Reason: No such file or directory)
   Active: inactive (dead)
The \x22 is the double quotation marks. Modify "%q" to "%s", then
the command will be passed to systemd without double quotation
marks.

Fixes #1224