### PR TITLE
Revert "fleetctl: use correct escape format in status command"

### DIFF
--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -82,7 +82,7 @@ func runStatusUnits(args []string) (exit int) {
 			fmt.Printf("\n")
 		}
 
-		cmd := fmt.Sprintf("systemctl status -l %q", name)
+		cmd := fmt.Sprintf("systemctl status -l %s", name)
 		if exit = runCommand(cmd, uMap[name].MachineID); exit != 0 {
 			break
 		}


### PR DESCRIPTION
This reverts commit 9b8ee4b5b67d4086de0a1cd72237f9a1cae5bf8e.

This was breaking all remote fleetctl status commands as they were
passing escaped quotes to systemctl.