### PR TITLE
fleetctl: properly run local and remote commands

### DIFF
--- a/fleetctl/journal.go
+++ b/fleetctl/journal.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/coreos/fleet/job"
 )
@@ -71,15 +71,15 @@ func runJournal(args []string) (exit int) {
 		return 1
 	}
 
-	command := fmt.Sprintf("journalctl --unit %s --no-pager -n %d", name, flagLines)
+	cmd := []string{"journalctl", "--unit", name, "--no-pager", "-n", strconv.Itoa(flagLines)}
 
 	if flagSudo {
-		command = "sudo " + command
+		cmd = append([]string{"sudo"}, cmd...)
 	}
 
 	if flagFollow {
-		command += " -f"
+		cmd = append(cmd, "-f")
 	}
 
-	return runCommand(command, u.MachineID)
+	return runCommand(u.MachineID, cmd[0], cmd[1:]...)
 }

--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -82,8 +82,7 @@ func runStatusUnits(args []string) (exit int) {
 			fmt.Printf("\n")
 		}
 
-		cmd := fmt.Sprintf("systemctl status -l %s", name)
-		if exit = runCommand(cmd, uMap[name].MachineID); exit != 0 {
+		if exit = runCommand(uMap[name].MachineID, "systemctl", "status", "-l", name); exit != 0 {
 			break
 		}
 	}


### PR DESCRIPTION
Remote commands need to be escaped because they are being interpretted
by a shell. Local commands, however, cannot be because they are being
exec'd. Additionally, splitting an opaque command by space is very error
prone (e.g. `ls "dumb filename"`).