### PR TITLE
Scale hack

### DIFF
--- a/pkg/reconcile_test.go
+++ b/pkg/reconcile_test.go
@@ -77,7 +77,8 @@ func TestPeriodicReconcilerRun(t *testing.T) {
 	select {
 	case <-called:
 	case <-time.After(time.Second):
-		t.Fatalf("rFunc() not called after trigger!")
+		// XXX(miek): Intentionally, as we disabled the eventstream.
+		t.Logf("rFunc() not called after trigger!")
 	}
 	// assert rFunc was only called once
 	select {
@@ -90,7 +91,8 @@ func TestPeriodicReconcilerRun(t *testing.T) {
 	select {
 	case <-called:
 	case <-time.After(time.Second):
-		t.Fatalf("rFunc() not called after trigger!")
+		// XXX(miek): Intentionally, as we disabled the eventstream.
+		t.Logf("rFunc() not called after trigger!")
 	}
 	// again, assert rFunc was only called once
 	select {
@@ -109,7 +111,8 @@ func TestPeriodicReconcilerRun(t *testing.T) {
 	select {
 	case <-called:
 	case <-time.After(time.Second):
-		t.Fatalf("rFunc() not called after time event!")
+		// XXX(miek): Intentionally, as we disabled the eventstream.
+		t.Logf("rFunc() not called after time event!")
 	}
 
 	// stop the PeriodicReconciler

--- a/registry/event.go
+++ b/registry/event.go
@@ -17,12 +17,9 @@ package registry
 import (
 	"path"
 	"strings"
-	"time"
 
 	etcd "github.com/coreos/fleet/Godeps/_workspace/src/github.com/coreos/etcd/client"
-	"github.com/coreos/fleet/Godeps/_workspace/src/golang.org/x/net/context"
 
-	"github.com/coreos/fleet/log"
 	"github.com/coreos/fleet/pkg"
 )
 
@@ -87,30 +84,31 @@ func parse(res *etcd.Response, prefix string) (ev pkg.Event, ok bool) {
 }
 
 func watch(kAPI etcd.KeysAPI, key string, stop chan struct{}) (res *etcd.Response) {
-	for res == nil {
-		select {
-		case <-stop:
-			log.Debugf("Gracefully closing etcd watch loop: key=%s", key)
-			return
-		default:
-			opts := &etcd.WatcherOptions{
-				AfterIndex: 0,
-				Recursive:  true,
-			}
-			watcher := kAPI.Watcher(key, opts)
-			log.Debugf("Creating etcd watcher: %s", key)
+	/*
+		for res == nil {
+			select {
+			case <-stop:
+				log.Debugf("Gracefully closing etcd watch loop: key=%s", key)
+				return
+			default:
+				opts := &etcd.WatcherOptions{
+					AfterIndex: 0,
+					Recursive:  true,
+				}
+				watcher := kAPI.Watcher(key, opts)
+				log.Debugf("Creating etcd watcher: %s", key)
 
-			var err error
-			res, err = watcher.Next(context.Background())
-			if err != nil {
-				log.Errorf("etcd watcher %v returned error: %v", key, err)
+				var err error
+				res, err = watcher.Next(context.Background())
+				if err != nil {
+					log.Errorf("etcd watcher %v returned error: %v", key, err)
+				}
 			}
+
+			// Let's not slam the etcd server in the event that we know
+			// an unexpected error occurred.
+			time.Sleep(time.Second)
 		}
-
-		// Let's not slam the etcd server in the event that we know
-		// an unexpected error occurred.
-		time.Sleep(time.Second)
-	}
-
+	*/
 	return
 }


### PR DESCRIPTION
Comment out the use of Etcd watches and only do time-based wake-ups. Add jitter to not have the whole cluster wake-up at the same time (make it even more less likely).

Note: this PR is rather *hackish*, it would be nice to know if something like will be considered for merging (if cleaned up, etc .etc.). IOW: comments welcome!