### PR TITLE
fleetd: support conflict in global unit

### DIFF
--- a/Documentation/unit-files-and-scheduling.md
+++ b/Documentation/unit-files-and-scheduling.md
@@ -22,7 +22,7 @@ Note that these requirements are derived directly from systemd, with the only ex
 | `MachineOf` | Limit eligible machines to the one that hosts a specific unit. |
 | `MachineMetadata` | Limit eligible machines to those with this specific metadata. |
 | `Conflicts` | Prevent a unit from being collocated with other units using glob-matching on the other unit names. |
-| `Global` | Schedule this unit on all agents in the cluster. A unit is considered invalid if options other than `MachineMetadata` are provided alongside `Global=true`. |
+| `Global` | Schedule this unit on those agents in the cluster, which satisfy the conditions of both `MachineMetadata` and `Conflicts` if any of them is also given. A unit is considered invalid if options other than `MachineMetadata` and `Conflicts` are provided alongside `Global=true`. If `MachineMetadata` is provided alongside `Global=true`, only the agents having the metadata can be scheduled on. If `Conflicts` is provided alongside `Global=true`, only the agents not having the conflicting units can be scheduled on. The conflicting units also can not be scheduled on the agents which already have the existing conflicting global unit.|
 
 See [more information](#unit-scheduling) on these parameters and how they impact scheduling decisions.
 

--- a/agent/reconcile.go
+++ b/agent/reconcile.go
@@ -141,17 +141,36 @@ func desiredAgentState(a *Agent, reg registry.Registry) (*AgentState, error) {
 
 	for _, u := range units {
 		u := u
+
+		if u.IsGlobal() {
+			continue
+		}
+
+		sUnit, ok := sUnitMap[u.Name]
+		if !ok || sUnit.TargetMachineID == "" || sUnit.TargetMachineID != ms.ID {
+			continue
+		}
+
+		as.Units[u.Name] = &u
+	}
+
+	for _, u := range units {
+		u := u
 		md := u.RequiredTargetMetadata()
-		if u.IsGlobal() && !machine.HasMetadata(&ms, md) {
+
+		if !u.IsGlobal() {
+			continue
+		}
+
+		if !machine.HasMetadata(&ms, md) {
 			log.Debugf("Agent unable to run global unit %s: missing required metadata", u.Name)
 			continue
 		}
-		if !u.IsGlobal() {
-			sUnit, ok := sUnitMap[u.Name]
-			if !ok || sUnit.TargetMachineID == "" || sUnit.TargetMachineID != ms.ID {
-				continue
-			}
+
+		if cExists, _ := as.HasConflict(u.Name, u.Conflicts()); cExists {
+			continue
 		}
+
 		as.Units[u.Name] = &u
 	}
 

--- a/agent/state.go
+++ b/agent/state.go
@@ -39,8 +39,8 @@ func (as *AgentState) unitScheduled(name string) bool {
 	return as.Units[name] != nil
 }
 
-// hasConflict determines whether there are any known conflicts with the given Unit
-func (as *AgentState) hasConflict(pUnitName string, pConflicts []string) (found bool, conflict string) {
+// HasConflict determines whether there are any known conflicts with the given Unit
+func (as *AgentState) HasConflict(pUnitName string, pConflicts []string) (found bool, conflict string) {
 	for _, eUnit := range as.Units {
 		if pUnitName == eUnit.Name {
 			continue
@@ -102,7 +102,7 @@ func (as *AgentState) AbleToRun(j *job.Job) (bool, string) {
 		}
 	}
 
-	if cExists, cJobName := as.hasConflict(j.Name, j.Conflicts()); cExists {
+	if cExists, cJobName := as.HasConflict(j.Name, j.Conflicts()); cExists {
 		return false, fmt.Sprintf("found conflict with locally-scheduled Unit(%s)", cJobName)
 	}
 

--- a/agent/state_test.go
+++ b/agent/state_test.go
@@ -85,7 +85,7 @@ func TestHasConflicts(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		got, conflict := tt.cState.hasConflict(tt.job.Name, tt.job.Conflicts())
+		got, conflict := tt.cState.HasConflict(tt.job.Name, tt.job.Conflicts())
 		if got != tt.want {
 			var msg string
 			if tt.want == true {

--- a/api/units.go
+++ b/api/units.go
@@ -211,8 +211,6 @@ func ValidateOptions(opts []*schema.UnitOption) error {
 		return errors.New("MachineID cannot be used with Global")
 	case isGlobal && hasPeers:
 		return errors.New("Global cannot be used with Peers")
-	case isGlobal && hasConflicts:
-		return errors.New("Global cannot be used with Conflicts")
 	}
 
 	return nil

--- a/api/units_test.go
+++ b/api/units_test.go
@@ -584,7 +584,7 @@ func TestValidateOptions(t *testing.T) {
 				},
 				makeConflictUO("foo.service"),
 			},
-			false,
+			true,
 		},
 		{
 			[]*schema.UnitOption{
@@ -595,7 +595,7 @@ func TestValidateOptions(t *testing.T) {
 				},
 				makeConflictUO("bar.service"),
 			},
-			false,
+			true,
 		},
 		{
 			[]*schema.UnitOption{

--- a/api/units_test.go
+++ b/api/units_test.go
@@ -574,7 +574,7 @@ func TestValidateOptions(t *testing.T) {
 			},
 			true,
 		},
-		// Global with Peers/Conflicts no good
+		// Global with Conflicts is ok
 		{
 			[]*schema.UnitOption{
 				&schema.UnitOption{
@@ -597,6 +597,7 @@ func TestValidateOptions(t *testing.T) {
 			},
 			true,
 		},
+		// Global with peer no good
 		{
 			[]*schema.UnitOption{
 				&schema.UnitOption{

--- a/engine/state.go
+++ b/engine/state.go
@@ -93,9 +93,14 @@ func (cs *clusterState) agents() map[string]*agent.AgentState {
 	for _, gu := range cs.gUnits {
 		gu := gu
 		for _, a := range agents {
-			if machine.HasMetadata(a.MState, gu.RequiredTargetMetadata()) {
-				a.Units[gu.Name] = gu
+			if !machine.HasMetadata(a.MState, gu.RequiredTargetMetadata()) {
+				continue
 			}
+
+			if cExists, _ := a.HasConflict(gu.Name, gu.Conflicts()); cExists {
+				continue
+			}
+			a.Units[gu.Name] = gu
 		}
 	}
 

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -165,26 +165,26 @@ func TestCreateUnitFails(t *testing.T) {
 		{
 			"foo.service",
 			newUnitFile(t, `[X-Fleet]
-	MachineOf=abcd
-	Conflicts=abcd`),
+			MachineOf=abcd
+			Conflicts=abcd`),
 		},
 		{
 			"foo.service",
 			newUnitFile(t, `[X-Fleet]
-MachineOf=abcd
-Conflicts=abcd`),
+			MachineOf=abcd
+			Conflicts=abcd`),
 		},
 		{
 			"foo.service",
 			newUnitFile(t, `[X-Fleet]
-Global=true
-MachineOf=abcd`),
+			Global=true
+			MachineOf=abcd`),
 		},
 		{
 			"foo.service",
 			newUnitFile(t, `[X-Fleet]
-Global=true
-MachineOf=zxcvq`),
+			Global=true
+			MachineOf=zxcvq`),
 		},
 	}
 	for i, tt = range testCases {

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -186,12 +186,6 @@ MachineOf=abcd`),
 Global=true
 MachineOf=zxcvq`),
 		},
-		{
-			"foo.service",
-			newUnitFile(t, `[X-Fleet]
-Global=true
-Conflicts=bar`),
-		},
 	}
 	for i, tt = range testCases {
 		un = tt.name


### PR DESCRIPTION
In global unit, support Conflict flag. So in
some machine, the unit will not be launched.

Fixes #1109