### PR TITLE
fleetctl: Support truthy values in boolean unit options

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -113,7 +113,8 @@ func (u *Unit) IsGlobal() bool {
 	}
 	// Last value found wins
 	last := values[len(values)-1]
-	return strings.ToLower(last) == "true"
+	lastLower := strings.ToLower(last)
+	return lastLower == "true" || lastLower == "yes" || lastLower == "1" || lastLower == "on" || lastLower == "t"
 }
 
 // NewJob creates a new Job based on the given name and Unit.

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -504,6 +504,11 @@ func TestUnitIsGlobal(t *testing.T) {
 		// correct specifications
 		{"[X-Fleet]\nMachineOf=foo\nGlobal=true", true},
 		{"[X-Fleet]\nMachineOf=foo\nGlobal=True", true},
+		{"[X-Fleet]\nMachineOf=foo\nGlobal=Yes", true},
+		{"[X-Fleet]\nMachineOf=foo\nGlobal=On", true},
+		{"[X-Fleet]\nMachineOf=foo\nGlobal=1", true},
+		{"[X-Fleet]\nMachineOf=foo\nGlobal=t", true},
+		{"[X-Fleet]\nMachineOf=foo\nGlobal=12", false},
 		// multiple parameters - last wins
 		{"[X-Fleet]\nGlobal=true\nGlobal=false", false},
 		{"[X-Fleet]\nGlobal=false\nGlobal=true", true},


### PR DESCRIPTION
Support truthy values in boolean unit options(yes, on, 1, t)

Fixes #1108