### PR TITLE
fleetctl: list-unit-files fully populated for global units

### DIFF
--- a/fleetctl/list_unit_files.go
+++ b/fleetctl/list_unit_files.go
@@ -68,7 +68,45 @@ var (
 		"target":   mapTargetField,
 		"tmachine": mapTargetField,
 		"state": func(u schema.Unit, full bool) string {
-			if suToGlobal(u) || u.CurrentState == "" {
+			if suToGlobal(u) {
+				states, err := cAPI.UnitStates()
+				if err != nil {
+					return "-"
+				}
+				var (
+					inactive      int
+					loaded        int
+					launched      int
+					currentStates []string
+				)
+				for _, state := range states {
+					if state.Name == u.Name {
+						if (state.SystemdActiveState == "active") || (state.SystemdSubState == "running") {
+							launched++
+							continue
+						}
+						if state.SystemdLoadState == "loaded" {
+							loaded++
+							continue
+						}
+						inactive++
+					}
+				}
+				if launched != 0 {
+					s := fmt.Sprintf("launched(%d)", launched)
+					currentStates = append(currentStates, s)
+				}
+				if loaded != 0 {
+					s := fmt.Sprintf("loaded(%d)", loaded)
+					currentStates = append(currentStates, s)
+				}
+				if inactive != 0 {
+					s := fmt.Sprintf("inactive(%d)", inactive)
+					currentStates = append(currentStates, s)
+				}
+				return strings.Join(currentStates, " ")
+			}
+			if u.CurrentState == "" {
 				return "-"
 			}
 			return u.CurrentState


### PR DESCRIPTION
Now, fleetctl list-unit-files command can show exact number
of the machines running the unit in STATE column as below:

localhost # fleetctl list-unit-files
UNIT                    HASH    DSTATE          STATE           TARGET
world_glob.service      66439c2 launched        launched(2)     global

Fixes #1072