### PR TITLE
fleetd: Detecting the existing machine-id

### DIFF
--- a/heart/heart.go
+++ b/heart/heart.go
@@ -24,6 +24,7 @@ import (
 type Heart interface {
 	Beat(time.Duration) (uint64, error)
 	Clear() error
+	Register(time.Duration) (uint64, error)
 }
 
 func New(reg registry.Registry, mach machine.Machine) Heart {
@@ -33,6 +34,10 @@ func New(reg registry.Registry, mach machine.Machine) Heart {
 type machineHeart struct {
 	reg  registry.Registry
 	mach machine.Machine
+}
+
+func (h *machineHeart) Register(ttl time.Duration) (uint64, error) {
+	return h.reg.CreateMachineState(h.mach.State(), ttl)
 }
 
 func (h *machineHeart) Beat(ttl time.Duration) (uint64, error) {

--- a/registry/interface.go
+++ b/registry/interface.go
@@ -26,6 +26,7 @@ import (
 
 type Registry interface {
 	ClearUnitHeartbeat(name string)
+	CreateMachineState(ms machine.MachineState, ttl time.Duration) (uint64, error)
 	CreateUnit(*job.Unit) error
 	DestroyUnit(string) error
 	UnitHeartbeat(name, machID string, ttl time.Duration) error

--- a/registry/machine.go
+++ b/registry/machine.go
@@ -61,6 +61,25 @@ func (r *EtcdRegistry) Machines() (machines []machine.MachineState, err error) {
 	return
 }
 
+func (r *EtcdRegistry) CreateMachineState(ms machine.MachineState, ttl time.Duration) (uint64, error) {
+	val, err := marshal(ms)
+	if err != nil {
+		return uint64(0), err
+	}
+
+	key := r.prefixed(machinePrefix, ms.ID, "object")
+	opts := &etcd.SetOptions{
+		PrevExist: etcd.PrevNoExist,
+		TTL:       ttl,
+	}
+	resp, err := r.kAPI.Set(r.ctx(), key, val, opts)
+	if err != nil {
+		return uint64(0), err
+	}
+
+	return resp.Node.ModifiedIndex, nil
+}
+
 func (r *EtcdRegistry) SetMachineState(ms machine.MachineState, ttl time.Duration) (uint64, error) {
 	val, err := marshal(ms)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -158,10 +158,11 @@ func (s *Server) Run() {
 
 	var err error
 	for sleep := time.Second; ; sleep = pkg.ExpBackoff(sleep, time.Minute) {
-		_, err = s.hrt.Beat(s.mon.TTL)
+		_, err = s.hrt.Register(s.mon.TTL)
 		if err == nil {
 			break
 		}
+		log.Errorf("Server register machine failed: %v", err)
 		time.Sleep(sleep)
 	}
 


### PR DESCRIPTION
Now support detecting the existing machine-id on startup.

Fixes #1241 #615