### PR TITLE
fleetctl: Remove unit content from etcd

### DIFF
--- a/registry/job.go
+++ b/registry/job.go
@@ -290,7 +290,12 @@ func (r *EtcdRegistry) DestroyUnit(name string) error {
 	opts := &etcd.DeleteOptions{
 		Recursive: true,
 	}
-	_, err := r.kAPI.Delete(r.ctx(), key, opts)
+	u, err := r.Unit(name)
+	if err != nil {
+		log.Warningf("r.Unit error, name=%s\n", name)
+		u = nil
+	}
+	_, err = r.kAPI.Delete(r.ctx(), key, opts)
 	if err != nil {
 		if isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
 			err = errors.New("job does not exist")
@@ -300,6 +305,17 @@ func (r *EtcdRegistry) DestroyUnit(name string) error {
 	}
 
 	// TODO(jonboulle): add unit reference counting and actually destroying Units
+	if u != nil { //delete unit
+		path := u.Unit.Hash().String()
+		key = r.prefixed(unitPrefix, path)
+		_, err = r.kAPI.Delete(r.ctx(), key, opts)
+		if err != nil {
+			if isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
+				err = errors.New("unit does not exist")
+			}
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fleetctl destroy unit does not remove the unit file content from
etcd registry(/_coreos.com/fleet/unit/XXXX). It will cause so
many junk to leave in the etcd. The modification removes it from
etcd when destroying unit.

Fixes #1290