### PR TITLE
fleetctl: Give DEBUG print if need wait for launch when start unit

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -779,7 +779,12 @@ func assertUnitState(name string, js job.JobState, out io.Writer) (ret bool) {
 		log.Warningf("Error retrieving Unit(%s) from Registry: %v", name, err)
 		return
 	}
-	if u == nil || job.JobState(u.CurrentState) != js {
+	if u == nil {
+		log.Warningf("Unit %s not found", name)
+		return
+	}
+	if job.JobState(u.CurrentState) != js {
+		log.Debugf("Waiting for Unit(%s) state(%s) to be %s", name, job.JobState(u.CurrentState), js)
 		return
 	}
 


### PR DESCRIPTION
When start unit, if [X-Fleet] give peer by "MachineOf=", the
fleetctl cannot know the exact reason. Only fleetd check the peer.
But still we can give a DEBUG print to inform launch is happing.
It's not the problem that the peer is not existing. After the
peer is running, the fleetctl will go on to the end. So just
add a debug print if --debug=true is given to fleetctl.

Fixes #1146