### PR TITLE
fleetd: support operators in metadata

### DIFF
--- a/Documentation/unit-files-and-scheduling.md
+++ b/Documentation/unit-files-and-scheduling.md
@@ -125,6 +125,14 @@ MachineMetadata=region=us-west-1
 
 This would allow a machine to match just one of the provided values to be considered eligible to run.
 
+`MachineMetadata` also support relational operators, including `<=`, `>=`, `<`, `>` and `!=`:
+
+```
+[X-Fleet]
+MachineMetadata=ram<1024
+```
+This requires an eligible machine to have the `ram` less than 1024. The value must be numeral when using `<=`, `>=`, `<` or `>`.
+
 A machine is not automatically configured with metadata.
 A deployer may define machine metadata using the `metadata` [config option](https://github.com/coreos/fleet/blob/master/Documentation/deployment-and-configuration.md#metadata).
 

--- a/job/job.go
+++ b/job/job.go
@@ -260,7 +260,17 @@ func (j *Job) RequiredTargetMetadata() map[string]pkg.Set {
 		fleetMachineMetadata,
 	} {
 		for _, valuePair := range j.requirements()[key] {
-			s := strings.Split(valuePair, "=")
+			var s []string
+			for _, sep := range []string{"<=", ">=", "!=", "<", ">"} {
+				index := strings.Index(valuePair, sep)
+				if index != -1 {
+					s = []string{valuePair[0:index], valuePair[index:]}
+					break
+				}
+			}
+			if s == nil {
+				s = strings.Split(valuePair, "=")
+			}
 
 			if len(s) != 2 {
 				continue

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -15,6 +15,9 @@
 package machine
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/coreos/fleet/log"
 	"github.com/coreos/fleet/pkg"
 )
@@ -38,8 +41,81 @@ func HasMetadata(state *MachineState, metadata map[string]pkg.Set) bool {
 		if values.Contains(local) {
 			log.Debugf("Local Metadata(%s) meets requirement", key)
 		} else {
-			log.Debugf("Local Metadata(%s) does not match requirement", key)
-			return false
+			vs := values.Values()
+			for _, v := range vs {
+				if index := strings.Index(v, "<="); strings.Contains(v, "<=") && (index == 0) {
+					need, err1 := strconv.Atoi(v[2:])
+					have, err2 := strconv.Atoi(local)
+					if err1 == nil && err2 == nil {
+						if have <= need {
+							log.Debugf("Local Metadata(%s) meets requirement", key)
+							continue
+						} else {
+							log.Debugf("Local Metadata(%s) does not match requirement", key)
+							return false
+						}
+					} else {
+						log.Debugf("Local Metadata(%s) does not match requirement", key)
+						return false
+					}
+				} else if index := strings.Index(v, ">="); strings.Contains(v, ">=") && (index == 0) {
+					need, err1 := strconv.Atoi(v[2:])
+					have, err2 := strconv.Atoi(local)
+					if err1 == nil && err2 == nil {
+						if have >= need {
+							log.Debugf("Local Metadata(%s) meets requirement", key)
+							continue
+						} else {
+							log.Debugf("Local Metadata(%s) does not match requirement", key)
+							return false
+						}
+					} else {
+						log.Debugf("Local Metadata(%s) does not match requirement", key)
+						return false
+					}
+				} else if index := strings.Index(v, ">"); strings.Contains(v, ">") && (index == 0) {
+					need, err1 := strconv.Atoi(v[1:])
+					have, err2 := strconv.Atoi(local)
+					if err1 == nil && err2 == nil {
+						if have > need {
+							log.Debugf("Local Metadata(%s) meets requirement", key)
+							continue
+						} else {
+							log.Debugf("Local Metadata(%s) does not match requirement", key)
+							return false
+						}
+					} else {
+						log.Debugf("Local Metadata(%s) does not match requirement", key)
+						return false
+					}
+				} else if index := strings.Index(v, "<"); strings.Contains(v, "<") && (index == 0) {
+					need, err1 := strconv.Atoi(v[1:])
+					have, err2 := strconv.Atoi(local)
+					if err1 == nil && err2 == nil {
+						if have < need {
+							log.Debugf("Local Metadata(%s) meets requirement", key)
+							continue
+						} else {
+							log.Debugf("Local Metadata(%s) does not match requirement", key)
+							return false
+						}
+					} else {
+						log.Debugf("Local Metadata(%s) does not match requirement", key)
+						return false
+					}
+				} else if index := strings.Index(v, "!="); strings.Contains(v, "!=") && (index == 0) {
+					if v[2:] != local {
+						log.Debugf("Local Metadata(%s) meets requirement", key)
+						continue
+					} else {
+						log.Debugf("Local Metadata(%s) does not match requirement", key)
+						return false
+					}
+				} else {
+					log.Debugf("Local Metadata(%s) does not match requirement", key)
+					return false
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
If define metadata in fleet conf, such as "ram=1024", we can
define the operator in [X-Fleet] unit as below:
[X-Fleet]
MachineMetadata=ram>=2048
The operators have been supported: "<=", ">=", "!=", "<", ">", "="
If the operatior are "<=", ">=", "!=", "<", ">", the value should
be integer, otherwise, the unit will never be launched.

Fixes #1143