### PR TITLE
consistent reads

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,13 +12,13 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/client",
-			"Comment": "v2.1.0-alpha.0-201-gebb7677",
-			"Rev": "ebb767765e8f7475fdad8b0c37b28841b6346d3d"
+			"Comment": "v2.1.1-31-g93002ca",
+			"Rev": "93002caca591fb51e0796813903c4fc1239f3ce7"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/types",
-			"Comment": "v2.1.0-alpha.0-201-gebb7677",
-			"Rev": "ebb767765e8f7475fdad8b0c37b28841b6346d3d"
+			"Comment": "v2.1.1-31-g93002ca",
+			"Rev": "93002caca591fb51e0796813903c4fc1239f3ce7"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-semver/semver",

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/auth_role.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/auth_role.go
@@ -1,0 +1,235 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/coreos/fleet/Godeps/_workspace/src/golang.org/x/net/context"
+)
+
+type Role struct {
+	Role        string       `json:"role"`
+	Permissions Permissions  `json:"permissions"`
+	Grant       *Permissions `json:"grant,omitempty"`
+	Revoke      *Permissions `json:"revoke,omitempty"`
+}
+
+type Permissions struct {
+	KV rwPermission `json:"kv"`
+}
+
+type rwPermission struct {
+	Read  []string `json:"read"`
+	Write []string `json:"write"`
+}
+
+type PermissionType int
+
+const (
+	ReadPermission PermissionType = iota
+	WritePermission
+	ReadWritePermission
+)
+
+// NewAuthRoleAPI constructs a new AuthRoleAPI that uses HTTP to
+// interact with etcd's role creation and modification features.
+func NewAuthRoleAPI(c Client) AuthRoleAPI {
+	return &httpAuthRoleAPI{
+		client: c,
+	}
+}
+
+type AuthRoleAPI interface {
+	// Add a role.
+	AddRole(ctx context.Context, role string) error
+
+	// Remove a role.
+	RemoveRole(ctx context.Context, role string) error
+
+	// Get role details.
+	GetRole(ctx context.Context, role string) (*Role, error)
+
+	// Grant a role some permission prefixes for the KV store.
+	GrantRoleKV(ctx context.Context, role string, prefixes []string, permType PermissionType) (*Role, error)
+
+	// Revoke some some permission prefixes for a role on the KV store.
+	RevokeRoleKV(ctx context.Context, role string, prefixes []string, permType PermissionType) (*Role, error)
+
+	// List roles.
+	ListRoles(ctx context.Context) ([]string, error)
+}
+
+type httpAuthRoleAPI struct {
+	client httpClient
+}
+
+type authRoleAPIAction struct {
+	verb string
+	name string
+	role *Role
+}
+
+type authRoleAPIList struct{}
+
+func (list *authRoleAPIList) HTTPRequest(ep url.URL) *http.Request {
+	u := v2AuthURL(ep, "roles", "")
+	req, _ := http.NewRequest("GET", u.String(), nil)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func (l *authRoleAPIAction) HTTPRequest(ep url.URL) *http.Request {
+	u := v2AuthURL(ep, "roles", l.name)
+	if l.role == nil {
+		req, _ := http.NewRequest(l.verb, u.String(), nil)
+		return req
+	}
+	b, err := json.Marshal(l.role)
+	if err != nil {
+		panic(err)
+	}
+	body := bytes.NewReader(b)
+	req, _ := http.NewRequest(l.verb, u.String(), body)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func (r *httpAuthRoleAPI) ListRoles(ctx context.Context) ([]string, error) {
+	resp, body, err := r.client.Do(ctx, &authRoleAPIList{})
+	if err != nil {
+		return nil, err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+		return nil, err
+	}
+	var userList struct {
+		Roles []string `json:"roles"`
+	}
+	err = json.Unmarshal(body, &userList)
+	if err != nil {
+		return nil, err
+	}
+	return userList.Roles, nil
+}
+
+func (r *httpAuthRoleAPI) AddRole(ctx context.Context, rolename string) error {
+	role := &Role{
+		Role: rolename,
+	}
+	return r.addRemoveRole(ctx, &authRoleAPIAction{
+		verb: "PUT",
+		name: rolename,
+		role: role,
+	})
+}
+
+func (r *httpAuthRoleAPI) RemoveRole(ctx context.Context, rolename string) error {
+	return r.addRemoveRole(ctx, &authRoleAPIAction{
+		verb: "DELETE",
+		name: rolename,
+	})
+}
+
+func (r *httpAuthRoleAPI) addRemoveRole(ctx context.Context, req *authRoleAPIAction) error {
+	resp, body, err := r.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK, http.StatusCreated); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return err
+		}
+		return sec
+	}
+	return nil
+}
+
+func (r *httpAuthRoleAPI) GetRole(ctx context.Context, rolename string) (*Role, error) {
+	return r.modRole(ctx, &authRoleAPIAction{
+		verb: "GET",
+		name: rolename,
+	})
+}
+
+func buildRWPermission(prefixes []string, permType PermissionType) rwPermission {
+	var out rwPermission
+	switch permType {
+	case ReadPermission:
+		out.Read = prefixes
+	case WritePermission:
+		out.Write = prefixes
+	case ReadWritePermission:
+		out.Read = prefixes
+		out.Write = prefixes
+	}
+	return out
+}
+
+func (r *httpAuthRoleAPI) GrantRoleKV(ctx context.Context, rolename string, prefixes []string, permType PermissionType) (*Role, error) {
+	rwp := buildRWPermission(prefixes, permType)
+	role := &Role{
+		Role: rolename,
+		Grant: &Permissions{
+			KV: rwp,
+		},
+	}
+	return r.modRole(ctx, &authRoleAPIAction{
+		verb: "PUT",
+		name: rolename,
+		role: role,
+	})
+}
+
+func (r *httpAuthRoleAPI) RevokeRoleKV(ctx context.Context, rolename string, prefixes []string, permType PermissionType) (*Role, error) {
+	rwp := buildRWPermission(prefixes, permType)
+	role := &Role{
+		Role: rolename,
+		Revoke: &Permissions{
+			KV: rwp,
+		},
+	}
+	return r.modRole(ctx, &authRoleAPIAction{
+		verb: "PUT",
+		name: rolename,
+		role: role,
+	})
+}
+
+func (r *httpAuthRoleAPI) modRole(ctx context.Context, req *authRoleAPIAction) (*Role, error) {
+	resp, body, err := r.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return nil, err
+		}
+		return nil, sec
+	}
+	var role Role
+	err = json.Unmarshal(body, &role)
+	if err != nil {
+		return nil, err
+	}
+	return &role, nil
+}

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/auth_user.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/auth_user.go
@@ -1,0 +1,297 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/coreos/fleet/Godeps/_workspace/src/golang.org/x/net/context"
+)
+
+var (
+	defaultV2AuthPrefix = "/v2/auth"
+)
+
+type User struct {
+	User     string   `json:"user"`
+	Password string   `json:"password,omitempty"`
+	Roles    []string `json:"roles"`
+	Grant    []string `json:"grant,omitempty"`
+	Revoke   []string `json:"revoke,omitempty"`
+}
+
+func v2AuthURL(ep url.URL, action string, name string) *url.URL {
+	if name != "" {
+		ep.Path = path.Join(ep.Path, defaultV2AuthPrefix, action, name)
+		return &ep
+	}
+	ep.Path = path.Join(ep.Path, defaultV2AuthPrefix, action)
+	return &ep
+}
+
+// NewAuthAPI constructs a new AuthAPI that uses HTTP to
+// interact with etcd's general auth features.
+func NewAuthAPI(c Client) AuthAPI {
+	return &httpAuthAPI{
+		client: c,
+	}
+}
+
+type AuthAPI interface {
+	// Enable auth.
+	Enable(ctx context.Context) error
+
+	// Disable auth.
+	Disable(ctx context.Context) error
+}
+
+type httpAuthAPI struct {
+	client httpClient
+}
+
+func (s *httpAuthAPI) Enable(ctx context.Context) error {
+	return s.enableDisable(ctx, &authAPIAction{"PUT"})
+}
+
+func (s *httpAuthAPI) Disable(ctx context.Context) error {
+	return s.enableDisable(ctx, &authAPIAction{"DELETE"})
+}
+
+func (s *httpAuthAPI) enableDisable(ctx context.Context, req httpAction) error {
+	resp, body, err := s.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK, http.StatusCreated); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return err
+		}
+		return sec
+	}
+	return nil
+}
+
+type authAPIAction struct {
+	verb string
+}
+
+func (l *authAPIAction) HTTPRequest(ep url.URL) *http.Request {
+	u := v2AuthURL(ep, "enable", "")
+	req, _ := http.NewRequest(l.verb, u.String(), nil)
+	return req
+}
+
+type authError struct {
+	Message string `json:"message"`
+	Code    int    `json:"-"`
+}
+
+func (e authError) Error() string {
+	return e.Message
+}
+
+// NewAuthUserAPI constructs a new AuthUserAPI that uses HTTP to
+// interact with etcd's user creation and modification features.
+func NewAuthUserAPI(c Client) AuthUserAPI {
+	return &httpAuthUserAPI{
+		client: c,
+	}
+}
+
+type AuthUserAPI interface {
+	// Add a user.
+	AddUser(ctx context.Context, username string, password string) error
+
+	// Remove a user.
+	RemoveUser(ctx context.Context, username string) error
+
+	// Get user details.
+	GetUser(ctx context.Context, username string) (*User, error)
+
+	// Grant a user some permission roles.
+	GrantUser(ctx context.Context, username string, roles []string) (*User, error)
+
+	// Revoke some permission roles from a user.
+	RevokeUser(ctx context.Context, username string, roles []string) (*User, error)
+
+	// Change the user's password.
+	ChangePassword(ctx context.Context, username string, password string) (*User, error)
+
+	// List users.
+	ListUsers(ctx context.Context) ([]string, error)
+}
+
+type httpAuthUserAPI struct {
+	client httpClient
+}
+
+type authUserAPIAction struct {
+	verb     string
+	username string
+	user     *User
+}
+
+type authUserAPIList struct{}
+
+func (list *authUserAPIList) HTTPRequest(ep url.URL) *http.Request {
+	u := v2AuthURL(ep, "users", "")
+	req, _ := http.NewRequest("GET", u.String(), nil)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func (l *authUserAPIAction) HTTPRequest(ep url.URL) *http.Request {
+	u := v2AuthURL(ep, "users", l.username)
+	if l.user == nil {
+		req, _ := http.NewRequest(l.verb, u.String(), nil)
+		return req
+	}
+	b, err := json.Marshal(l.user)
+	if err != nil {
+		panic(err)
+	}
+	body := bytes.NewReader(b)
+	req, _ := http.NewRequest(l.verb, u.String(), body)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func (u *httpAuthUserAPI) ListUsers(ctx context.Context) ([]string, error) {
+	resp, body, err := u.client.Do(ctx, &authUserAPIList{})
+	if err != nil {
+		return nil, err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return nil, err
+		}
+		return nil, sec
+	}
+	var userList struct {
+		Users []string `json:"users"`
+	}
+	err = json.Unmarshal(body, &userList)
+	if err != nil {
+		return nil, err
+	}
+	return userList.Users, nil
+}
+
+func (u *httpAuthUserAPI) AddUser(ctx context.Context, username string, password string) error {
+	user := &User{
+		User:     username,
+		Password: password,
+	}
+	return u.addRemoveUser(ctx, &authUserAPIAction{
+		verb:     "PUT",
+		username: username,
+		user:     user,
+	})
+}
+
+func (u *httpAuthUserAPI) RemoveUser(ctx context.Context, username string) error {
+	return u.addRemoveUser(ctx, &authUserAPIAction{
+		verb:     "DELETE",
+		username: username,
+	})
+}
+
+func (u *httpAuthUserAPI) addRemoveUser(ctx context.Context, req *authUserAPIAction) error {
+	resp, body, err := u.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK, http.StatusCreated); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return err
+		}
+		return sec
+	}
+	return nil
+}
+
+func (u *httpAuthUserAPI) GetUser(ctx context.Context, username string) (*User, error) {
+	return u.modUser(ctx, &authUserAPIAction{
+		verb:     "GET",
+		username: username,
+	})
+}
+
+func (u *httpAuthUserAPI) GrantUser(ctx context.Context, username string, roles []string) (*User, error) {
+	user := &User{
+		User:  username,
+		Grant: roles,
+	}
+	return u.modUser(ctx, &authUserAPIAction{
+		verb:     "PUT",
+		username: username,
+		user:     user,
+	})
+}
+
+func (u *httpAuthUserAPI) RevokeUser(ctx context.Context, username string, roles []string) (*User, error) {
+	user := &User{
+		User:   username,
+		Revoke: roles,
+	}
+	return u.modUser(ctx, &authUserAPIAction{
+		verb:     "PUT",
+		username: username,
+		user:     user,
+	})
+}
+
+func (u *httpAuthUserAPI) ChangePassword(ctx context.Context, username string, password string) (*User, error) {
+	user := &User{
+		User:     username,
+		Password: password,
+	}
+	return u.modUser(ctx, &authUserAPIAction{
+		verb:     "PUT",
+		username: username,
+		user:     user,
+	})
+}
+
+func (u *httpAuthUserAPI) modUser(ctx context.Context, req *authUserAPIAction) (*User, error) {
+	resp, body, err := u.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return nil, err
+		}
+		return nil, sec
+	}
+	var user User
+	err = json.Unmarshal(body, &user)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/client_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/client_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/etcd/pkg/testutil"
 	"github.com/coreos/fleet/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
@@ -113,10 +114,15 @@ func (t *fakeTransport) RoundTrip(*http.Request) (*http.Response, error) {
 	case err := <-t.errchan:
 		return nil, err
 	case <-t.startCancel:
+		select {
+		// this simulates that the request is finished before cancel effects
+		case resp := <-t.respchan:
+			return resp, nil
 		// wait on finishCancel to simulate taking some amount of
 		// time while calling CancelRequest
-		<-t.finishCancel
-		return nil, errors.New("cancelled")
+		case <-t.finishCancel:
+			return nil, errors.New("cancelled")
+		}
 	}
 }
 
@@ -203,12 +209,12 @@ func TestSimpleHTTPClientDoCancelContextResponseBodyClosed(t *testing.T) {
 
 	body := &checkableReadCloser{ReadCloser: ioutil.NopCloser(strings.NewReader("foo"))}
 	go func() {
-		// wait for CancelRequest to be called, informing us that simpleHTTPClient
-		// knows the context is already timed out
-		<-tr.startCancel
+		// wait that simpleHTTPClient knows the context is already timed out,
+		// and calls CancelRequest
+		testutil.WaitSchedule()
 
+		// response is returned before cancel effects
 		tr.respchan <- &http.Response{Body: body}
-		tr.finishCancel <- struct{}{}
 	}()
 
 	_, _, err := c.Do(ctx, &fakeAction{})

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/keys_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/keys_test.go
@@ -102,27 +102,38 @@ func TestGetAction(t *testing.T) {
 	tests := []struct {
 		recursive bool
 		sorted    bool
+		quorum    bool
 		wantQuery string
 	}{
 		{
 			recursive: false,
 			sorted:    false,
-			wantQuery: "recursive=false&sorted=false",
+			quorum:    false,
+			wantQuery: "quorum=false&recursive=false&sorted=false",
 		},
 		{
 			recursive: true,
 			sorted:    false,
-			wantQuery: "recursive=true&sorted=false",
+			quorum:    false,
+			wantQuery: "quorum=false&recursive=true&sorted=false",
 		},
 		{
 			recursive: false,
 			sorted:    true,
-			wantQuery: "recursive=false&sorted=true",
+			quorum:    false,
+			wantQuery: "quorum=false&recursive=false&sorted=true",
 		},
 		{
 			recursive: true,
 			sorted:    true,
-			wantQuery: "recursive=true&sorted=true",
+			quorum:    false,
+			wantQuery: "quorum=false&recursive=true&sorted=true",
+		},
+		{
+			recursive: false,
+			sorted:    false,
+			quorum:    true,
+			wantQuery: "quorum=true&recursive=false&sorted=false",
 		},
 	}
 
@@ -131,6 +142,7 @@ func TestGetAction(t *testing.T) {
 			Key:       "/foo/bar",
 			Recursive: tt.recursive,
 			Sorted:    tt.sorted,
+			Quorum:    tt.quorum,
 		}
 		got := *f.HTTPRequest(ep)
 
@@ -1120,11 +1132,13 @@ func TestHTTPKeysAPIGetAction(t *testing.T) {
 			opts: &GetOptions{
 				Sort:      true,
 				Recursive: true,
+				Quorum:    true,
 			},
 			wantAction: &getAction{
 				Key:       "/foo",
 				Sorted:    true,
 				Recursive: true,
+				Quorum:    true,
 			},
 		},
 	}

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/members.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/members.go
@@ -67,11 +67,11 @@ func (c *memberCollection) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-type memberCreateRequest struct {
+type memberCreateOrUpdateRequest struct {
 	PeerURLs types.URLs
 }
 
-func (m *memberCreateRequest) MarshalJSON() ([]byte, error) {
+func (m *memberCreateOrUpdateRequest) MarshalJSON() ([]byte, error) {
 	s := struct {
 		PeerURLs []string `json:"peerURLs"`
 	}{
@@ -102,6 +102,9 @@ type MembersAPI interface {
 
 	// Remove demotes an existing Member out of the cluster.
 	Remove(ctx context.Context, mID string) error
+
+	// Update instructs etcd to update an existing Member in the cluster.
+	Update(ctx context.Context, mID string, peerURLs []string) error
 }
 
 type httpMembersAPI struct {
@@ -159,6 +162,33 @@ func (m *httpMembersAPI) Add(ctx context.Context, peerURL string) (*Member, erro
 	return &memb, nil
 }
 
+func (m *httpMembersAPI) Update(ctx context.Context, memberID string, peerURLs []string) error {
+	urls, err := types.NewURLs(peerURLs)
+	if err != nil {
+		return err
+	}
+
+	req := &membersAPIActionUpdate{peerURLs: urls, memberID: memberID}
+	resp, body, err := m.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if err := assertStatusCode(resp.StatusCode, http.StatusNoContent, http.StatusNotFound, http.StatusConflict); err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		var merr membersError
+		if err := json.Unmarshal(body, &merr); err != nil {
+			return err
+		}
+		return merr
+	}
+
+	return nil
+}
+
 func (m *httpMembersAPI) Remove(ctx context.Context, memberID string) error {
 	req := &membersAPIActionRemove{memberID: memberID}
 	resp, _, err := m.client.Do(ctx, req)
@@ -194,9 +224,24 @@ type membersAPIActionAdd struct {
 
 func (a *membersAPIActionAdd) HTTPRequest(ep url.URL) *http.Request {
 	u := v2MembersURL(ep)
-	m := memberCreateRequest{PeerURLs: a.peerURLs}
+	m := memberCreateOrUpdateRequest{PeerURLs: a.peerURLs}
 	b, _ := json.Marshal(&m)
 	req, _ := http.NewRequest("POST", u.String(), bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+type membersAPIActionUpdate struct {
+	memberID string
+	peerURLs types.URLs
+}
+
+func (a *membersAPIActionUpdate) HTTPRequest(ep url.URL) *http.Request {
+	u := v2MembersURL(ep)
+	m := memberCreateOrUpdateRequest{PeerURLs: a.peerURLs}
+	u.Path = path.Join(u.Path, a.memberID)
+	b, _ := json.Marshal(&m)
+	req, _ := http.NewRequest("PUT", u.String(), bytes.NewReader(b))
 	req.Header.Set("Content-Type", "application/json")
 	return req
 }

--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/members_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/members_test.go
@@ -70,6 +70,33 @@ func TestMembersAPIActionAdd(t *testing.T) {
 	}
 }
 
+func TestMembersAPIActionUpdate(t *testing.T) {
+	ep := url.URL{Scheme: "http", Host: "example.com"}
+	act := &membersAPIActionUpdate{
+		memberID: "0xabcd",
+		peerURLs: types.URLs([]url.URL{
+			url.URL{Scheme: "https", Host: "127.0.0.1:8081"},
+			url.URL{Scheme: "http", Host: "127.0.0.1:8080"},
+		}),
+	}
+
+	wantURL := &url.URL{
+		Scheme: "http",
+		Host:   "example.com",
+		Path:   "/v2/members/0xabcd",
+	}
+	wantHeader := http.Header{
+		"Content-Type": []string{"application/json"},
+	}
+	wantBody := []byte(`{"peerURLs":["https://127.0.0.1:8081","http://127.0.0.1:8080"]}`)
+
+	got := *act.HTTPRequest(ep)
+	err := assertRequest(got, "PUT", wantURL, wantHeader, wantBody)
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
 func TestMembersAPIActionRemove(t *testing.T) {
 	ep := url.URL{Scheme: "http", Host: "example.com"}
 	act := &membersAPIActionRemove{memberID: "XXX"}
@@ -260,7 +287,7 @@ func TestMemberCollectionUnmarshal(t *testing.T) {
 }
 
 func TestMemberCreateRequestMarshal(t *testing.T) {
-	req := memberCreateRequest{
+	req := memberCreateOrUpdateRequest{
 		PeerURLs: types.URLs([]url.URL{
 			url.URL{Scheme: "http", Host: "127.0.0.1:8081"},
 			url.URL{Scheme: "https", Host: "127.0.0.1:8080"},

--- a/Godeps/_workspace/src/github.com/coreos/etcd/pkg/types/urlsmap.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/pkg/types/urlsmap.go
@@ -25,7 +25,7 @@ type URLsMap map[string]URLs
 
 // NewURLsMap returns a URLsMap instantiated from the given string,
 // which consists of discovery-formatted names-to-URLs, like:
-// mach0=http://1.1.1.1,mach0=http://2.2.2.2,mach1=http://3.3.3.3,mach2=http://4.4.4.4
+// mach0=http://1.1.1.1:2380,mach0=http://2.2.2.2::2380,mach1=http://3.3.3.3:2380,mach2=http://4.4.4.4:2380
 func NewURLsMap(s string) (URLsMap, error) {
 	cl := URLsMap{}
 	v, err := url.ParseQuery(strings.Replace(s, ",", "&", -1))
@@ -68,4 +68,8 @@ func (c URLsMap) URLs() []string {
 	}
 	sort.Strings(urls)
 	return urls
+}
+
+func (c URLsMap) Len() int {
+	return len(c)
 }

--- a/registry/job.go
+++ b/registry/job.go
@@ -37,6 +37,7 @@ func (r *EtcdRegistry) Schedule() ([]job.ScheduledUnit, error) {
 	opts := &etcd.GetOptions{
 		Sort:      true,
 		Recursive: true,
+		Quorum:    true,
 	}
 	res, err := r.kAPI.Get(r.ctx(), key, opts)
 	if err != nil {
@@ -92,6 +93,7 @@ func (r *EtcdRegistry) Units() ([]job.Unit, error) {
 	opts := &etcd.GetOptions{
 		Sort:      true,
 		Recursive: true,
+		Quorum:    true,
 	}
 	res, err := r.kAPI.Get(r.ctx(), key, opts)
 	if err != nil {
@@ -134,6 +136,7 @@ func (r *EtcdRegistry) Unit(name string) (*job.Unit, error) {
 	key := r.prefixed(jobPrefix, name)
 	opts := &etcd.GetOptions{
 		Recursive: true,
+		Quorum:    true,
 	}
 	res, err := r.kAPI.Get(r.ctx(), key, opts)
 	if err != nil {
@@ -184,6 +187,7 @@ func (r *EtcdRegistry) ScheduledUnit(name string) (*job.ScheduledUnit, error) {
 	key := r.prefixed(jobPrefix, name)
 	opts := &etcd.GetOptions{
 		Recursive: true,
+		Quorum:    true,
 	}
 	res, err := r.kAPI.Get(r.ctx(), key, opts)
 	if err != nil {

--- a/registry/machine.go
+++ b/registry/machine.go
@@ -32,6 +32,7 @@ func (r *EtcdRegistry) Machines() (machines []machine.MachineState, err error) {
 	opts := &etcd.GetOptions{
 		Sort:      true,
 		Recursive: true,
+		Quorum:    true,
 	}
 
 	resp, err := r.kAPI.Get(r.ctx(), key, opts)

--- a/registry/unit.go
+++ b/registry/unit.go
@@ -53,6 +53,7 @@ func (r *EtcdRegistry) getUnitByHash(hash unit.Hash) *unit.UnitFile {
 	key := r.hashedUnitPath(hash)
 	opts := &etcd.GetOptions{
 		Recursive: true,
+		Quorum:    true,
 	}
 	resp, err := r.kAPI.Get(r.ctx(), key, opts)
 	if err != nil {


### PR DESCRIPTION
this fixes a race encountered when fleetd does a PUT followed by GET but does not use `quorum=true` for the get, resulting in a 404 from the local etcd.

/cc @bcwaldon @jonboulle @marineam 