### PR TITLE
fleetctl: optimize status command

### DIFF
--- a/fleetctl/status.go
+++ b/fleetctl/status.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/coreos/fleet/job"
-	"github.com/coreos/fleet/schema"
 )
 
 var cmdStatusUnits = &Command{
@@ -44,47 +43,34 @@ func init() {
 }
 
 func runStatusUnits(args []string) (exit int) {
-	units, err := cAPI.Units()
-	if err != nil {
-		stderr("Error retrieving unit: %v", err)
-		return 1
-	}
-
-	uMap := make(map[string]*schema.Unit, len(args))
-	for _, u := range units {
-		if u != nil {
-			u := u
-			uMap[u.Name] = u
-		}
-	}
-
-	names := make([]string, len(args))
 	for i, arg := range args {
 		name := unitNameMangle(arg)
-		names[i] = name
-
-		u, ok := uMap[name]
-		if !ok {
-			stderr("Unit %s does not exist.", name)
-			return 1
-		} else if suToGlobal(*u) {
-			stderr("Unable to determine status of global unit %s.", name)
-			return 1
-		} else if job.JobState(u.CurrentState) == job.JobStateInactive {
-			stderr("Unit %s does not appear to be loaded.", name)
+		unit, err := cAPI.Unit(name)
+		if err != nil {
+			stderr("Error retrieving unit: %v", err)
 			return 1
 		}
-	}
 
-	for i, name := range names {
+		if unit == nil {
+			stderr("Unit %s does not exist.", name)
+			return 1
+		} else if suToGlobal(*unit) {
+			stderr("Unable to determine status of global unit %s.", unit.Name)
+			return 1
+		} else if job.JobState(unit.CurrentState) == job.JobStateInactive {
+			stderr("Unit %s does not appear to be loaded.", unit.Name)
+			return 1
+		}
+
 		// This extra newline is here to match systemctl status output
 		if i != 0 {
 			fmt.Printf("\n")
 		}
 
-		if exit = runCommand(uMap[name].MachineID, "systemctl", "status", "-l", name); exit != 0 {
+		if exit = runCommand(unit.MachineID, "systemctl", "status", "-l", unit.Name); exit != 0 {
 			break
 		}
 	}
+
 	return
 }


### PR DESCRIPTION
Use the Unit API instead of Units API to speed up lookups on
environments with a large number of distinct services.

Fixes #1340