### PR TITLE
etcd: enable basic authentication

### DIFF
--- a/Documentation/deployment-and-configuration.md
+++ b/Documentation/deployment-and-configuration.md
@@ -103,6 +103,12 @@ Provide TLS configuration when SSL certificate authentication is enabled in etcd
 
 Default: ""
 
+#### etcd_username, etcd_password
+
+Provide credentials when [authentication](https://github.com/coreos/etcd/blob/master/Documentation/authentication.md) is enabled in etcd endpoints.
+
+Default: ""
+
 #### etcd_key_prefix
 
 Keyspace path for fleet data in etcd.

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,8 @@ type Config struct {
 	EtcdKeyFile             string
 	EtcdCertFile            string
 	EtcdCAFile              string
+	EtcdUsername            string
+	EtcdPassword            string
 	EtcdRequestTimeout      float64
 	EngineReconcileInterval float64
 	PublicIP                string

--- a/fleet.conf.sample
+++ b/fleet.conf.sample
@@ -16,6 +16,10 @@
 # etcd_keyfile=/path/to/keyfile
 # etcd_certfile=/path/to/certfile
 
+# Provide credentials when authentication is enabled in etcd endpoints
+# etcd_username=guest
+# etcd_password=p4ssw0rd
+
 # IP address that should be published with any socket information. By default,
 # no IP address is published.
 # public_ip=""

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -69,6 +69,8 @@ func main() {
 	cfgset.String("etcd_keyfile", "", "SSL key file used to secure etcd communication")
 	cfgset.String("etcd_certfile", "", "SSL certification file used to secure etcd communication")
 	cfgset.String("etcd_cafile", "", "SSL Certificate Authority file used to secure etcd communication")
+	cfgset.String("etcd_username", "", "Username for etcd authentication")
+	cfgset.String("etcd_password", "", "Password for etcd authentication")
 	cfgset.String("etcd_key_prefix", registry.DefaultKeyPrefix, "Keyspace for fleet data in etcd")
 	cfgset.Float64("etcd_request_timeout", 1.0, "Amount of time in seconds to allow a single etcd request before considering it failed.")
 	cfgset.Float64("engine_reconcile_interval", 2.0, "Interval at which the engine should reconcile the cluster schedule in etcd.")
@@ -182,6 +184,8 @@ func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error
 		EtcdKeyFile:             (*flagset.Lookup("etcd_keyfile")).Value.(flag.Getter).Get().(string),
 		EtcdCertFile:            (*flagset.Lookup("etcd_certfile")).Value.(flag.Getter).Get().(string),
 		EtcdCAFile:              (*flagset.Lookup("etcd_cafile")).Value.(flag.Getter).Get().(string),
+		EtcdUsername:            (*flagset.Lookup("etcd_username")).Value.(flag.Getter).Get().(string),
+		EtcdPassword:            (*flagset.Lookup("etcd_password")).Value.(flag.Getter).Get().(string),
 		EtcdRequestTimeout:      (*flagset.Lookup("etcd_request_timeout")).Value.(flag.Getter).Get().(float64),
 		EngineReconcileInterval: (*flagset.Lookup("engine_reconcile_interval")).Value.(flag.Getter).Get().(float64),
 		PublicIP:                (*flagset.Lookup("public_ip")).Value.(flag.Getter).Get().(string),

--- a/server/server.go
+++ b/server/server.go
@@ -84,6 +84,8 @@ func New(cfg config.Config) (*Server, error) {
 	eCfg := etcd.Config{
 		Transport: &http.Transport{TLSClientConfig: tlsConfig},
 		Endpoints: cfg.EtcdServers,
+		Username:  cfg.EtcdUsername,
+		Password:  cfg.EtcdPassword,
 	}
 	eClient, err := etcd.New(eCfg)
 	if err != nil {


### PR DESCRIPTION
Supported by client, boring glue ties to fleetd config.