### PR TITLE
fleetd: fix argument handling

### DIFF
--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -42,8 +42,13 @@ func main() {
 	printVersion := userset.Bool("version", false, "Print the version and exit")
 	cfgPath := userset.String("config", "", fmt.Sprintf("Path to config file. Fleet will look for a config at %s by default.", DefaultConfigFile))
 
+	userset.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		userset.PrintDefaults()
+	}
+
 	err := userset.Parse(os.Args[1:])
-	if err == flag.ErrHelp {
+	if err != nil {
 		userset.Usage()
 		os.Exit(1)
 	}


### PR DESCRIPTION
We were calling userset.Usage but it was never actually defined. Unlike
in the top-level of the flag package (i.e. `flag.Usage`), this method
does not have a default value on `FlagSet`s.

The only reason this never showed up way earlier in the `ErrHelp` path
(and was only revealed via 8ebb81bcd1668be4a874db98cbf2e67ae305d7f6)
is that branch was never actually encountered.

Fixes #1360