### PR TITLE
Support for targeting `systemd --user`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	DisableWatches          bool
 	VerifyUnits             bool
 	UnitsDirectory          string
+	SystemdUser             bool
 	AuthorizedKeysFile      string
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	DisableEngine           bool
 	DisableWatches          bool
 	VerifyUnits             bool
+	UnitsDirectory          string
 	AuthorizedKeysFile      string
 }
 

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -86,6 +86,7 @@ func main() {
 	cfgset.String("public_ip", "", "IP address that fleet machine should publish")
 	cfgset.String("metadata", "", "List of key-value metadata to assign to the fleet machine")
 	cfgset.String("agent_ttl", agent.DefaultTTL, "TTL in seconds of fleet machine state in etcd")
+	cfgset.String("units_directory", "/run/fleet/units/", "Path to the fleet units directory")
 	cfgset.Int("token_limit", 100, "Maximum number of entries per page returned from API requests")
 	cfgset.Bool("disable_engine", false, "Disable the engine entirely, use with care")
 	cfgset.Bool("disable_watches", false, "Disable the use of etcd watches. Increases scheduling latency")
@@ -225,6 +226,7 @@ func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error
 		DisableEngine:           (*flagset.Lookup("disable_engine")).Value.(flag.Getter).Get().(bool),
 		DisableWatches:          (*flagset.Lookup("disable_watches")).Value.(flag.Getter).Get().(bool),
 		VerifyUnits:             (*flagset.Lookup("verify_units")).Value.(flag.Getter).Get().(bool),
+		UnitsDirectory:          (*flagset.Lookup("units_directory")).Value.(flag.Getter).Get().(string),
 		TokenLimit:              (*flagset.Lookup("token_limit")).Value.(flag.Getter).Get().(int),
 		AuthorizedKeysFile:      (*flagset.Lookup("authorized_keys_file")).Value.(flag.Getter).Get().(string),
 	}

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -87,6 +87,7 @@ func main() {
 	cfgset.String("metadata", "", "List of key-value metadata to assign to the fleet machine")
 	cfgset.String("agent_ttl", agent.DefaultTTL, "TTL in seconds of fleet machine state in etcd")
 	cfgset.String("units_directory", "/run/fleet/units/", "Path to the fleet units directory")
+	cfgset.Bool("systemd_user", false, "When true use systemd --user)")
 	cfgset.Int("token_limit", 100, "Maximum number of entries per page returned from API requests")
 	cfgset.Bool("disable_engine", false, "Disable the engine entirely, use with care")
 	cfgset.Bool("disable_watches", false, "Disable the use of etcd watches. Increases scheduling latency")
@@ -227,6 +228,7 @@ func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error
 		DisableWatches:          (*flagset.Lookup("disable_watches")).Value.(flag.Getter).Get().(bool),
 		VerifyUnits:             (*flagset.Lookup("verify_units")).Value.(flag.Getter).Get().(bool),
 		UnitsDirectory:          (*flagset.Lookup("units_directory")).Value.(flag.Getter).Get().(string),
+		SystemdUser:             (*flagset.Lookup("systemd_user")).Value.(flag.Getter).Get().(bool),
 		TokenLimit:              (*flagset.Lookup("token_limit")).Value.(flag.Getter).Get().(int),
 		AuthorizedKeysFile:      (*flagset.Lookup("authorized_keys_file")).Value.(flag.Getter).Get().(string),
 	}

--- a/functional/systemd_test.go
+++ b/functional/systemd_test.go
@@ -35,7 +35,7 @@ func TestSystemdUnitFlow(t *testing.T) {
 	}
 	defer os.RemoveAll(uDir)
 
-	mgr, err := systemd.NewSystemdUnitManager(uDir)
+	mgr, err := systemd.NewSystemdUnitManager(uDir, false)
 	if err != nil {
 		t.Fatalf("Failed initializing SystemdUnitManager: %v", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -75,7 +75,7 @@ func New(cfg config.Config, listeners []net.Listener) (*Server, error) {
 		return nil, err
 	}
 
-	mgr, err := systemd.NewSystemdUnitManager(systemd.DefaultUnitsDirectory)
+	mgr, err := systemd.NewSystemdUnitManager(cfg.UnitsDirectory)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -75,7 +75,7 @@ func New(cfg config.Config, listeners []net.Listener) (*Server, error) {
 		return nil, err
 	}
 
-	mgr, err := systemd.NewSystemdUnitManager(cfg.UnitsDirectory)
+	mgr, err := systemd.NewSystemdUnitManager(cfg.UnitsDirectory, cfg.SystemdUser)
 	if err != nil {
 		return nil, err
 	}

--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -28,10 +28,6 @@ import (
 	"github.com/coreos/fleet/unit"
 )
 
-const (
-	DefaultUnitsDirectory = "/run/fleet/units/"
-)
-
 type systemdUnitManager struct {
 	systemd  *dbus.Conn
 	unitsDir string

--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -36,8 +36,8 @@ type systemdUnitManager struct {
 	mutex  sync.RWMutex
 }
 
-func NewSystemdUnitManager(uDir string) (*systemdUnitManager, error) {
-	systemd, err := dbus.New()
+func NewSystemdUnitManager(uDir string, systemdUser bool) (*systemdUnitManager, error) {
+	systemd, err := createDbusConnection(systemdUser)
 	if err != nil {
 		return nil, err
 	}
@@ -58,6 +58,13 @@ func NewSystemdUnitManager(uDir string) (*systemdUnitManager, error) {
 		mutex:    sync.RWMutex{},
 	}
 	return &mgr, nil
+}
+
+func createDbusConnection(systemdUser bool) (*dbus.Conn, error) {
+	if systemdUser {
+		return dbus.NewUserConnection()
+	}
+	return dbus.New()
 }
 
 func hashUnitFiles(dir string) (map[string]unit.Hash, error) {


### PR DESCRIPTION
Hi! I am looking at using fleet to manage a handful of machines with ssh access but without root access.
It might be a far shot or a misguided idea: please let me know if this is a dead-end.

If this is interesting I added 2 options to fleetd's configuration file to support that:
```
# fleetd.conf
units_dir=/home/vagrant/fleetunits
systemd_user=true
```

On archlinux, I can deploy `example/hello.service` but I get
`AgentReconciler task failed: type=LoadUnit job=hello.service reason="unit scheduled here but not loaded" err=No such file or directory`.
Some debugging shows that it comes from dbus's call to `LinkUnitFiles`; I have not figured out which folder it tries to link into yet.

Thanks for your attention.