### PR TITLE
fleet:build: remove build warnings on go1.5

### DIFF
--- a/build
+++ b/build
@@ -3,7 +3,10 @@
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/fleet"
 VERSION=$(git describe --dirty)
-GLDFLAGS="-X github.com/coreos/fleet/version.Version \"${VERSION}\""
+CODE_VER_SYMBOL="github.com/coreos/fleet/version.Version"
+GO_VERSION=$(go version)
+
+GLDFLAGS=""
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then
 	mkdir -p gopath/src/${ORG_PATH}
@@ -12,6 +15,18 @@ fi
 
 export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
+
+_oifs=$IFS
+IFS=" "
+read -r -a go_ver <<< "${GO_VERSION}"
+if [[ ${go_ver[2]} == "go1.4"* ]]; then
+	GLDFLAGS="-X ${CODE_VER_SYMBOL} \"${VERSION}\""
+else
+	# go > 1.4 uses param=value format
+	GLDFLAGS="-X ${CODE_VER_SYMBOL}=\"${VERSION}\""
+fi
+
+IFS=$_oifs
 
 eval $(go env)
 


### PR DESCRIPTION
When building fleet with go1.5 we got the following warning:
Building fleetd...
link: warning: option -X github.com/coreos/fleet/version.Version v0.10.1-117-g7b2a547 may not work in future releases; use -X github.com/coreos/fleet/version.Version=v0.10.1-117-g7b2a547
Building fleetctl...
link: warning: option -X github.com/coreos/fleet/version.Version v0.10.1-117-g7b2a547 may not work in future releases; use -X github.com/coreos/fleet/version.Version=v0.10.1-117-g7b2a547

Newer go versions will only support '-X name=value' format, so make our
build system smarter. It will make sure to use the right format for
future builds.

Reference: https://github.com/golang/go/issues/13498