### PR TITLE
Add unit state cache to mitigate the iteration between fleet and systemd - dbus

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	DisableWatches          bool
 	VerifyUnits             bool
 	AuthorizedKeysFile      string
+	EnableUnitStateCache    bool
 }
 
 func (c *Config) Metadata() map[string]string {

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -91,6 +91,7 @@ func main() {
 	cfgset.Bool("disable_watches", false, "Disable the use of etcd watches. Increases scheduling latency")
 	cfgset.Bool("verify_units", false, "DEPRECATED - This option is ignored")
 	cfgset.String("authorized_keys_file", "", "DEPRECATED - This option is ignored")
+	cfgset.Bool("enable_unitstate_cache", true, "Enable an unit state cache to minimize the systemd and dbus communication overhead.")
 
 	globalconf.Register("", cfgset)
 	cfg, err := getConfig(cfgset, *cfgPath)
@@ -227,8 +228,12 @@ func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error
 		VerifyUnits:             (*flagset.Lookup("verify_units")).Value.(flag.Getter).Get().(bool),
 		TokenLimit:              (*flagset.Lookup("token_limit")).Value.(flag.Getter).Get().(int),
 		AuthorizedKeysFile:      (*flagset.Lookup("authorized_keys_file")).Value.(flag.Getter).Get().(string),
+		EnableUnitStateCache:    (*flagset.Lookup("enable_unitstate_cache")).Value.(flag.Getter).Get().(bool),
 	}
 
+	if cfg.EnableUnitStateCache {
+		log.Info("Config option enable_unitstate_cache is activated")
+	}
 	if cfg.VerifyUnits {
 		log.Error("Config option verify_units is no longer supported - ignoring")
 	}

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -91,7 +91,7 @@ func main() {
 	cfgset.Bool("disable_watches", false, "Disable the use of etcd watches. Increases scheduling latency")
 	cfgset.Bool("verify_units", false, "DEPRECATED - This option is ignored")
 	cfgset.String("authorized_keys_file", "", "DEPRECATED - This option is ignored")
-	cfgset.Bool("enable_unitstate_cache", true, "Enable an unit state cache to minimize the systemd and dbus communication overhead.")
+	cfgset.Bool("enable_unitstate_cache", false, "Enable an unit state cache to minimize the systemd and dbus communication overhead.")
 
 	globalconf.Register("", cfgset)
 	cfg, err := getConfig(cfgset, *cfgPath)

--- a/server/server.go
+++ b/server/server.go
@@ -73,8 +73,7 @@ func New(cfg config.Config, listeners []net.Listener) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	mgr, err := systemd.NewSystemdUnitManager(systemd.DefaultUnitsDirectory)
+	mgr, err := systemd.NewSystemdUnitManager(cfg, systemd.DefaultUnitsDirectory)
 	if err != nil {
 		return nil, err
 	}

--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/coreos/fleet/Godeps/_workspace/src/github.com/coreos/go-systemd/dbus"
 
+	"github.com/coreos/fleet/config"
 	"github.com/coreos/fleet/log"
 	"github.com/coreos/fleet/pkg"
 	"github.com/coreos/fleet/unit"
@@ -38,9 +39,24 @@ type systemdUnitManager struct {
 
 	hashes map[string]unit.Hash
 	mutex  sync.RWMutex
+
+	enableUnitStateCache bool
+	unitStateCache       *unitStateCache
 }
 
-func NewSystemdUnitManager(uDir string) (*systemdUnitManager, error) {
+type unitStateCache struct {
+	unitStates            map[string]*unit.UnitState
+	registerUnitOperation map[string]string
+}
+
+func NewSystemdUnitManager(cfg config.Config, uDir string) (*systemdUnitManager, error) {
+	statesCache := &unitStateCache{}
+	if cfg.EnableUnitStateCache {
+		statesCache = &unitStateCache{
+			unitStates:            make(map[string]*unit.UnitState),
+			registerUnitOperation: make(map[string]string),
+		}
+	}
 	systemd, err := dbus.New()
 	if err != nil {
 		return nil, err
@@ -56,10 +72,12 @@ func NewSystemdUnitManager(uDir string) (*systemdUnitManager, error) {
 	}
 
 	mgr := systemdUnitManager{
-		systemd:  systemd,
-		unitsDir: uDir,
-		hashes:   hashes,
-		mutex:    sync.RWMutex{},
+		systemd:              systemd,
+		unitsDir:             uDir,
+		hashes:               hashes,
+		mutex:                sync.RWMutex{},
+		enableUnitStateCache: cfg.EnableUnitStateCache,
+		unitStateCache:       statesCache,
 	}
 	return &mgr, nil
 }
@@ -107,6 +125,10 @@ func (m *systemdUnitManager) Load(name string, u unit.UnitFile) error {
 		return err
 	}
 	m.hashes[name] = u.Hash()
+	if m.enableUnitStateCache {
+		m.unitStateCache.registerUnitOperation[name] = "load"
+	}
+
 	return nil
 }
 
@@ -117,6 +139,10 @@ func (m *systemdUnitManager) Unload(name string) {
 	defer m.mutex.Unlock()
 	delete(m.hashes, name)
 	m.removeUnit(name)
+
+	if m.enableUnitStateCache {
+		m.unitStateCache.registerUnitOperation[name] = "unload"
+	}
 }
 
 // TriggerStart asynchronously starts the unit identified by the given name.
@@ -127,6 +153,10 @@ func (m *systemdUnitManager) TriggerStart(name string) {
 		log.Infof("Triggered systemd unit %s start: job=%d", name, jobID)
 	} else {
 		log.Errorf("Failed to trigger systemd unit %s start: %v", name, err)
+	}
+
+	if m.enableUnitStateCache {
+		m.unitStateCache.registerUnitOperation[name] = "start"
 	}
 }
 
@@ -139,6 +169,9 @@ func (m *systemdUnitManager) TriggerStop(name string) {
 	} else {
 		log.Errorf("Failed to trigger systemd unit %s stop: %v", name, err)
 	}
+	if m.enableUnitStateCache {
+		m.unitStateCache.registerUnitOperation[name] = "stop"
+	}
 }
 
 // GetUnitState generates a UnitState object representing the
@@ -146,6 +179,13 @@ func (m *systemdUnitManager) TriggerStop(name string) {
 func (m *systemdUnitManager) GetUnitState(name string) (*unit.UnitState, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
+
+	// If there is not any operation previously registered, we return the cached state
+	_, ok := m.unitStateCache.registerUnitOperation[name]
+	if m.enableUnitStateCache && !ok && m.unitStateCache.unitStates[name] != nil {
+		return m.unitStateCache.unitStates[name], nil
+	}
+
 	us, err := m.getUnitState(name)
 	if err != nil {
 		return nil, err
@@ -187,7 +227,6 @@ func (m *systemdUnitManager) ReloadUnitFiles() error {
 // this manager's units directory.
 func (m *systemdUnitManager) Units() ([]string, error) {
 	return lsUnitsDir(m.unitsDir)
-
 }
 
 func (m *systemdUnitManager) GetUnitStates(filter pkg.Set) (map[string]*unit.UnitState, error) {
@@ -198,13 +237,14 @@ func (m *systemdUnitManager) GetUnitStates(filter pkg.Set) (map[string]*unit.Uni
 	// present in the initial ListUnits() call.
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	dbusStatuses, err := m.systemd.ListUnits()
 
+	// Systemd units has to be queried as unit states can change at any time.
+	dbusStatuses, err := m.systemd.ListUnits()
 	if err != nil {
 		return nil, err
 	}
 
-	states := make(map[string]*unit.UnitState)
+	unitStates := make(map[string]*unit.UnitState)
 	for _, dus := range dbusStatuses {
 		if !filter.Contains(dus.Name) {
 			continue
@@ -218,27 +258,49 @@ func (m *systemdUnitManager) GetUnitStates(filter pkg.Set) (map[string]*unit.Uni
 		if h, ok := m.hashes[dus.Name]; ok {
 			us.UnitHash = h.String()
 		}
-		states[dus.Name] = us
+		unitStates[dus.Name] = us
+		if m.enableUnitStateCache {
+			delete(m.unitStateCache.registerUnitOperation, dus.Name)
+		}
 	}
 
-	// grab data on subscribed units that didn't show up in ListUnits, most
-	// likely due to being inactive
+	unitStates, err = m.inactiveUnitStates(filter, unitStates)
+
+	if m.enableUnitStateCache {
+		m.unitStateCache.unitStates = unitStates
+	}
+	return unitStates, nil
+}
+
+// This function grabs data on subscribed units that didn't show up in ListUnits, most
+// likely due to being an inactive state
+func (m *systemdUnitManager) inactiveUnitStates(filter pkg.Set, unitStates map[string]*unit.UnitState) (map[string]*unit.UnitState, error) {
 	for _, name := range filter.Values() {
-		if _, ok := states[name]; ok {
+		if _, ok := unitStates[name]; ok {
 			continue
 		}
 
-		us, err := m.getUnitState(name)
-		if err != nil {
-			return nil, err
+		// If there is any operation previously registered we collect the states from systemd
+		_, ok := m.unitStateCache.registerUnitOperation[name]
+		if m.enableUnitStateCache && !ok && m.unitStateCache.unitStates[name] != nil {
+			unitStates[name] = m.unitStateCache.unitStates[name]
+		} else {
+			us, err := m.getUnitState(name)
+			if err != nil {
+				return unitStates, err
+			}
+			if h, ok := m.hashes[name]; ok {
+				us.UnitHash = h.String()
+			}
+			unitStates[name] = us
+
+			if m.enableUnitStateCache {
+				delete(m.unitStateCache.registerUnitOperation, name)
+			}
 		}
-		if h, ok := m.hashes[name]; ok {
-			us.UnitHash = h.String()
-		}
-		states[name] = us
 	}
 
-	return states, nil
+	return unitStates, nil
 }
 
 func (m *systemdUnitManager) writeUnit(name string, contents string) error {

--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -265,6 +265,9 @@ func (m *systemdUnitManager) GetUnitStates(filter pkg.Set) (map[string]*unit.Uni
 	}
 
 	unitStates, err = m.inactiveUnitStates(filter, unitStates)
+	if err != nil {
+		return nil, err
+	}
 
 	if m.enableUnitStateCache {
 		m.unitStateCache.unitStates = unitStates
@@ -287,7 +290,7 @@ func (m *systemdUnitManager) inactiveUnitStates(filter pkg.Set, unitStates map[s
 		} else {
 			us, err := m.getUnitState(name)
 			if err != nil {
-				return unitStates, err
+				return nil, err
 			}
 			if h, ok := m.hashes[name]; ok {
 				us.UnitHash = h.String()


### PR DESCRIPTION
Unit state cache: 

**Motivation:** Inactive units induce an overload to systemd-dbus communication which linearly increases proportionally to the amount of existing inactive units. Therefore, we decided to research about solutions to minimize the workload of fleet caused by this issue. We decided to build a cache to reduce the amount of calls from systemd to dbus. Fleet periodically performs operations to gather the state of the units in the cluster, so for each inactive unit located in a host, a read operation is triggered to obtain the state from dbus. Therefore, you could have an impression of how this operation could use more resources than the desired.

Nevertheless, we thought about another optimal solution during the development of this cache. This solution requires to modify the `go-dbus` library implementation to provide an event-driven mechanism. This event-driven mechanism would notify every time an operation affects the state of a unit. These notifications would enable to know when the state of a unit change without having to constantly query systemd to get its state.  Obviously we declined this solution as it required the modification of third party software used by fleet.

## Implementation
We added a new flag `enable_unitstate_cache` that will activate the usage of the unit state cache and therefore to minimize the usage of the system resources. The unit state cache is used to give the state of inactive units whenever no operation has been recently triggered over them. Otherwise the system will query to dbus in order to get its final state. Consequently, we register operations that are being triggered over the units in order to decide whether or not to use its cached state.

### Test scenario:
- 3 node cluster
- fleet version 0.11.3
- CoreOS stable (835.9.0)
- etcd version 2.2.1

## Metrics analyzed:
- CPU usage
- Memory usage
- FS bytes usage
- NET bytes IN
- NET bytes OUT
- NET bytes TOTAL 
- Capacity used

### Savings deducted from these experiments:

A brief and quick summary:
- There is a clear CPU reduction using the unit state cache. In the following experiments, this benefit can be identified as approx. 10% CPU usage reduction. However this amount will increase/decrease based on the amount of inactive units.
- There is a clear Memory usage reduction using the unit state cache.  In the following experiments, this benefit is up to approx. 100Mb Memory usage reduction. However this amount will increase/decrease based on the amount of inactive units.
- FS bytes used during the experiments slightly INCREASED with the unit state implementation.
- NET bytes IN/OUT used during the experiments slightly INCREASED in the implementation WITHOUT unit cache.
- Capacity used obviously decreased when using the unit state cache.


### Experiment 1:
Without any iteration in the cluster, we evaluated how 3 inactive units could use the system resources of a host.

#### CPU usage of our implementation using an UNIT STATE CACHE:
<img width="1139" alt="screen shot 2016-01-21 at 6 06 52 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488013/e27eac54-c069-11e5-8270-90e8e0268def.png">

#### Memory usage of our implementation using an UNIT STATE CACHE:
<img width="1133" alt="screen shot 2016-01-21 at 6 07 11 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488014/e2848f2a-c069-11e5-8f3f-4335946689c5.png">

#### CPU usage WITHOUT unit state cache:
<img width="1134" alt="screen shot 2016-01-21 at 6 04 31 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488084/28bcae3c-c06a-11e5-9bcc-5f106455dfe6.png">

#### Memory usage WITHOUT unit state cache:
<img width="1139" alt="screen shot 2016-01-21 at 6 04 59 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488085/28bdcd6c-c06a-11e5-92c2-26b49f5fd1fa.png">

As shown above, there is a slight difference caused by these periodic queries to dbus in order to get the state of inactive units.

### Experiment 2:
We used a benchmarking tool that starts 900 units in the cluster, and consequently stop+destroy all after a timeout.

#### CPU usage of our implementation using an UNIT STATE CACHE:
<img width="1127" alt="screen shot 2016-01-21 at 5 39 26 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487096/00660e50-c066-11e5-8e5d-477e1a3587b2.png">

#### CPU usage WITHOUT unit state cache:
<img width="1130" alt="screen shot 2016-01-21 at 6 15 52 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488263/0df22ad6-c06b-11e5-9982-4b4ad56675cb.png">
--------------------
### Memory usage of our implementation using an UNIT STATE CACHE:
<img width="1077" alt="screen shot 2016-01-21 at 3 59 26 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487117/199194c6-c066-11e5-8c26-81850174d56e.png">

### Memory usage WITHOUT unit state cache:
<img width="1132" alt="screen shot 2016-01-21 at 6 15 38 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488262/0de70872-c06b-11e5-8986-cdcbc7f12350.png">
--------------------
### FS bytes used of our implementation using an UNIT STATE CACHE:
<img width="875" alt="screen shot 2016-01-21 at 3 59 37 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487119/19951f88-c066-11e5-956c-898712b940ab.png">
### FS bytes used WITHOUT unit state cache:
<img width="876" alt="screen shot 2016-01-21 at 3 57 13 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488707/3e9df2f8-c06d-11e5-9673-7b6d558371b6.png">
--------------------
### Capacity usage of our implementation using an UNIT STATE CACHE:
<img width="878" alt="screen shot 2016-01-21 at 3 59 44 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487118/1993d8a8-c066-11e5-9fd4-2952173705de.png">
### Capacity used WITHOUT unit state cache:
<img width="875" alt="screen shot 2016-01-21 at 3 57 21 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488709/3ea51d26-c06d-11e5-81d2-3b8435e7ac8f.png">
--------------------
### Net bytes IN of our implementation using an UNIT STATE CACHE:
<img width="878" alt="screen shot 2016-01-21 at 3 59 54 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487116/1990d072-c066-11e5-993c-f06b3b95d7d0.png">

### Net bytes IN WITHOUT unit state cache:
<img width="881" alt="screen shot 2016-01-21 at 3 56 42 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488706/3e9c0ee8-c06d-11e5-8f6e-138ff6a37809.png">
----------------------
### Net bytes OUT of our implementation using an UNIT STATE CACHE:
<img width="873" alt="screen shot 2016-01-21 at 4 00 01 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487121/19aae1a6-c066-11e5-9927-98af0d682a23.png">

### Net bytes OUT WITHOUT unit state cache:
<img width="871" alt="screen shot 2016-01-21 at 3 56 50 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488708/3ea1047a-c06d-11e5-9df1-69a46a78d27a.png">

--------------------
### Net bytes total of our implementation using an UNIT STATE CACHE:
<img width="886" alt="screen shot 2016-01-21 at 4 00 10 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487120/19a9d4f0-c066-11e5-9c84-77ab220e1c27.png">
### Net bytes total WITHOUT unit state cache:
<img width="1138" alt="screen shot 2016-01-21 at 6 38 58 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488966/55b57cd0-c06e-11e5-959e-cf59a4ec509a.png">


NOTE: As shown in above Figures (CPU usage, Mem usage, ...) there are two spikes that represent the start operation and the stop/destroy operation which is performed after a fixed timeout.