### PR TITLE
fleetctl: destroy fix and more tests

### DIFF
--- a/client/http.go
+++ b/client/http.go
@@ -137,3 +137,7 @@ func is404(err error) bool {
 	googerr, ok := err.(*googleapi.Error)
 	return ok && googerr.Code == http.StatusNotFound
 }
+
+func IsErrorUnitNotFound(err error) bool {
+	return is404(err)
+}

--- a/fleetctl/destroy.go
+++ b/fleetctl/destroy.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"time"
+
+	"github.com/coreos/fleet/client"
 )
 
 var cmdDestroyUnit = &Command{
@@ -42,6 +44,10 @@ func runDestroyUnits(args []string) (exit int) {
 	for _, v := range units {
 		err := cAPI.DestroyUnit(v.Name)
 		if err != nil {
+			// Ignore 'Unit does not exist' error
+			if client.IsErrorUnitNotFound(err) {
+				continue
+			}
 			stderr("Error destroying units: %v", err)
 			exit = 1
 			continue

--- a/fleetctl/destroy.go
+++ b/fleetctl/destroy.go
@@ -71,7 +71,7 @@ func runDestroyUnits(args []string) (exit int) {
 				if u == nil {
 					break
 				}
-				time.Sleep(500 * time.Millisecond)
+				time.Sleep(defaultSleepTime)
 			}
 		}
 

--- a/fleetctl/destroy_test.go
+++ b/fleetctl/destroy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,73 +18,17 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
-
-	"github.com/coreos/fleet/client"
-	"github.com/coreos/fleet/job"
-	"github.com/coreos/fleet/machine"
-	"github.com/coreos/fleet/registry"
-	"github.com/coreos/fleet/unit"
 )
 
-type DestroyTestResults struct {
-	Description  string
-	DestroyUnits []string
-	ExpectedExit int
-}
-
-func newFakeRegistryForDestroy(prefix string, unitCnt int) client.API {
-	// clear machineStates for every invocation
-	machineStates = nil
-	machines := []machine.MachineState{
-		newMachineState("c31e44e1-f858-436e-933e-59c642517860", "1.2.3.4", map[string]string{"ping": "pong"}),
-		newMachineState("595989bb-cbb7-49ce-8726-722d6e157b4e", "5.6.7.8", map[string]string{"foo": "bar"}),
+func doDestroyUnits(r commandTestResults, errchan chan error) {
+	exit := runDestroyUnits(r.units)
+	if exit != r.expectedExit {
+		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
 	}
-
-	jobs := make([]job.Job, 0)
-	appendJobsForTests(&jobs, machines[0], prefix, unitCnt)
-	appendJobsForTests(&jobs, machines[1], prefix, unitCnt)
-
-	states := make([]unit.UnitState, 0)
-	for i := 1; i <= unitCnt; i++ {
-		state := unit.UnitState{
-			UnitName:    fmt.Sprintf("%s%d.service", prefix, i),
-			LoadState:   "loaded",
-			ActiveState: "active",
-			SubState:    "listening",
-			MachineID:   machines[0].ID,
-		}
-		states = append(states, state)
-	}
-
-	for i := 1; i <= unitCnt; i++ {
-		state := unit.UnitState{
-			UnitName:    fmt.Sprintf("%s%d.service", prefix, i),
-			LoadState:   "loaded",
-			ActiveState: "inactive",
-			SubState:    "dead",
-			MachineID:   machines[1].ID,
-		}
-		states = append(states, state)
-	}
-
-	reg := registry.NewFakeRegistry()
-	reg.SetMachines(machines)
-	reg.SetUnitStates(states)
-	reg.SetJobs(jobs)
-
-	return &client.RegistryClient{Registry: reg}
-}
-
-func doDestroyUnits(r DestroyTestResults, errchan chan error) {
-	exit := runDestroyUnits(r.DestroyUnits)
-	if exit != r.ExpectedExit {
-		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.Description, r.ExpectedExit, exit)
-	}
-	for _, destroyedUnit := range r.DestroyUnits {
+	for _, destroyedUnit := range r.units {
 		u, _ := cAPI.Unit(destroyedUnit)
 		if u != nil {
-			errchan <- fmt.Errorf("%s: unit %s was not destroyed as requested", r.Description, destroyedUnit)
+			errchan <- fmt.Errorf("%s: unit %s was not destroyed as requested", r.description, destroyedUnit)
 		}
 	}
 }
@@ -92,14 +36,14 @@ func doDestroyUnits(r DestroyTestResults, errchan chan error) {
 // TestRunDestroyUnits checks for correct unit destruction
 func TestRunDestroyUnits(t *testing.T) {
 	unitPrefix := "j"
-	results := []DestroyTestResults{
+	results := []commandTestResults{
 		{
 			"destroy available units",
 			[]string{"j1", "j2", "j3", "j4", "j5"},
 			0,
 		},
 		{
-			"destroy non-existent units",
+			"destroy non-available units",
 			[]string{"y1", "y2"},
 			0,
 		},
@@ -118,12 +62,11 @@ func TestRunDestroyUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForDestroy(unitPrefix, len(r.DestroyUnits))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
 
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			time.Sleep(2 * time.Microsecond)
 			doDestroyUnits(r, errchan)
 		}()
 		go func() {

--- a/fleetctl/destroy_test.go
+++ b/fleetctl/destroy_test.go
@@ -75,6 +75,11 @@ func TestRunDestroyUnits(t *testing.T) {
 			0,
 		},
 		{
+			"destroy non-existent units",
+			[]string{"y1", "y2"},
+			0,
+		},
+		{
 			"attempt to destroy available and non-available units",
 			[]string{"j1", "j2", "j3"},
 			0,

--- a/fleetctl/destroy_test.go
+++ b/fleetctl/destroy_test.go
@@ -1,0 +1,97 @@
+// Copyright 2014 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/coreos/fleet/client"
+	"github.com/coreos/fleet/job"
+	"github.com/coreos/fleet/machine"
+	"github.com/coreos/fleet/registry"
+	"github.com/coreos/fleet/unit"
+)
+
+func newFakeRegistryForDestroy() client.API {
+	// clear machineStates for every invocation
+	machineStates = nil
+	machines := []machine.MachineState{
+		newMachineState("c31e44e1-f858-436e-933e-59c642517860", "1.2.3.4", map[string]string{"ping": "pong"}),
+		newMachineState("595989bb-cbb7-49ce-8726-722d6e157b4e", "5.6.7.8", map[string]string{"foo": "bar"}),
+	}
+
+	jobs := []job.Job{
+		job.Job{Name: "j1.service", Unit: unit.UnitFile{}, TargetMachineID: machines[0].ID},
+		job.Job{Name: "j2.service", Unit: unit.UnitFile{}, TargetMachineID: machines[1].ID},
+	}
+
+	states := []unit.UnitState{
+		unit.UnitState{
+			UnitName:    "j1.service",
+			LoadState:   "loaded",
+			ActiveState: "active",
+			SubState:    "listening",
+			MachineID:   machines[0].ID,
+		},
+		unit.UnitState{
+			UnitName:    "j2.service",
+			LoadState:   "loaded",
+			ActiveState: "inactive",
+			SubState:    "dead",
+			MachineID:   machines[1].ID,
+		},
+	}
+
+	reg := registry.NewFakeRegistry()
+	reg.SetMachines(machines)
+	reg.SetUnitStates(states)
+	reg.SetJobs(jobs)
+
+	return &client.RegistryClient{Registry: reg}
+}
+
+// TestRunDestroyUnits checks for correct unit destruction
+func TestRunDestroyUnits(t *testing.T) {
+	for _, s := range []struct {
+		Description  string
+		DestroyUnits []string
+		ExpectedExit int
+	}{
+		{
+			"destroy available units",
+			[]string{"j1", "j2"},
+			0,
+		},
+		{
+			"attempt to destroy available and non-available units",
+			[]string{"j1", "j2", "j3"},
+			0,
+		},
+	} {
+		cAPI = newFakeRegistryForDestroy()
+		exit := runDestroyUnits(s.DestroyUnits)
+		if exit != s.ExpectedExit {
+			t.Errorf("%s: expected exit code %d but received %d",
+				s.Description, s.ExpectedExit, exit)
+		}
+		for _, destroyedUnit := range s.DestroyUnits {
+			u, _ := cAPI.Unit(destroyedUnit)
+			if u != nil {
+				t.Errorf("%s: unit %s was not destroyed as requested",
+					s.Description, destroyedUnit)
+			}
+		}
+	}
+}

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -59,7 +59,8 @@ recommended to upgrade fleetctl to prevent incompatibility issues.
 	clientDriverAPI  = "API"
 	clientDriverEtcd = "etcd"
 
-	defaultEndpoint = "unix:///var/run/fleet.sock"
+	defaultEndpoint  = "unix:///var/run/fleet.sock"
+	defaultSleepTime = 500 * time.Millisecond
 )
 
 var (
@@ -771,7 +772,7 @@ func waitForUnitStates(units []string, js job.JobState, maxAttempts int, out io.
 func checkUnitState(name string, js job.JobState, maxAttempts int, out io.Writer, wg *sync.WaitGroup, errchan chan error) {
 	defer wg.Done()
 
-	sleep := 500 * time.Millisecond
+	sleep := defaultSleepTime
 
 	if maxAttempts < 1 {
 		for {

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -15,9 +15,11 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/fleet/client"
+	"github.com/coreos/fleet/job"
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/registry"
 	"github.com/coreos/fleet/unit"
@@ -25,6 +27,19 @@ import (
 
 	"github.com/coreos/fleet/Godeps/_workspace/src/github.com/coreos/go-semver/semver"
 )
+
+func appendJobsForTests(jobs *[]job.Job, machine machine.MachineState, prefix string, unitCnt int) {
+	for i := 1; i <= unitCnt; i++ {
+		j := job.Job{
+			Name:            fmt.Sprintf("%s%d.service", prefix, i),
+			Unit:            unit.UnitFile{},
+			TargetMachineID: machine.ID,
+		}
+		*jobs = append(*jobs, j)
+	}
+
+	return
+}
 
 func newFakeRegistryForCheckVersion(v string) registry.ClusterRegistry {
 	sv, err := semver.NewVersion(v)

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -28,8 +28,57 @@ import (
 	"github.com/coreos/fleet/Godeps/_workspace/src/github.com/coreos/go-semver/semver"
 )
 
-func appendJobsForTests(jobs *[]job.Job, machine machine.MachineState, prefix string, unitCnt int) {
-	for i := 1; i <= unitCnt; i++ {
+type commandTestResults struct {
+	description  string
+	units        []string
+	expectedExit int
+}
+
+func newFakeRegistryForCommands(unitPrefix string, unitCount int) client.API {
+	// clear machineStates for every invocation
+	machineStates = nil
+	machines := []machine.MachineState{
+		newMachineState("c31e44e1-f858-436e-933e-59c642517860", "1.2.3.4", map[string]string{"ping": "pong"}),
+		newMachineState("595989bb-cbb7-49ce-8726-722d6e157b4e", "5.6.7.8", map[string]string{"foo": "bar"}),
+	}
+
+	jobs := make([]job.Job, 0)
+	appendJobsForTests(&jobs, machines[0], unitPrefix, unitCount)
+	appendJobsForTests(&jobs, machines[1], unitPrefix, unitCount)
+
+	states := make([]unit.UnitState, 0)
+	for i := 1; i <= unitCount; i++ {
+		state := unit.UnitState{
+			UnitName:    fmt.Sprintf("%s%d.service", unitPrefix, i),
+			LoadState:   "loaded",
+			ActiveState: "active",
+			SubState:    "listening",
+			MachineID:   machines[0].ID,
+		}
+		states = append(states, state)
+	}
+
+	for i := 1; i <= unitCount; i++ {
+		state := unit.UnitState{
+			UnitName:    fmt.Sprintf("%s%d.service", unitPrefix, i),
+			LoadState:   "loaded",
+			ActiveState: "inactive",
+			SubState:    "dead",
+			MachineID:   machines[1].ID,
+		}
+		states = append(states, state)
+	}
+
+	reg := registry.NewFakeRegistry()
+	reg.SetMachines(machines)
+	reg.SetUnitStates(states)
+	reg.SetJobs(jobs)
+
+	return &client.RegistryClient{Registry: reg}
+}
+
+func appendJobsForTests(jobs *[]job.Job, machine machine.MachineState, prefix string, unitCount int) {
+	for i := 1; i <= unitCount; i++ {
 		j := job.Job{
 			Name:            fmt.Sprintf("%s%d.service", prefix, i),
 			Unit:            unit.UnitFile{},

--- a/fleetctl/stop_test.go
+++ b/fleetctl/stop_test.go
@@ -61,7 +61,7 @@ func TestRunStopUnits(t *testing.T) {
 			0,
 		},
 		{
-			"attempt to stop available and non-available units",
+			"stop available and non-available units",
 			[]string{"y1", "y2", "y3", "y4", "stop1", "stop2", "stop3", "stop4", "stop5", "y0"},
 			0,
 		},

--- a/fleetctl/stop_test.go
+++ b/fleetctl/stop_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func doStopUnits(r commandTestResults, errchan chan error) {
-	sharedFlags.NoBlock = true
-
 	exit := runStopUnit(r.units)
 	if exit != r.expectedExit {
 		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
@@ -46,6 +44,11 @@ func doStopUnits(r commandTestResults, errchan chan error) {
 
 func TestRunStopUnits(t *testing.T) {
 	unitPrefix := "stop"
+	oldNoBlock := sharedFlags.NoBlock
+	defer func() {
+		sharedFlags.NoBlock = oldNoBlock
+	}()
+
 	results := []commandTestResults{
 		{
 			"stop available units",
@@ -64,6 +67,7 @@ func TestRunStopUnits(t *testing.T) {
 		},
 	}
 
+	sharedFlags.NoBlock = true
 	for _, r := range results {
 		var wg sync.WaitGroup
 		errchan := make(chan error)

--- a/fleetctl/stop_test.go
+++ b/fleetctl/stop_test.go
@@ -1,0 +1,92 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/coreos/fleet/job"
+)
+
+func doStopUnits(r commandTestResults, errchan chan error) {
+	sharedFlags.NoBlock = true
+
+	exit := runStopUnit(r.units)
+	if exit != r.expectedExit {
+		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+	}
+
+	real_units, err := findUnits(r.units)
+	if err != nil {
+		errchan <- err
+		return
+	}
+
+	// We assume that we reached the desired state
+	for _, v := range real_units {
+		if job.JobState(v.DesiredState) != job.JobStateLoaded {
+			errchan <- fmt.Errorf("Error: unit %s was not stopped as requested", v.Name)
+		}
+	}
+}
+
+func TestRunStopUnits(t *testing.T) {
+	unitPrefix := "stop"
+	results := []commandTestResults{
+		{
+			"stop available units",
+			[]string{"stop1", "stop2", "stop3", "stop4", "stop5"},
+			0,
+		},
+		{
+			"stop non-available units",
+			[]string{"y1", "y2"},
+			0,
+		},
+		{
+			"attempt to stop available and non-available units",
+			[]string{"y1", "y2", "y3", "y4", "stop1", "stop2", "stop3", "stop4", "stop5", "y0"},
+			0,
+		},
+	}
+
+	for _, r := range results {
+		var wg sync.WaitGroup
+		errchan := make(chan error)
+
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			doStopUnits(r, errchan)
+		}()
+		go func() {
+			defer wg.Done()
+			doStopUnits(r, errchan)
+		}()
+
+		go func() {
+			wg.Wait()
+			close(errchan)
+		}()
+
+		for err := range errchan {
+			t.Errorf("%v", err)
+		}
+	}
+}

--- a/fleetctl/unload_test.go
+++ b/fleetctl/unload_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func doUnloadUnits(r commandTestResults, errchan chan error) {
-	sharedFlags.NoBlock = true
-
 	exit := runUnloadUnit(r.units)
 	if exit != r.expectedExit {
 		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
@@ -46,6 +44,11 @@ func doUnloadUnits(r commandTestResults, errchan chan error) {
 
 func TestRunUnloadUnits(t *testing.T) {
 	unitPrefix := "unload"
+	oldNoBlock := sharedFlags.NoBlock
+	defer func() {
+		sharedFlags.NoBlock = oldNoBlock
+	}()
+
 	results := []commandTestResults{
 		{
 			"unload available units",
@@ -64,6 +67,7 @@ func TestRunUnloadUnits(t *testing.T) {
 		},
 	}
 
+	sharedFlags.NoBlock = true
 	for _, r := range results {
 		var wg sync.WaitGroup
 		errchan := make(chan error)

--- a/fleetctl/unload_test.go
+++ b/fleetctl/unload_test.go
@@ -61,7 +61,7 @@ func TestRunUnloadUnits(t *testing.T) {
 			0,
 		},
 		{
-			"attempt to unload available and non-available units",
+			"unload available and non-available units",
 			[]string{"y1", "y2", "y3", "y4", "unload1", "unload2", "unload3", "unload4", "unload5", "y0"},
 			0,
 		},

--- a/fleetctl/unload_test.go
+++ b/fleetctl/unload_test.go
@@ -1,0 +1,92 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/coreos/fleet/job"
+)
+
+func doUnloadUnits(r commandTestResults, errchan chan error) {
+	sharedFlags.NoBlock = true
+
+	exit := runUnloadUnit(r.units)
+	if exit != r.expectedExit {
+		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+	}
+
+	real_units, err := findUnits(r.units)
+	if err != nil {
+		errchan <- err
+		return
+	}
+
+	// We assume that we reached the desired state
+	for _, v := range real_units {
+		if job.JobState(v.DesiredState) != job.JobStateInactive {
+			errchan <- fmt.Errorf("Error: unit %s was not unloaded as requested", v.Name)
+		}
+	}
+}
+
+func TestRunUnloadUnits(t *testing.T) {
+	unitPrefix := "unload"
+	results := []commandTestResults{
+		{
+			"unload available units",
+			[]string{"unload1", "unload2", "unload3", "unload4", "unload5"},
+			0,
+		},
+		{
+			"unload non-available units",
+			[]string{"y1", "y2"},
+			0,
+		},
+		{
+			"attempt to unload available and non-available units",
+			[]string{"y1", "y2", "y3", "y4", "unload1", "unload2", "unload3", "unload4", "unload5", "y0"},
+			0,
+		},
+	}
+
+	for _, r := range results {
+		var wg sync.WaitGroup
+		errchan := make(chan error)
+
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			doUnloadUnits(r, errchan)
+		}()
+		go func() {
+			defer wg.Done()
+			doUnloadUnits(r, errchan)
+		}()
+
+		go func() {
+			wg.Wait()
+			close(errchan)
+		}()
+
+		for err := range errchan {
+			t.Errorf("%v", err)
+		}
+	}
+}


### PR DESCRIPTION
fleetctl destroy fix and more tests. It contains a follow up fix for the race condition that was discussed in this merged PR: https://github.com/coreos/fleet/pull/1417