### PR TITLE
build: check for go binaries and print a better error message

### DIFF
--- a/build
+++ b/build
@@ -7,6 +7,11 @@ ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/fleet"
 VERSION=$(git describe --dirty)
 
+if [ ! $(command -v go 2>/dev/null) ]; then
+  echo "build: failed to locate Go binaries."
+  exit 1
+fi
+
 source build-env
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then


### PR DESCRIPTION
Currently running ./build or ./test on hosts without go, gives the
confusing message:
build-env: line 3: go: command not found
build-env: line 20: go: command not found
./build: line 17: [: =: unary operator expected
Not on Linux - skipping fleetd build
Building fleetctl...
./build: line 25: go: command not found

Improve this by just:
build: can not find go binaries, Aborting.