### PR TITLE
fleetctl: more tests for start load command and template path

### DIFF
--- a/fleetctl/destroy_test.go
+++ b/fleetctl/destroy_test.go
@@ -24,6 +24,7 @@ func doDestroyUnits(r commandTestResults, errchan chan error) {
 	exit := runDestroyUnits(r.units)
 	if exit != r.expectedExit {
 		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+		return
 	}
 	for _, destroyedUnit := range r.units {
 		u, _ := cAPI.Unit(destroyedUnit)

--- a/fleetctl/destroy_test.go
+++ b/fleetctl/destroy_test.go
@@ -62,7 +62,7 @@ func TestRunDestroyUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -58,28 +58,28 @@ func newFakeRegistryForCommands(unitPrefix string, unitCount int, template bool)
 		states = append(states, state)
 		state.MachineID = machines[1].ID
 		states = append(states, state)
-	}
-
-	for i := 1; i <= unitCount; i++ {
-		state := unit.UnitState{
-			UnitName:    fmt.Sprintf("%s%d.service", unitPrefix, i),
-			LoadState:   "loaded",
-			ActiveState: "active",
-			SubState:    "listening",
-			MachineID:   machines[0].ID,
+	} else {
+		for i := 1; i <= unitCount; i++ {
+			state := unit.UnitState{
+				UnitName:    fmt.Sprintf("%s%d.service", unitPrefix, i),
+				LoadState:   "loaded",
+				ActiveState: "active",
+				SubState:    "listening",
+				MachineID:   machines[0].ID,
+			}
+			states = append(states, state)
 		}
-		states = append(states, state)
-	}
 
-	for i := 1; i <= unitCount; i++ {
-		state := unit.UnitState{
-			UnitName:    fmt.Sprintf("%s%d.service", unitPrefix, i),
-			LoadState:   "loaded",
-			ActiveState: "inactive",
-			SubState:    "dead",
-			MachineID:   machines[1].ID,
+		for i := 1; i <= unitCount; i++ {
+			state := unit.UnitState{
+				UnitName:    fmt.Sprintf("%s%d.service", unitPrefix, i),
+				LoadState:   "loaded",
+				ActiveState: "inactive",
+				SubState:    "dead",
+				MachineID:   machines[1].ID,
+			}
+			states = append(states, state)
 		}
-		states = append(states, state)
 	}
 
 	reg := registry.NewFakeRegistry()
@@ -91,7 +91,6 @@ func newFakeRegistryForCommands(unitPrefix string, unitCount int, template bool)
 }
 
 func appendJobsForTests(jobs *[]job.Job, machine machine.MachineState, prefix string, unitCount int, template bool) {
-
 	if template {
 		j := job.Job{
 			Name:            fmt.Sprintf("%s@.service", prefix),
@@ -99,15 +98,15 @@ func appendJobsForTests(jobs *[]job.Job, machine machine.MachineState, prefix st
 			TargetMachineID: machine.ID,
 		}
 		*jobs = append(*jobs, j)
-	}
-
-	for i := 1; i <= unitCount; i++ {
-		j := job.Job{
-			Name:            fmt.Sprintf("%s%d.service", prefix, i),
-			Unit:            unit.UnitFile{},
-			TargetMachineID: machine.ID,
+	} else {
+		for i := 1; i <= unitCount; i++ {
+			j := job.Job{
+				Name:            fmt.Sprintf("%s%d.service", prefix, i),
+				Unit:            unit.UnitFile{},
+				TargetMachineID: machine.ID,
+			}
+			*jobs = append(*jobs, j)
 		}
-		*jobs = append(*jobs, j)
 	}
 
 	return

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -34,7 +34,7 @@ type commandTestResults struct {
 	expectedExit int
 }
 
-func newFakeRegistryForCommands(unitPrefix string, unitCount int) client.API {
+func newFakeRegistryForCommands(unitPrefix string, unitCount int, template bool) client.API {
 	// clear machineStates for every invocation
 	machineStates = nil
 	machines := []machine.MachineState{
@@ -43,10 +43,23 @@ func newFakeRegistryForCommands(unitPrefix string, unitCount int) client.API {
 	}
 
 	jobs := make([]job.Job, 0)
-	appendJobsForTests(&jobs, machines[0], unitPrefix, unitCount)
-	appendJobsForTests(&jobs, machines[1], unitPrefix, unitCount)
+	appendJobsForTests(&jobs, machines[0], unitPrefix, unitCount, template)
+	appendJobsForTests(&jobs, machines[1], unitPrefix, unitCount, template)
 
 	states := make([]unit.UnitState, 0)
+	if template {
+		state := unit.UnitState{
+			UnitName:    fmt.Sprintf("%s@.service", unitPrefix),
+			LoadState:   "loaded",
+			ActiveState: "inactive",
+			SubState:    "dead",
+			MachineID:   machines[0].ID,
+		}
+		states = append(states, state)
+		state.MachineID = machines[1].ID
+		states = append(states, state)
+	}
+
 	for i := 1; i <= unitCount; i++ {
 		state := unit.UnitState{
 			UnitName:    fmt.Sprintf("%s%d.service", unitPrefix, i),
@@ -77,7 +90,17 @@ func newFakeRegistryForCommands(unitPrefix string, unitCount int) client.API {
 	return &client.RegistryClient{Registry: reg}
 }
 
-func appendJobsForTests(jobs *[]job.Job, machine machine.MachineState, prefix string, unitCount int) {
+func appendJobsForTests(jobs *[]job.Job, machine machine.MachineState, prefix string, unitCount int, template bool) {
+
+	if template {
+		j := job.Job{
+			Name:            fmt.Sprintf("%s@.service", prefix),
+			Unit:            unit.UnitFile{},
+			TargetMachineID: machine.ID,
+		}
+		*jobs = append(*jobs, j)
+	}
+
 	for i := 1; i <= unitCount; i++ {
 		j := job.Job{
 			Name:            fmt.Sprintf("%s%d.service", prefix, i),

--- a/fleetctl/load_test.go
+++ b/fleetctl/load_test.go
@@ -39,6 +39,7 @@ func doLoadUnits(r commandTestResults, errchan chan error) {
 	exit := runLoadUnits(r.units)
 	if exit != r.expectedExit {
 		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+		return
 	}
 
 	real_units, err := findUnits(r.units)

--- a/fleetctl/load_test.go
+++ b/fleetctl/load_test.go
@@ -82,7 +82,7 @@ func TestRunLoadUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/load_test.go
+++ b/fleetctl/load_test.go
@@ -1,0 +1,106 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/coreos/fleet/job"
+	"github.com/coreos/fleet/schema"
+)
+
+func checkLoadUnitState(unit schema.Unit, loadRet int, errchan chan error) {
+	if loadRet == 0 {
+		if job.JobState(unit.DesiredState) != job.JobStateLoaded {
+			errchan <- fmt.Errorf("Error: unit %s was not loaded as requested", unit.Name)
+		}
+	} else if unit.DesiredState != "" {
+		// if the whole load operation failed, then no unit
+		// should have a DesiredState set
+		errchan <- fmt.Errorf("Error: Unit(%s) DesiredState was set to (%s)", unit.Name, unit.DesiredState)
+	}
+}
+
+func doLoadUnits(r commandTestResults, errchan chan error) {
+	exit := runLoadUnits(r.units)
+	if exit != r.expectedExit {
+		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+	}
+
+	real_units, err := findUnits(r.units)
+	if err != nil {
+		errchan <- err
+		return
+	}
+
+	for _, v := range real_units {
+		checkLoadUnitState(v, r.expectedExit, errchan)
+	}
+}
+
+func TestRunLoadUnits(t *testing.T) {
+	unitPrefix := "load"
+	oldNoBlock := sharedFlags.NoBlock
+	defer func() {
+		sharedFlags.NoBlock = oldNoBlock
+	}()
+
+	results := []commandTestResults{
+		{
+			"load available units",
+			[]string{"load1", "load2", "load3", "load4", "load5"},
+			0,
+		},
+		{
+			"load non-available units",
+			[]string{"y1", "y2"},
+			1,
+		},
+		{
+			"load available and non-available units",
+			[]string{"y1", "y2", "y3", "y4", "load1", "load2", "load3", "load4", "load5", "load6", "y0"},
+			1,
+		},
+	}
+
+	sharedFlags.NoBlock = true
+	for _, r := range results {
+		var wg sync.WaitGroup
+		errchan := make(chan error)
+
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			doLoadUnits(r, errchan)
+		}()
+		go func() {
+			defer wg.Done()
+			doLoadUnits(r, errchan)
+		}()
+
+		go func() {
+			wg.Wait()
+			close(errchan)
+		}()
+
+		for err := range errchan {
+			t.Errorf("%v", err)
+		}
+	}
+}

--- a/fleetctl/start_test.go
+++ b/fleetctl/start_test.go
@@ -53,11 +53,17 @@ func doStartUnits(r commandTestResults, errchan chan error) {
 }
 
 func runStartUnits(t *testing.T, unitPrefix string, results []commandTestResults, template bool) {
+	unitsCount := 0
+	sharedFlags.NoBlock = true
 	for _, r := range results {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), template)
+		if !template {
+			unitsCount = len(r.units)
+		}
+
+		cAPI = newFakeRegistryForCommands(unitPrefix, unitsCount, template)
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/stop_test.go
+++ b/fleetctl/stop_test.go
@@ -26,6 +26,7 @@ func doStopUnits(r commandTestResults, errchan chan error) {
 	exit := runStopUnit(r.units)
 	if exit != r.expectedExit {
 		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+		return
 	}
 
 	real_units, err := findUnits(r.units)

--- a/fleetctl/stop_test.go
+++ b/fleetctl/stop_test.go
@@ -72,7 +72,7 @@ func TestRunStopUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/unload_test.go
+++ b/fleetctl/unload_test.go
@@ -26,6 +26,7 @@ func doUnloadUnits(r commandTestResults, errchan chan error) {
 	exit := runUnloadUnit(r.units)
 	if exit != r.expectedExit {
 		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+		return
 	}
 
 	real_units, err := findUnits(r.units)

--- a/fleetctl/unload_test.go
+++ b/fleetctl/unload_test.go
@@ -72,7 +72,7 @@ func TestRunUnloadUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {


### PR DESCRIPTION
Add more tests for fleetctl start and load commands, and make sure that the template unit path also works as expected. While we are it improve fleetctl test helper functions.