### PR TITLE
tests: Added run-in-qemu script for functional tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # fleet - a distributed init system
 
 [![Build Status](https://travis-ci.org/coreos/fleet.png?branch=master)](https://travis-ci.org/coreos/fleet)
+[![Build Status](https://semaphoreci.com/api/v1/coreos/fleet/branches/master/badge.svg)](https://semaphoreci.com/coreos/fleet)
 
 fleet ties together [systemd](http://coreos.com/using-coreos/systemd) and [etcd](https://github.com/coreos/etcd) into a simple distributed init system. Think of it as an extension of systemd that operates at the cluster level instead of the machine level.
 

--- a/functional/README.md
+++ b/functional/README.md
@@ -23,7 +23,19 @@ $ ./run-in-vagrant
 
 Vagrant's provision step includes go binaries download using `functional/provision/install_go.sh` script.
 
-### Run tests inside other CoreOS platforms (QEMU/BareMetal/libvirt/etc)
+### Run tests in QEMU
+
+If you don't want to use Vagrant or VirtualBox, you can run tests inside official CoreOS QEMU image. You have to make sure QEMU is installed on your system.
+
+```sh
+$ git clone https://github.com/coreos/fleet
+$ cd fleet/functional
+$ ./run-in-qemu
+```
+
+If you get `Could not access KVM kernel module: Permission denied` error message, please make sure your CPU supports hardware-assisted virtualization and try to run the script using `sudo`.
+
+### Run tests inside other CoreOS platforms (BareMetal/EC2/GCE/libvirt/etc)
 
 It's also possible to run the tests on CoreOS on other platforms. The following commands should be run *inside* the CoreOS instance.
 
@@ -65,7 +77,7 @@ sudo dpkg -i vagrant_1.8.1_x86_64.deb
 echo "deb http://download.virtualbox.org/virtualbox/debian $(lsb_release -sc) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
 wget -q https://www.virtualbox.org/download/oracle_vbox.asc -O- | sudo apt-key add -
 sudo apt-get update
-sudo apt-get install -y build-essential dkms
+sudo apt-get install -y build-essential linux-headers-`uname -r` dkms
 sudo apt-get install -y VirtualBox-5.0
 #Previous VirtualBox (if you have problems with nested virtualization, more info here: https://www.virtualbox.org/ticket/14965)
 #sudo apt-get install -y VirtualBox-4.3

--- a/functional/provision/install_qemu_on_semaphoreci.sh
+++ b/functional/provision/install_qemu_on_semaphoreci.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Installing QEMU..."
+sudo apt-get update -qq
+sudo apt-get install -qq -y qemu-system-x86

--- a/functional/provision/install_vagrant_on_semaphoreci.sh
+++ b/functional/provision/install_vagrant_on_semaphoreci.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+echo "Installing Vagrant and VirtualBox..."
+echo "deb http://download.virtualbox.org/virtualbox/debian $(lsb_release -sc) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
+wget -q https://www.virtualbox.org/download/oracle_vbox.asc -O- | sudo apt-key add -
+sudo apt-get update -qq
+sudo apt-get install -qq -y build-essential dkms nfs-kernel-server linux-headers-`uname -r`
+wget -P /tmp/ https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
+sudo dpkg -i /tmp/vagrant_1.8.1_x86_64.deb
+sudo apt-get install -qq -y VirtualBox-4.3

--- a/functional/run-in-qemu
+++ b/functional/run-in-qemu
@@ -1,0 +1,70 @@
+#!/bin/bash -e
+
+if ! qemu-system-x86_64 --version > /dev/null 2>&1; then
+  echo "Please install QEMU first"
+  exit 1
+fi
+
+CDIR=$(cd `dirname $0` && pwd)
+cd $CDIR
+
+ARGS=`for i in "$@"; do printf '%q ' "$i"; done`
+
+CONFIG_DIR=$(mktemp -t -d coreos-configdrive.XXXXXXXXXX)
+mkdir -p "${CONFIG_DIR}/openstack/latest"
+QEMU_DIR=$HOME/.qemu
+mkdir -p $QEMU_DIR
+MAX_SSH_TRIES=60
+SSH_KEYS=$(cat fixtures/id_rsa.pub)
+PID_FILE=$(mktemp)
+SSH_PORT=2222
+NAME=fleet-tester
+IMAGE=$QEMU_DIR/coreos_production_qemu_image.img
+CHANNEL=stable
+
+if [ ! -f "$IMAGE" ]; then
+  curl --progress-bar http://$CHANNEL.release.core-os.net/amd64-usr/current/coreos_production_qemu_image.img.bz2 | bzcat > $IMAGE
+fi
+
+trap 'kill $(cat $PID_FILE) && rm -f "$PID_FILE" && rm -rf "$CONFIG_DIR"' EXIT
+
+sed "s#---#ssh_authorized_keys:\n - $SSH_KEYS#" user-data > ${CONFIG_DIR}/openstack/latest/user_data
+
+qemu-system-x86_64 \
+  -name $NAME \
+  -m 512 \
+  -net nic,vlan=0,model=virtio \
+  -net user,vlan=0,hostfwd=tcp:127.0.0.1:$SSH_PORT-:22,hostname=$NAME \
+  -drive if=virtio,file=$IMAGE \
+  -fsdev local,id=conf,security_model=none,readonly,path=$CONFIG_DIR \
+  -fsdev local,id=fleet,security_model=none,path=$CDIR/../ \
+  -device virtio-9p-pci,fsdev=conf,mount_tag=config-2 \
+  -device virtio-9p-pci,fsdev=fleet,mount_tag=fleet \
+  -machine accel=kvm \
+  -cpu host \
+  -smp 1 \
+  -daemonize \
+  -display none \
+  -serial none \
+  -pidfile $PID_FILE
+
+TRY=0
+while true; do
+  TRY=$((TRY+1))
+  if [ $TRY -gt $MAX_SSH_TRIES ]; then
+    echo "Can not connect to ssh, exiting..."
+    exit 1
+  fi
+  echo "Trying to connect to qemu VM, #${TRY} of #${MAX_SSH_TRIES}..."
+  set +e
+  RES=$(ssh -l core -o ConnectTimeout=1 -o PasswordAuthentication=no -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $SSH_PORT -i fixtures/id_rsa 127.0.0.1 "ls ~/fleet/functional/test" 2>&1)
+  RES_CODE=$?
+  set -e
+  if [ $RES_CODE -eq 0 ]; then
+    break
+  else
+    echo "$RES" | grep -q "Connection refused" && sleep 1 || true
+  fi
+done
+
+ssh -l core -o PasswordAuthentication=no -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $SSH_PORT -i fixtures/id_rsa 127.0.0.1 "sudo ~/fleet/functional/test $ARGS"

--- a/functional/run-in-vagrant
+++ b/functional/run-in-vagrant
@@ -3,5 +3,10 @@
 CDIR=$(cd `dirname $0` && pwd)
 cd $CDIR
 
+if ! vagrant version > /dev/null 2>&1; then
+  echo "Please install vagrant first"
+  exit 1
+fi
+
 vagrant up
 vagrant ssh core-01 -c "sudo ~/fleet/functional/test"

--- a/functional/user-data
+++ b/functional/user-data
@@ -8,5 +8,16 @@ coreos:
   units:
   - name: etcd2.service
     command: start
+  - name: home-core-fleet.mount
+    command: start
+    content: |
+      [Unit]
+      Requires=systemd-networkd-wait-online.service
+      After=systemd-networkd-wait-online.service
+      [Mount]
+      What=fleet
+      Where=/home/core/fleet
+      Type=9p
+      Options=rw,trans=virtio,version=9p2000.L
   update:
     reboot-strategy: off


### PR DESCRIPTION
/cc @jonboulle 

Can you configure semaphoreci with the commands below?

setup: `./functional/provision/install_qemu_on_semaphoreci.sh`
run tests: `sudo ./functional/run-in-qemu`