### PR TITLE
fleetctl:test: {destroy|stop|unload} if the test fails then return as early as possible

### DIFF
--- a/fleetctl/destroy_test.go
+++ b/fleetctl/destroy_test.go
@@ -24,6 +24,7 @@ func doDestroyUnits(r commandTestResults, errchan chan error) {
 	exit := runDestroyUnits(r.units)
 	if exit != r.expectedExit {
 		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+		return
 	}
 	for _, destroyedUnit := range r.units {
 		u, _ := cAPI.Unit(destroyedUnit)

--- a/fleetctl/stop_test.go
+++ b/fleetctl/stop_test.go
@@ -26,6 +26,7 @@ func doStopUnits(r commandTestResults, errchan chan error) {
 	exit := runStopUnit(r.units)
 	if exit != r.expectedExit {
 		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+		return
 	}
 
 	real_units, err := findUnits(r.units)

--- a/fleetctl/unload_test.go
+++ b/fleetctl/unload_test.go
@@ -26,6 +26,7 @@ func doUnloadUnits(r commandTestResults, errchan chan error) {
 	exit := runUnloadUnit(r.units)
 	if exit != r.expectedExit {
 		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+		return
 	}
 
 	real_units, err := findUnits(r.units)


### PR DESCRIPTION
If the tests fail then return, and avoid printing other confusing error messages