### PR TITLE
fleetctl:test: improve the start test and make sure that it handles templates

### DIFF
--- a/fleetctl/destroy_test.go
+++ b/fleetctl/destroy_test.go
@@ -63,7 +63,7 @@ func TestRunDestroyUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/load_test.go
+++ b/fleetctl/load_test.go
@@ -83,7 +83,7 @@ func TestRunLoadUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/start_test.go
+++ b/fleetctl/start_test.go
@@ -15,80 +15,123 @@
 package main
 
 import (
-	"time"
+	"fmt"
+	"sync"
+	"testing"
 
-	"github.com/coreos/fleet/client"
 	"github.com/coreos/fleet/job"
-	"github.com/coreos/fleet/machine"
-	"github.com/coreos/fleet/registry"
-	"github.com/coreos/fleet/unit"
+	"github.com/coreos/fleet/schema"
 )
 
-type BlockedFakeRegistry struct {
-	EchoAttempts int
-	registry.FakeRegistry
+func checkStartUnitState(unit schema.Unit, startRet int, errchan chan error) {
+	if startRet == 0 {
+		if job.JobState(unit.DesiredState) != job.JobStateLaunched {
+			errchan <- fmt.Errorf("Error: unit %s was not started as requested", unit.Name)
+		}
+	} else if unit.DesiredState != "" {
+		// if the whole start operation failed, then no unit
+		// should have a DesiredState set
+		errchan <- fmt.Errorf("Error: Unit(%s) DesiredState was set to (%s)", unit.Name, unit.DesiredState)
+	}
 }
 
-func (b *BlockedFakeRegistry) Unit(name string) (*job.Unit, error) {
-	if name == "hello.service" {
-		time.Sleep(500 * time.Millisecond)
+func doStartUnits(r commandTestResults, errchan chan error) {
+	exit := runStartUnit(r.units)
+	if exit != r.expectedExit {
+		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+		return
 	}
 
-	if name == "echo.service" {
-		if b.EchoAttempts != 0 {
-			b.EchoAttempts--
-			return nil, nil
+	real_units, err := findUnits(r.units)
+	if err != nil {
+		errchan <- err
+		return
+	}
+
+	for _, v := range real_units {
+		checkStartUnitState(v, r.expectedExit, errchan)
+	}
+}
+
+func runStartUnits(t *testing.T, unitPrefix string, results []commandTestResults, template bool) {
+	unitsCount := 0
+	sharedFlags.NoBlock = true
+	for _, r := range results {
+		var wg sync.WaitGroup
+		errchan := make(chan error)
+
+		if !template {
+			unitsCount = len(r.units)
+		}
+
+		cAPI = newFakeRegistryForCommands(unitPrefix, unitsCount, template)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			doStartUnits(r, errchan)
+		}()
+
+		go func() {
+			wg.Wait()
+			close(errchan)
+		}()
+
+		for err := range errchan {
+			t.Errorf("%v", err)
 		}
 	}
-
-	return b.FakeRegistry.Unit(name)
 }
 
-func setupRegistryForStart(echoAttempts int) {
-	m1 := machine.MachineState{
-		ID:       "c31e44e1-f858-436e-933e-59c642517860",
-		PublicIP: "1.2.3.4",
-		Metadata: map[string]string{"ping": "pong"},
-	}
-	m2 := machine.MachineState{
-		ID:       "595989bb-cbb7-49ce-8726-722d6e157b4e",
-		PublicIP: "5.6.7.8",
-		Metadata: map[string]string{"foo": "bar"},
-	}
-	m3 := machine.MachineState{
-		ID:       "520983A8-FB9C-4A68-B49C-CED5BB2E9D08",
-		Metadata: map[string]string{"foo": "bar"},
-	}
+func TestRunStartUnits(t *testing.T) {
+	unitPrefix := "start"
+	oldNoBlock := sharedFlags.NoBlock
+	defer func() {
+		sharedFlags.NoBlock = oldNoBlock
+	}()
 
-	states := []unit.UnitState{
-		unit.UnitState{
-			UnitName:    "pong.service",
-			LoadState:   "loaded",
-			ActiveState: "active",
-			SubState:    "listening",
-			MachineID:   m1.ID,
+	results := []commandTestResults{
+		{
+			"start available units",
+			[]string{"start1", "start2", "start3", "start4", "start5", "start6"},
+			0,
 		},
-		unit.UnitState{
-			UnitName:    "hello.service",
-			LoadState:   "loaded",
-			ActiveState: "inactive",
-			SubState:    "dead",
-			MachineID:   m2.ID,
+		{
+			"start non-available units",
+			[]string{"y1", "y2"},
+			1,
 		},
-		unit.UnitState{
-			UnitName:    "echo.service",
-			LoadState:   "loaded",
-			ActiveState: "inactive",
-			SubState:    "dead",
-			MachineID:   m2.ID,
+		{
+			"start available and non-available units",
+			[]string{"y1", "y2", "y3", "y4", "start1", "start2", "start3", "start4", "start5", "start6", "y0"},
+			1,
+		},
+		{
+			"start a unit from a non-available template",
+			[]string{"foo-template@1"},
+			1,
 		},
 	}
 
-	machines := []machine.MachineState{m1, m2, m3}
+	templateResults := []commandTestResults{
+		{
+			"start a unit from a non-available template",
+			[]string{"start-foo@1"},
+			1,
+		},
+		{
+			"start units from an available template",
+			[]string{"start@1", "start@100", "start@1000"},
+			0,
+		},
+		{
+			"start same unit from an available template",
+			[]string{"start@1", "start@1", "start@1"},
+			0,
+		},
+	}
 
-	reg := registry.NewFakeRegistry()
-	reg.SetMachines(machines)
-	reg.SetUnitStates(states)
-
-	cAPI = &client.RegistryClient{Registry: &BlockedFakeRegistry{EchoAttempts: echoAttempts, FakeRegistry: *reg}}
+	sharedFlags.NoBlock = true
+	runStartUnits(t, unitPrefix, results, false)
+	runStartUnits(t, unitPrefix, templateResults, true)
 }

--- a/fleetctl/stop_test.go
+++ b/fleetctl/stop_test.go
@@ -73,7 +73,7 @@ func TestRunStopUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/unload_test.go
+++ b/fleetctl/unload_test.go
@@ -73,7 +73,7 @@ func TestRunUnloadUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {


### PR DESCRIPTION
Patch 1: This is a preparation patch for the next start test patch that will try to create and start units from a template unit.

Patch 2: improve the start test and make sure that it handles templates