### PR TITLE
tests: Fix kvm kernel module bug at semaphoreci

### DIFF
--- a/functional/provision/install_qemu_on_semaphoreci.sh
+++ b/functional/provision/install_qemu_on_semaphoreci.sh
@@ -3,3 +3,5 @@
 echo "Installing QEMU..."
 sudo apt-get update -qq
 sudo apt-get install -qq -y qemu-system-x86
+# Fix "initctl: Unknown job: qemu-kvm" bug
+sudo initctl --system start qemu-kvm || true


### PR DESCRIPTION
Sometimes Ubuntu has problems starting upstart services
https://bugs.launchpad.net/ubuntu/+source/upstart/+bug/1367214
This fix implements workaround
/cc @jonboulle @tixxdz 