### PR TITLE
fleetctl: {load|unload|start|stop} and get unit code cleanups

### DIFF
--- a/fleetctl/destroy_test.go
+++ b/fleetctl/destroy_test.go
@@ -63,7 +63,7 @@ func TestRunDestroyUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -487,7 +487,7 @@ func getUnitFile(file string) (*unit.UnitFile, error) {
 	var uf *unit.UnitFile
 	name := unitNameMangle(file)
 
-	log.Debugf("Looking up for Unit(%s) or its corresponding template", name)
+	log.Debugf("Looking for Unit(%s) or its corresponding template", name)
 
 	// Assume that the file references a local unit file on disk and
 	// attempt to load it, if it exists
@@ -499,14 +499,14 @@ func getUnitFile(file string) (*unit.UnitFile, error) {
 	} else {
 		// Otherwise (if the unit file does not exist), check if the
 		// name appears to be an instance unit, and if so, check for
-		// a corresponding template unit in the Registry or disk
+		// a corresponding template unit in the Registry or disk.
+		// If we found a template unit, later we create a
+		// near-identical instance unit in the Registry - same
+		// unit file as the template, but different name
 		uf, err = getUnitFileFromTemplate(file)
 		if err != nil {
 			return nil, err
 		}
-
-		// If we found a template unit, create a near-identical instance unit in
-		// the Registry - same unit file as the template, but different name
 	}
 
 	log.Debugf("Found Unit(%s)", name)
@@ -792,12 +792,10 @@ func getBlockAttempts() int {
 	// By default we wait forever
 	var attempts int = -1
 
-	// Up to BlockAttempts
 	if sharedFlags.BlockAttempts > 0 {
 		attempts = sharedFlags.BlockAttempts
 	}
 
-	// NoBlock we do not wait
 	if sharedFlags.NoBlock {
 		attempts = 0
 	}

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -785,19 +785,19 @@ func setTargetStateOfUnits(units []string, state job.JobState) ([]*schema.Unit, 
 
 // getBlockAttempts gets the correct value of how many attempts to try
 // before giving up on an operation.
-// It returns a negative value which means try forever, if zero is
-// returned then do not make any attempt, and if a positive value is
+// It returns a negative value which means do not block, if zero is
+// returned then it means try forever, and if a positive value is
 // returned then try up to that value
 func getBlockAttempts() int {
 	// By default we wait forever
-	var attempts int = -1
+	var attempts int = 0
 
 	if sharedFlags.BlockAttempts > 0 {
 		attempts = sharedFlags.BlockAttempts
 	}
 
 	if sharedFlags.NoBlock {
-		attempts = 0
+		attempts = -1
 	}
 
 	return attempts
@@ -808,14 +808,14 @@ func getBlockAttempts() int {
 // desired JobState, how many attempts before timing out and a writer
 // interface.
 // tryWaitForUnitStates polls each of the indicated units until they
-// reach the desired state. If maxAttempts is zero, then it will not
+// reach the desired state. If maxAttempts is negative, then it will not
 // wait, it will assume that all units reached their desired state.
-// If maxAttempts is negative tryWaitForUnitStates will retry forever, and
+// If maxAttempts is zero tryWaitForUnitStates will retry forever, and
 // if it is greater than zero, it will retry up to the indicated value.
 // It returns 0 on success or 1 on errors.
 func tryWaitForUnitStates(units []string, state string, js job.JobState, maxAttempts int, out io.Writer) (ret int) {
 	// We do not wait just assume we reached the desired state
-	if maxAttempts == 0 {
+	if maxAttempts <= -1 {
 		for _, name := range units {
 			stdout("Triggered unit %s %s", name, state)
 		}

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -501,7 +501,7 @@ func getUnitFile(file string) (*unit.UnitFile, error) {
 		// name appears to be an instance of a template unit
 		info, err := getUnitInstanceInfo(name)
 		if err != nil {
-			return nil, fmt.Errorf("failed getting template Unit(%s) info: %v", name, err)
+			return nil, fmt.Errorf("failed getting Unit(%s) info: %v", name, err)
 		}
 
 		// If it is an instance check for a corresponding template
@@ -539,7 +539,7 @@ func getUnitInstanceInfo(name string) (*unit.UnitNameInfo, error) {
 	if uni == nil {
 		return nil, errors.New("unable to extract information from unit name")
 	} else if !uni.IsInstance() {
-		return nil, errors.New("Not an instance of a template unit")
+		return nil, errors.New("unable to find Unit in Registry or on filesystem")
 	}
 
 	return uni, nil
@@ -565,7 +565,7 @@ func getUnitFileFromTemplate(arg string, uni *unit.UnitNameInfo) (*unit.UnitFile
 		// check the local disk for one instead
 		file := path.Join(path.Dir(arg), uni.Template)
 		if _, err := os.Stat(file); os.IsNotExist(err) {
-			return nil, fmt.Errorf("unable to find Unit(%s) on filesystem", file)
+			return nil, fmt.Errorf("unable to find Unit(%s) in Registry or on filesystem", uni.Template)
 		}
 
 		uf, err = getUnitFromFile(file)

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -506,9 +506,11 @@ func getUnitFile(file string) (*unit.UnitFile, error) {
 	} else {
 		// Otherwise (if the unit file does not exist), check if the
 		// name appears to be an instance of a template unit
-		info, err := getUnitInstanceInfo(name)
-		if err != nil {
-			return nil, fmt.Errorf("failed getting Unit(%s) info: %v", name, err)
+		info := unit.NewUnitNameInfo(name)
+		if info == nil {
+			return nil, fmt.Errorf("error extracting information from unit name %s", name)
+		} else if !info.IsInstance() {
+			return nil, fmt.Errorf("unable to find Unit(%s) in Registry or on filesystem", name)
 		}
 
 		// If it is an instance check for a corresponding template
@@ -538,18 +540,6 @@ func getUnitFromFile(file string) (*unit.UnitFile, error) {
 	log.Debugf("Unit(%s) found in local filesystem", unitName)
 
 	return unit.NewUnitFile(string(out))
-}
-
-func getUnitInstanceInfo(name string) (*unit.UnitNameInfo, error) {
-	// Check if the name appears to be an instance unit
-	uni := unit.NewUnitNameInfo(name)
-	if uni == nil {
-		return nil, errors.New("unable to extract information from unit name")
-	} else if !uni.IsInstance() {
-		return nil, errors.New("unable to find Unit in Registry or on filesystem")
-	}
-
-	return uni, nil
 }
 
 // getUnitFileFromTemplate attempts to get a Unit from a template unit that

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -483,6 +483,13 @@ func getChecker() *ssh.HostKeyChecker {
 	return ssh.NewHostKeyChecker(keyFile)
 }
 
+// getUnitFile attempts to get a UnitFile configuration
+// It takes a unit file name as a parameter and tries first to lookup
+// the unit from the local disk. If it fails, it checks if the provided
+// file name may reference an instance of a template unit, if so, it
+// tries to get the template configuration either from the registry or
+// the local disk.
+// It returns a UnitFile configuration or nil; and any error ecountered
 func getUnitFile(file string) (*unit.UnitFile, error) {
 	var uf *unit.UnitFile
 	name := unitNameMangle(file)
@@ -509,7 +516,7 @@ func getUnitFile(file string) (*unit.UnitFile, error) {
 		// If we found a template unit, later we create a
 		// near-identical instance unit in the Registry - same
 		// unit file as the template, but different name
-		uf, err = getUnitFileFromTemplate(file, info)
+		uf, err = getUnitFileFromTemplate(info, file)
 		if err != nil {
 			return nil, fmt.Errorf("failed getting Unit(%s) from template: %v", file, err)
 		}
@@ -545,10 +552,11 @@ func getUnitInstanceInfo(name string) (*unit.UnitNameInfo, error) {
 	return uni, nil
 }
 
-// getUnitFileFromTemplate checks if the name appears to be an instance unit
-// and gets its corresponding template unit from the registry or local disk
+// getUnitFileFromTemplate attempts to get a Unit from a template unit that
+// is either in the registry or on the file system
+// It takes two arguments, the template information and the unit file name
 // It returns the Unit or nil; and any error encountered
-func getUnitFileFromTemplate(arg string, uni *unit.UnitNameInfo) (*unit.UnitFile, error) {
+func getUnitFileFromTemplate(uni *unit.UnitNameInfo, fileName string) (*unit.UnitFile, error) {
 	var uf *unit.UnitFile
 
 	tmpl, err := cAPI.Unit(uni.Template)
@@ -557,20 +565,20 @@ func getUnitFileFromTemplate(arg string, uni *unit.UnitNameInfo) (*unit.UnitFile
 	}
 
 	if tmpl != nil {
-		warnOnDifferentLocalUnit(arg, tmpl)
+		warnOnDifferentLocalUnit(fileName, tmpl)
 		uf = schema.MapSchemaUnitOptionsToUnitFile(tmpl.Options)
 		log.Debugf("Template Unit(%s) found in registry", uni.Template)
 	} else {
 		// Finally, if we could not find a template unit in the Registry,
 		// check the local disk for one instead
-		file := path.Join(path.Dir(arg), uni.Template)
-		if _, err := os.Stat(file); os.IsNotExist(err) {
+		filePath := path.Join(path.Dir(fileName), uni.Template)
+		if _, err := os.Stat(filePath); os.IsNotExist(err) {
 			return nil, fmt.Errorf("unable to find Unit(%s) in Registry or on filesystem", uni.Template)
 		}
 
-		uf, err = getUnitFromFile(file)
+		uf, err = getUnitFromFile(filePath)
 		if err != nil {
-			return nil, fmt.Errorf("unable to load Unit(%s) from file: %v", file, err)
+			return nil, fmt.Errorf("unable to load Unit(%s) from file: %v", filePath, err)
 		}
 	}
 

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -221,6 +221,37 @@ func TestUnitNameMangle(t *testing.T) {
 	}
 }
 
+func TestGetBlockAttempts(t *testing.T) {
+	oldNoBlock := sharedFlags.NoBlock
+	oldBlockAttempts := sharedFlags.BlockAttempts
+
+	defer func() {
+		sharedFlags.NoBlock = oldNoBlock
+		sharedFlags.BlockAttempts = oldBlockAttempts
+	}()
+
+	var blocktests = []struct {
+		noBlock       bool
+		blockAttempts int
+		expected      int
+	}{
+		{true, 0, -1},
+		{true, -1, -1},
+		{true, 9999, -1},
+		{false, 0, 0},
+		{false, -1, 0},
+		{false, 9999, 9999},
+	}
+
+	for _, tt := range blocktests {
+		sharedFlags.NoBlock = tt.noBlock
+		sharedFlags.BlockAttempts = tt.blockAttempts
+		if n := getBlockAttempts(); n != tt.expected {
+			t.Errorf("got %d, want %d", n, tt.expected)
+		}
+	}
+}
+
 func newUnitFile(t *testing.T, contents string) *unit.UnitFile {
 	uf, err := unit.NewUnitFile(contents)
 	if err != nil {

--- a/fleetctl/load.go
+++ b/fleetctl/load.go
@@ -46,6 +46,8 @@ func init() {
 }
 
 func runLoadUnits(args []string) (exit int) {
+	attempts := getBlockAttempts()
+
 	if err := lazyCreateUnits(args); err != nil {
 		stderr("Error creating units: %v", err)
 		return 1
@@ -66,17 +68,7 @@ func runLoadUnits(args []string) (exit int) {
 		}
 	}
 
-	if !sharedFlags.NoBlock {
-		errchan := waitForUnitStates(loading, job.JobStateLoaded, sharedFlags.BlockAttempts, os.Stdout)
-		for err := range errchan {
-			stderr("Error waiting for units: %v", err)
-			exit = 1
-		}
-	} else {
-		for _, name := range loading {
-			stdout("Triggered unit %s load", name)
-		}
-	}
+	exit = tryWaitForUnitStates(loading, "load", job.JobStateLoaded, attempts, os.Stdout)
 
 	return
 }

--- a/fleetctl/load.go
+++ b/fleetctl/load.go
@@ -46,8 +46,6 @@ func init() {
 }
 
 func runLoadUnits(args []string) (exit int) {
-	attempts := getBlockAttempts()
-
 	if err := lazyCreateUnits(args); err != nil {
 		stderr("Error creating units: %v", err)
 		return 1
@@ -68,7 +66,7 @@ func runLoadUnits(args []string) (exit int) {
 		}
 	}
 
-	exit = tryWaitForUnitStates(loading, "load", job.JobStateLoaded, attempts, os.Stdout)
+	exit = tryWaitForUnitStates(loading, "load", job.JobStateLoaded, getBlockAttempts(), os.Stdout)
 
 	return
 }

--- a/fleetctl/load_test.go
+++ b/fleetctl/load_test.go
@@ -83,7 +83,7 @@ func TestRunLoadUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -54,8 +54,6 @@ func init() {
 }
 
 func runStartUnit(args []string) (exit int) {
-	attempts := getBlockAttempts()
-
 	if err := lazyCreateUnits(args); err != nil {
 		stderr("Error creating units: %v", err)
 		return 1
@@ -76,7 +74,7 @@ func runStartUnit(args []string) (exit int) {
 		}
 	}
 
-	exit = tryWaitForUnitStates(starting, "start", job.JobStateLaunched, attempts, os.Stdout)
+	exit = tryWaitForUnitStates(starting, "start", job.JobStateLaunched, getBlockAttempts(), os.Stdout)
 
 	return
 }

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -54,6 +54,8 @@ func init() {
 }
 
 func runStartUnit(args []string) (exit int) {
+	attempts := getBlockAttempts()
+
 	if err := lazyCreateUnits(args); err != nil {
 		stderr("Error creating units: %v", err)
 		return 1
@@ -74,17 +76,7 @@ func runStartUnit(args []string) (exit int) {
 		}
 	}
 
-	if !sharedFlags.NoBlock {
-		errchan := waitForUnitStates(starting, job.JobStateLaunched, sharedFlags.BlockAttempts, os.Stdout)
-		for err := range errchan {
-			stderr("Error waiting for units: %v", err)
-			exit = 1
-		}
-	} else {
-		for _, name := range starting {
-			stdout("Triggered unit %s start", name)
-		}
-	}
+	exit = tryWaitForUnitStates(starting, "start", job.JobStateLaunched, attempts, os.Stdout)
 
 	return
 }

--- a/fleetctl/start_test.go
+++ b/fleetctl/start_test.go
@@ -15,80 +15,123 @@
 package main
 
 import (
-	"time"
+	"fmt"
+	"sync"
+	"testing"
 
-	"github.com/coreos/fleet/client"
 	"github.com/coreos/fleet/job"
-	"github.com/coreos/fleet/machine"
-	"github.com/coreos/fleet/registry"
-	"github.com/coreos/fleet/unit"
+	"github.com/coreos/fleet/schema"
 )
 
-type BlockedFakeRegistry struct {
-	EchoAttempts int
-	registry.FakeRegistry
+func checkStartUnitState(unit schema.Unit, startRet int, errchan chan error) {
+	if startRet == 0 {
+		if job.JobState(unit.DesiredState) != job.JobStateLaunched {
+			errchan <- fmt.Errorf("Error: unit %s was not started as requested", unit.Name)
+		}
+	} else if unit.DesiredState != "" {
+		// if the whole start operation failed, then no unit
+		// should have a DesiredState set
+		errchan <- fmt.Errorf("Error: Unit(%s) DesiredState was set to (%s)", unit.Name, unit.DesiredState)
+	}
 }
 
-func (b *BlockedFakeRegistry) Unit(name string) (*job.Unit, error) {
-	if name == "hello.service" {
-		time.Sleep(500 * time.Millisecond)
+func doStartUnits(r commandTestResults, errchan chan error) {
+	exit := runStartUnit(r.units)
+	if exit != r.expectedExit {
+		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+		return
 	}
 
-	if name == "echo.service" {
-		if b.EchoAttempts != 0 {
-			b.EchoAttempts--
-			return nil, nil
+	real_units, err := findUnits(r.units)
+	if err != nil {
+		errchan <- err
+		return
+	}
+
+	for _, v := range real_units {
+		checkStartUnitState(v, r.expectedExit, errchan)
+	}
+}
+
+func runStartUnits(t *testing.T, unitPrefix string, results []commandTestResults, template bool) {
+	unitsCount := 0
+	sharedFlags.NoBlock = true
+	for _, r := range results {
+		var wg sync.WaitGroup
+		errchan := make(chan error)
+
+		if !template {
+			unitsCount = len(r.units)
+		}
+
+		cAPI = newFakeRegistryForCommands(unitPrefix, unitsCount, template)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			doStartUnits(r, errchan)
+		}()
+
+		go func() {
+			wg.Wait()
+			close(errchan)
+		}()
+
+		for err := range errchan {
+			t.Errorf("%v", err)
 		}
 	}
-
-	return b.FakeRegistry.Unit(name)
 }
 
-func setupRegistryForStart(echoAttempts int) {
-	m1 := machine.MachineState{
-		ID:       "c31e44e1-f858-436e-933e-59c642517860",
-		PublicIP: "1.2.3.4",
-		Metadata: map[string]string{"ping": "pong"},
-	}
-	m2 := machine.MachineState{
-		ID:       "595989bb-cbb7-49ce-8726-722d6e157b4e",
-		PublicIP: "5.6.7.8",
-		Metadata: map[string]string{"foo": "bar"},
-	}
-	m3 := machine.MachineState{
-		ID:       "520983A8-FB9C-4A68-B49C-CED5BB2E9D08",
-		Metadata: map[string]string{"foo": "bar"},
-	}
+func TestRunStartUnits(t *testing.T) {
+	unitPrefix := "start"
+	oldNoBlock := sharedFlags.NoBlock
+	defer func() {
+		sharedFlags.NoBlock = oldNoBlock
+	}()
 
-	states := []unit.UnitState{
-		unit.UnitState{
-			UnitName:    "pong.service",
-			LoadState:   "loaded",
-			ActiveState: "active",
-			SubState:    "listening",
-			MachineID:   m1.ID,
+	results := []commandTestResults{
+		{
+			"start available units",
+			[]string{"start1", "start2", "start3", "start4", "start5", "start6"},
+			0,
 		},
-		unit.UnitState{
-			UnitName:    "hello.service",
-			LoadState:   "loaded",
-			ActiveState: "inactive",
-			SubState:    "dead",
-			MachineID:   m2.ID,
+		{
+			"start non-available units",
+			[]string{"y1", "y2"},
+			1,
 		},
-		unit.UnitState{
-			UnitName:    "echo.service",
-			LoadState:   "loaded",
-			ActiveState: "inactive",
-			SubState:    "dead",
-			MachineID:   m2.ID,
+		{
+			"start available and non-available units",
+			[]string{"y1", "y2", "y3", "y4", "start1", "start2", "start3", "start4", "start5", "start6", "y0"},
+			1,
+		},
+		{
+			"start a unit from a non-available template",
+			[]string{"foo-template@1"},
+			1,
 		},
 	}
 
-	machines := []machine.MachineState{m1, m2, m3}
+	templateResults := []commandTestResults{
+		{
+			"start a unit from a non-available template",
+			[]string{"start-foo@1"},
+			1,
+		},
+		{
+			"start units from an available template",
+			[]string{"start@1", "start@100", "start@1000"},
+			0,
+		},
+		{
+			"start same unit from an available template",
+			[]string{"start@1", "start@1", "start@1"},
+			0,
+		},
+	}
 
-	reg := registry.NewFakeRegistry()
-	reg.SetMachines(machines)
-	reg.SetUnitStates(states)
-
-	cAPI = &client.RegistryClient{Registry: &BlockedFakeRegistry{EchoAttempts: echoAttempts, FakeRegistry: *reg}}
+	sharedFlags.NoBlock = true
+	runStartUnits(t, unitPrefix, results, false)
+	runStartUnits(t, unitPrefix, templateResults, true)
 }

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -52,6 +52,8 @@ func init() {
 }
 
 func runStopUnit(args []string) (exit int) {
+	attempts := getBlockAttempts()
+
 	units, err := findUnits(args)
 	if err != nil {
 		stderr("%v", err)
@@ -79,17 +81,7 @@ func runStopUnit(args []string) (exit int) {
 		}
 	}
 
-	if !sharedFlags.NoBlock {
-		errchan := waitForUnitStates(stopping, job.JobStateLoaded, sharedFlags.BlockAttempts, os.Stdout)
-		for err := range errchan {
-			stderr("Error waiting for units: %v", err)
-			exit = 1
-		}
-	} else {
-		for _, name := range stopping {
-			stdout("Triggered unit %s stop", name)
-		}
-	}
+	exit = tryWaitForUnitStates(stopping, "stop", job.JobStateLoaded, attempts, os.Stdout)
 
 	return
 }

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -52,8 +52,6 @@ func init() {
 }
 
 func runStopUnit(args []string) (exit int) {
-	attempts := getBlockAttempts()
-
 	units, err := findUnits(args)
 	if err != nil {
 		stderr("%v", err)
@@ -81,7 +79,7 @@ func runStopUnit(args []string) (exit int) {
 		}
 	}
 
-	exit = tryWaitForUnitStates(stopping, "stop", job.JobStateLoaded, attempts, os.Stdout)
+	exit = tryWaitForUnitStates(stopping, "stop", job.JobStateLoaded, getBlockAttempts(), os.Stdout)
 
 	return
 }

--- a/fleetctl/stop_test.go
+++ b/fleetctl/stop_test.go
@@ -73,7 +73,7 @@ func TestRunStopUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -36,6 +36,8 @@ func init() {
 }
 
 func runUnloadUnit(args []string) (exit int) {
+	attempts := getBlockAttempts()
+
 	units, err := findUnits(args)
 	if err != nil {
 		stderr("%v", err)
@@ -60,17 +62,7 @@ func runUnloadUnit(args []string) (exit int) {
 		}
 	}
 
-	if !sharedFlags.NoBlock {
-		errchan := waitForUnitStates(wait, job.JobStateInactive, sharedFlags.BlockAttempts, os.Stdout)
-		for err := range errchan {
-			stderr("Error waiting for units: %v", err)
-			exit = 1
-		}
-	} else {
-		for _, name := range wait {
-			stdout("Triggered unit %s unload", name)
-		}
-	}
+	exit = tryWaitForUnitStates(wait, "unload", job.JobStateInactive, attempts, os.Stdout)
 
 	return
 }

--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -36,8 +36,6 @@ func init() {
 }
 
 func runUnloadUnit(args []string) (exit int) {
-	attempts := getBlockAttempts()
-
 	units, err := findUnits(args)
 	if err != nil {
 		stderr("%v", err)
@@ -62,7 +60,7 @@ func runUnloadUnit(args []string) (exit int) {
 		}
 	}
 
-	exit = tryWaitForUnitStates(wait, "unload", job.JobStateInactive, attempts, os.Stdout)
+	exit = tryWaitForUnitStates(wait, "unload", job.JobStateInactive, getBlockAttempts(), os.Stdout)
 
 	return
 }

--- a/fleetctl/unload_test.go
+++ b/fleetctl/unload_test.go
@@ -73,7 +73,7 @@ func TestRunUnloadUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
-		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units))
+		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
 
 		wg.Add(2)
 		go func() {


### PR DESCRIPTION
This patches set aims to make the code more consistent and robust. It does not change the current behaviour just improves the code, consolidate it, more debug logs and code comments.

The main goal is to let stop, start, load and unload to share the same code base and probably avoid any corner case or bug that may related to one of these commands.

Some logic can be easily shared later when we add stop to destroy command to solve #1000

There were some TODOs in the code base that I cleaned up with the last two patches. These patches will make it easy for us to implement later #1295

This new PR is to trigger semaphoreci.