### PR TITLE
fleet:functional-test: make Fleetctl() start print stdout and stderr on failures

### DIFF
--- a/functional/cluster_test.go
+++ b/functional/cluster_test.go
@@ -42,18 +42,18 @@ func TestDynamicClusterNewMemberUnitMigration(t *testing.T) {
 	}
 
 	// Start 3 conflicting units on the 4-node cluster
-	_, _, err = cluster.Fleetctl(m0, "start",
+	stdout, stderr, err := cluster.Fleetctl(m0, "start",
 		"fixtures/units/conflict.0.service",
 		"fixtures/units/conflict.1.service",
 		"fixtures/units/conflict.2.service",
 	)
 	if err != nil {
-		t.Errorf("Failed starting units: %v", err)
+		t.Errorf("Failed starting units: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
 	}
 
 	// All 3 services should be visible immediately, and all of them should
 	// become ACTIVE shortly thereafter
-	stdout, _, err := cluster.Fleetctl(m0, "list-units", "--no-legend")
+	stdout, _, err = cluster.Fleetctl(m0, "list-units", "--no-legend")
 	if err != nil {
 		t.Fatalf("Failed to run list-units: %v", err)
 	}

--- a/functional/node_test.go
+++ b/functional/node_test.go
@@ -42,9 +42,9 @@ func TestNodeShutdown(t *testing.T) {
 
 	// Start a unit and ensure it comes up quickly
 	unit := fmt.Sprintf("fixtures/units/pin@%s.service", machines[0])
-	_, _, err = cluster.Fleetctl(m0, "start", unit)
+	stdout, stderr, err := cluster.Fleetctl(m0, "start", unit)
 	if err != nil {
-		t.Errorf("Failed starting unit: %v", err)
+		t.Errorf("Failed starting unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
 	}
 	_, err = cluster.WaitForNActiveUnits(m0, 1)
 	if err != nil {
@@ -77,7 +77,7 @@ func TestNodeShutdown(t *testing.T) {
 	}
 
 	// The member's unit should actually stop running, too
-	stdout, _ := cluster.MemberCommand(m0, "sudo", "systemctl", "status", "hello.service")
+	stdout, _ = cluster.MemberCommand(m0, "sudo", "systemctl", "status", "hello.service")
 	if !strings.Contains(stdout, "Active: inactive") {
 		t.Fatalf("Unit hello.service not reported as inactive:\n%s\n", stdout)
 	}

--- a/functional/scheduling_test.go
+++ b/functional/scheduling_test.go
@@ -57,9 +57,9 @@ func TestScheduleMachineOf(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		ping := fmt.Sprintf("fixtures/units/ping.%d.service", i)
 		pong := fmt.Sprintf("fixtures/units/pong.%d.service", i)
-		_, _, err := cluster.Fleetctl(m0, "start", "--no-block", ping, pong)
+		stdout, stderr, err := cluster.Fleetctl(m0, "start", "--no-block", ping, pong)
 		if err != nil {
-			t.Errorf("Failed starting units: %v", err)
+			t.Errorf("Failed starting units: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
 		}
 	}
 
@@ -175,9 +175,9 @@ func TestScheduleConflicts(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		unit := fmt.Sprintf("fixtures/units/conflict.%d.service", i)
-		_, _, err := cluster.Fleetctl(m0, "start", "--no-block", unit)
+		stdout, stderr, err := cluster.Fleetctl(m0, "start", "--no-block", unit)
 		if err != nil {
-			t.Errorf("Failed starting unit %s: %v", unit, err)
+			t.Errorf("Failed starting unit %s: \nstdout: %s\nstderr: %s\nerr: %v", unit, stdout, stderr, err)
 		}
 	}
 
@@ -234,8 +234,8 @@ func TestScheduleOneWayConflict(t *testing.T) {
 
 	// Start a unit that conflicts with a yet-to-be-scheduled unit
 	name := "fixtures/units/conflicts-with-hello.service"
-	if _, _, err := cluster.Fleetctl(m0, "start", "--no-block", name); err != nil {
-		t.Fatalf("Failed starting unit %s: %v", name, err)
+	if stdout, stderr, err := cluster.Fleetctl(m0, "start", "--no-block", name); err != nil {
+		t.Fatalf("Failed starting unit %s: \nstdout: %s\nstderr: %s\nerr: %v", name, stdout, stderr, err)
 	}
 
 	active, err := cluster.WaitForNActiveUnits(m0, 1)
@@ -249,7 +249,9 @@ func TestScheduleOneWayConflict(t *testing.T) {
 
 	// Start a unit that has not defined conflicts
 	name = "fixtures/units/hello.service"
-	cluster.Fleetctl(m0, "start", "--no-block", name)
+	if stdout, stderr, err := cluster.Fleetctl(m0, "start", "--no-block", name); err != nil {
+		t.Fatalf("Failed starting unit %s: \nstdout: %s\nstderr: %s\nerr: %v", name, stdout, stderr, err)
+	}
 
 	// Both units should show up, but only conflicts-with-hello.service
 	// should report ACTIVE

--- a/functional/scheduling_test.go
+++ b/functional/scheduling_test.go
@@ -346,9 +346,9 @@ MachineID=%s
 		}
 		defer os.Remove(unitFile)
 
-		_, _, err = cluster.Fleetctl(m0, "start", unitFile)
+		stdout, stderr, err := cluster.Fleetctl(m0, "start", unitFile)
 		if err != nil {
-			t.Fatalf("Failed starting unit file %s: %v", unitFile, err)
+			t.Fatalf("Failed starting unit file %s: \nstdout: %s\nstderr: %s\nerr: %v", unitFile, stdout, stderr, err)
 		}
 
 		unit := filepath.Base(unitFile)
@@ -390,7 +390,10 @@ func TestScheduleGlobalUnits(t *testing.T) {
 	}
 
 	// Launch a couple of simple units
-	cluster.Fleetctl(m0, "start", "--no-block", "fixtures/units/hello.service", "fixtures/units/goodbye.service")
+	stdout, stderr, err := cluster.Fleetctl(m0, "start", "--no-block", "fixtures/units/hello.service", "fixtures/units/goodbye.service")
+	if err != nil {
+		t.Fatalf("Failed starting units: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
+	}
 
 	// Both units should show up active
 	_, err = cluster.WaitForNActiveUnits(m0, 2)
@@ -399,7 +402,10 @@ func TestScheduleGlobalUnits(t *testing.T) {
 	}
 
 	// Now add a global unit
-	cluster.Fleetctl(m0, "start", "--no-block", "fixtures/units/global.service")
+	stdout, stderr, err = cluster.Fleetctl(m0, "start", "--no-block", "fixtures/units/global.service")
+	if err != nil {
+		t.Fatalf("Failed starting unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
+	}
 
 	// Should see 2 + 3 units
 	states, err := cluster.WaitForNActiveUnits(m0, 5)

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -183,8 +183,8 @@ func TestUnitSSHActions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, err := cluster.Fleetctl(m, "start", "--no-block", "fixtures/units/hello.service"); err != nil {
-		t.Fatalf("Unable to start fleet unit: %v", err)
+	if stdout, stderr, err := cluster.Fleetctl(m, "start", "--no-block", "fixtures/units/hello.service"); err != nil {
+		t.Fatalf("Unable to start fleet unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
 	}
 
 	units, err := cluster.WaitForNActiveUnits(m, 1)


### PR DESCRIPTION
If functional tests fail in Fleetctl() start for some units, then just print directly as much information as possible. This will save some time when errors are just obvious ones.
