### PR TITLE
fleetctl: check for empty input unit strings

### DIFF
--- a/fleetctl/destroy.go
+++ b/fleetctl/destroy.go
@@ -35,6 +35,11 @@ Destroyed units are impossible to start unless re-submitted.`,
 }
 
 func runDestroyUnits(args []string) (exit int) {
+	if len(args) == 0 {
+		stderr("No units given")
+		return 0
+	}
+
 	units, err := findUnits(args)
 	if err != nil {
 		stderr("%v", err)

--- a/fleetctl/destroy_test.go
+++ b/fleetctl/destroy_test.go
@@ -53,6 +53,11 @@ func TestRunDestroyUnits(t *testing.T) {
 			[]string{"y1", "y2", "y3", "y4", "j1", "j2", "j3", "j4", "j5", "y0"},
 			0,
 		},
+		{
+			"destroy null input",
+			[]string{},
+			0,
+		},
 	}
 
 	// Check with two goroutines we don't care we should just get

--- a/fleetctl/load.go
+++ b/fleetctl/load.go
@@ -46,6 +46,11 @@ func init() {
 }
 
 func runLoadUnits(args []string) (exit int) {
+	if len(args) == 0 {
+		stderr("No units given")
+		return 0
+	}
+
 	if err := lazyCreateUnits(args); err != nil {
 		stderr("Error creating units: %v", err)
 		return 1

--- a/fleetctl/load_test.go
+++ b/fleetctl/load_test.go
@@ -76,6 +76,11 @@ func TestRunLoadUnits(t *testing.T) {
 			[]string{"y1", "y2", "y3", "y4", "load1", "load2", "load3", "load4", "load5", "load6", "y0"},
 			1,
 		},
+		{
+			"load null input",
+			[]string{},
+			0,
+		},
 	}
 
 	sharedFlags.NoBlock = true

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -54,6 +54,11 @@ func init() {
 }
 
 func runStartUnit(args []string) (exit int) {
+	if len(args) == 0 {
+		stderr("No units given")
+		return 0
+	}
+
 	if err := lazyCreateUnits(args); err != nil {
 		stderr("Error creating units: %v", err)
 		return 1

--- a/fleetctl/start_test.go
+++ b/fleetctl/start_test.go
@@ -111,6 +111,11 @@ func TestRunStartUnits(t *testing.T) {
 			[]string{"foo-template@1"},
 			1,
 		},
+		{
+			"start null input",
+			[]string{},
+			0,
+		},
 	}
 
 	templateResults := []commandTestResults{

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -52,6 +52,11 @@ func init() {
 }
 
 func runStopUnit(args []string) (exit int) {
+	if len(args) == 0 {
+		stderr("No units given")
+		return 0
+	}
+
 	units, err := findUnits(args)
 	if err != nil {
 		stderr("%v", err)

--- a/fleetctl/stop_test.go
+++ b/fleetctl/stop_test.go
@@ -66,6 +66,11 @@ func TestRunStopUnits(t *testing.T) {
 			[]string{"y1", "y2", "y3", "y4", "stop1", "stop2", "stop3", "stop4", "stop5", "y0"},
 			0,
 		},
+		{
+			"stop null input",
+			[]string{},
+			0,
+		},
 	}
 
 	sharedFlags.NoBlock = true

--- a/fleetctl/submit.go
+++ b/fleetctl/submit.go
@@ -36,6 +36,11 @@ func init() {
 }
 
 func runSubmitUnits(args []string) (exit int) {
+	if len(args) == 0 {
+		stderr("No units given")
+		return 0
+	}
+
 	if err := lazyCreateUnits(args); err != nil {
 		stderr("Error creating units: %v", err)
 		exit = 1

--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -36,6 +36,11 @@ func init() {
 }
 
 func runUnloadUnit(args []string) (exit int) {
+	if len(args) == 0 {
+		stderr("No units given")
+		return 0
+	}
+
 	units, err := findUnits(args)
 	if err != nil {
 		stderr("%v", err)

--- a/fleetctl/unload_test.go
+++ b/fleetctl/unload_test.go
@@ -66,6 +66,11 @@ func TestRunUnloadUnits(t *testing.T) {
 			[]string{"y1", "y2", "y3", "y4", "unload1", "unload2", "unload3", "unload4", "unload5", "y0"},
 			0,
 		},
+		{
+			"unload null input",
+			[]string{},
+			0,
+		},
 	}
 
 	sharedFlags.NoBlock = true


### PR DESCRIPTION
If no unit name is given for fleetctl commands like destroy, load,
start, stop, submit, and unload, then return with exit code 0,
printing out a soft warning message to stderr.

Fixes: #1443

/cc @kayrus @tixxdz @jonboulle
(A new revision of #1461)