### PR TITLE
functional-tests:clean: fix a typo in the functional-tests.log filename

### DIFF
--- a/functional/clean.sh
+++ b/functional/clean.sh
@@ -10,4 +10,4 @@ sudo systemctl daemon-reload
 ip link show fleet0 &>/dev/null && sudo ip link del fleet0
 etcdctl rm --recursive /fleet_functional
 
-rm -f functional-test.log
+rm -f functional-tests.log


### PR DESCRIPTION
functional-test.log should be functional-tests.log with (s)