### PR TITLE
tests: kill ssh-agent on exit

### DIFF
--- a/functional/test
+++ b/functional/test
@@ -11,6 +11,7 @@ export PATH=${HOME}/go/bin:${PATH}
 
 if [ ! -S "$SSH_AUTH_SOCK" ]; then
   eval $(ssh-agent)
+  trap "ssh-agent -k > /dev/null" EXIT
 fi
 
 # github doesn't support explicit file permission set, this is workaround


### PR DESCRIPTION
in case when you run several tests inside one VM you'd probably see lots of `ssh-agent`'s
/cc @jonboulle @antrik @tixxdz 