### PR TITLE
tests: fixed multiple sequenced tabs recognition

### DIFF
--- a/functional/util/util.go
+++ b/functional/util/util.go
@@ -98,7 +98,7 @@ type UnitState struct {
 
 func ParseUnitStates(units []string) (states []UnitState) {
 	for _, unit := range units {
-		cols := strings.SplitN(unit, "\t", 3)
+		cols := strings.Fields(unit)
 		if len(cols) == 3 {
 			machine := strings.SplitN(cols[2], "/", 2)[0]
 			states = append(states, UnitState{cols[0], cols[1], machine})


### PR DESCRIPTION
When string has multiple sequenced tabs, SplitN recognized tab as a column, not separator.

quick explanation is here: https://play.golang.org/p/yfLpvycQEk

fixes status detection here: https://github.com/endocode/fleet/commit/a9dca463494251d286035cbb7da991dcad839dc4

/cc @jonboulle @tixxdz 