### PR TITLE
fleetctl: print error when units were not found in registry

### DIFF
--- a/fleetctl/destroy.go
+++ b/fleetctl/destroy.go
@@ -46,6 +46,11 @@ func runDestroyUnits(args []string) (exit int) {
 		return 1
 	}
 
+	if len(units) == 0 {
+		stderr("Units not found in registry")
+		return 0
+	}
+
 	for _, v := range units {
 		err := cAPI.DestroyUnit(v.Name)
 		if err != nil {

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -63,6 +63,11 @@ func runStopUnit(args []string) (exit int) {
 		return 1
 	}
 
+	if len(units) == 0 {
+		stderr("Units not found in registry")
+		return 0
+	}
+
 	stopping := make([]string, 0)
 	for _, u := range units {
 		if !suToGlobal(u) {

--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -47,6 +47,11 @@ func runUnloadUnit(args []string) (exit int) {
 		return 1
 	}
 
+	if len(units) == 0 {
+		stderr("Units not found in registry")
+		return 0
+	}
+
 	wait := make([]string, 0)
 	for _, s := range units {
 		if !suToGlobal(s) {


### PR DESCRIPTION
Destroy logic was already [improved](https://github.com/coreos/fleet/commit/ad702480e3a5a404690396d6c6b5e6c8c5d486f4) so this issue could be closed: https://github.com/coreos/fleet/pull/1256
https://github.com/coreos/fleet/issues/710

But we still have to print some kind of error message when units were not found.