### PR TITLE
fleet: add replace unit support

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -563,7 +563,7 @@ func getUnitFileFromTemplate(uni *unit.UnitNameInfo, fileName string) (*unit.Uni
 	}
 
 	if tmpl != nil {
-		warnOnDifferentLocalUnit(fileName, tmpl)
+		isLocalUnitDifferent(fileName, tmpl, true, false)
 		uf = schema.MapSchemaUnitOptionsToUnitFile(tmpl.Options)
 		log.Debugf("Template Unit(%s) found in registry", uni.Template)
 	} else {
@@ -883,26 +883,6 @@ func isLocalUnitDifferent(file string, su *schema.Unit, warnIfDifferent bool, fa
 	}
 
 	return false, err
-}
-
-func warnOnDifferentLocalUnit(loc string, su *schema.Unit) {
-	suf := schema.MapSchemaUnitOptionsToUnitFile(su.Options)
-	if _, err := os.Stat(loc); !os.IsNotExist(err) {
-		luf, err := getUnitFromFile(loc)
-		if err == nil && luf.Hash() != suf.Hash() {
-			stderr("WARNING: Unit %s in registry differs from local unit file %s", su.Name, loc)
-			return
-		}
-	}
-	if uni := unit.NewUnitNameInfo(path.Base(loc)); uni != nil && uni.IsInstance() {
-		file := path.Join(path.Dir(loc), uni.Template)
-		if _, err := os.Stat(file); !os.IsNotExist(err) {
-			tmpl, err := getUnitFromFile(file)
-			if err == nil && tmpl.Hash() != suf.Hash() {
-				stderr("WARNING: Unit %s in registry differs from local template unit file %s", su.Name, uni.Template)
-			}
-		}
-	}
 }
 
 func lazyLoadUnits(args []string) ([]*schema.Unit, error) {

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -103,10 +103,14 @@ var (
 		Full          bool
 		NoLegend      bool
 		NoBlock       bool
+		Replace       bool
 		BlockAttempts int
 		Fields        string
 		SSHPort       int
 	}{}
+
+	// current command being executed
+	currentCommand string
 
 	// used to cache MachineStates
 	machineStates map[string]*machine.MachineState
@@ -286,6 +290,10 @@ func main() {
 			os.Exit(1)
 		}
 	}
+
+	// We use this to know in which context we are,
+	// submit, load or start
+	currentCommand = cmd.Name
 
 	os.Exit(cmd.Run(cmd.Flags.Args()))
 

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -812,16 +812,6 @@ func lazyCreateUnits(args []string) error {
 	return nil
 }
 
-// matchUnitFiles compares two unitFiles
-// Returns true if the units match, false otherwise.
-func matchUnitFiles(a *unit.UnitFile, b *unit.UnitFile) bool {
-	if a.Hash() == b.Hash() {
-		return true
-	}
-
-	return false
-}
-
 // matchLocalFileAndUnit compares a file with a Unit
 // Returns true if the contents of the file matches the unit one, false
 // otherwise; and any error encountered.
@@ -833,7 +823,7 @@ func matchLocalFileAndUnit(file string, su *schema.Unit) (bool, error) {
 	if err == nil {
 		b, err := getUnitFromFile(file)
 		if err == nil {
-			result = matchUnitFiles(a, b)
+			result = unit.MatchUnitFiles(a, b)
 		}
 	}
 

--- a/fleetctl/load.go
+++ b/fleetctl/load.go
@@ -43,6 +43,7 @@ func init() {
 	cmdLoadUnits.Flags.BoolVar(&sharedFlags.Sign, "sign", false, "DEPRECATED - this option cannot be used")
 	cmdLoadUnits.Flags.IntVar(&sharedFlags.BlockAttempts, "block-attempts", 0, "Wait until the jobs are loaded, performing up to N attempts before giving up. A value of 0 indicates no limit. Does not apply to global units.")
 	cmdLoadUnits.Flags.BoolVar(&sharedFlags.NoBlock, "no-block", false, "Do not wait until the jobs have been loaded before exiting. Always the case for global units.")
+	cmdLoadUnits.Flags.BoolVar(&sharedFlags.Replace, "replace", false, "Replace the old scheduled units in the cluster with new versions.")
 }
 
 func runLoadUnits(args []string) (exit int) {

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -51,6 +51,7 @@ func init() {
 	cmdStartUnit.Flags.BoolVar(&sharedFlags.Sign, "sign", false, "DEPRECATED - this option cannot be used")
 	cmdStartUnit.Flags.IntVar(&sharedFlags.BlockAttempts, "block-attempts", 0, "Wait until the units are launched, performing up to N attempts before giving up. A value of 0 indicates no limit. Does not apply to global units.")
 	cmdStartUnit.Flags.BoolVar(&sharedFlags.NoBlock, "no-block", false, "Do not wait until the units have launched before exiting. Always the case for global units.")
+	cmdStartUnit.Flags.BoolVar(&sharedFlags.Replace, "replace", false, "Replace the already started units in the cluster with new versions.")
 }
 
 func runStartUnit(args []string) (exit int) {

--- a/fleetctl/submit.go
+++ b/fleetctl/submit.go
@@ -33,6 +33,7 @@ Submit a directory of units with glob matching:
 
 func init() {
 	cmdSubmitUnit.Flags.BoolVar(&sharedFlags.Sign, "sign", false, "DEPRECATED - this option cannot be used")
+	cmdSubmitUnit.Flags.BoolVar(&sharedFlags.Replace, "replace", false, "Replace the old submitted units in the cluster with new versions.")
 }
 
 func runSubmitUnits(args []string) (exit int) {

--- a/functional/fixtures/units/replace-sync.service
+++ b/functional/fixtures/units/replace-sync.service
@@ -1,0 +1,5 @@
+[Service]
+ExecStartPre=/bin/bash -c "echo 'sync'"
+ExecStart=/bin/bash -c "while true; do echo Hello, World!; sleep 1; done"
+ExecStop=/bin/bash -c "echo 'stopping'"
+ExecStopPost=/bin/bash -c "sleep 3; touch /tmp/fleetSyncReplaceFile"

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -17,6 +17,7 @@ package functional
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"reflect"
 	"sort"
@@ -25,6 +26,11 @@ import (
 
 	"github.com/coreos/fleet/functional/platform"
 	"github.com/coreos/fleet/functional/util"
+)
+
+const (
+	tmpHelloService = "/tmp/hello.service"
+	fxtHelloService = "fixtures/units/hello.service"
 )
 
 // TestUnitRunnable is the simplest test possible, deplying a single-node
@@ -124,6 +130,30 @@ func TestUnitStart(t *testing.T) {
 	}
 
 	if err := doMultipleUnitsCmd(cluster, m, "start", 3); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUnitSubmitReplace() tests whether a command "fleetctl submit --replace
+// hello.service" works or not.
+func TestUnitSubmitReplace(t *testing.T) {
+	if err := replaceUnitCommon("submit"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUnitLoadReplace() tests whether a command "fleetctl load --replace
+// hello.service" works or not.
+func TestUnitLoadReplace(t *testing.T) {
+	if err := replaceUnitCommon("load"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUnitStartReplace() tests whether a command "fleetctl start --replace
+// hello.service" works or not.
+func TestUnitStartReplace(t *testing.T) {
+	if err := replaceUnitCommon("start"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -454,6 +484,95 @@ func doMultipleUnitsCmd(cluster platform.Cluster, m platform.Member, cmd string,
 	}
 	if err := checkListUnits(cmd, unitFiles, 0); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// replaceUnitCommon() tests whether a command "fleetctl {submit,load,start}
+// --replace hello.service" works or not.
+func replaceUnitCommon(cmd string) error {
+	// check if cmd is one of the supported commands.
+	listCmds := []string{"submit", "load", "start"}
+	found := false
+	for _, ccmd := range listCmds {
+		if ccmd == cmd {
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf("invalid command %s", cmd)
+	}
+
+	cluster, err := platform.NewNspawnCluster("smoke")
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+	defer cluster.Destroy()
+
+	m, err := cluster.CreateMember()
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+	_, err = cluster.WaitForNMachines(m, 1)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	WaitForNUnitsCmd := func(cmd string, expectedUnits int) (err error) {
+		if cmd == "submit" {
+			_, err = cluster.WaitForNUnitFiles(m, expectedUnits)
+		} else {
+			_, err = cluster.WaitForNUnits(m, expectedUnits)
+		}
+		return err
+	}
+
+	// run a command for a unit and assert it shows up
+	if _, _, err := cluster.Fleetctl(m, cmd, fxtHelloService); err != nil {
+		return fmt.Errorf("Unable to %s fleet unit: %v", cmd, err)
+	}
+	if err := WaitForNUnitsCmd(cmd, 1); err != nil {
+		return fmt.Errorf("Did not find 1 unit in cluster: %v", err)
+	}
+
+	helloFilename := path.Base(tmpHelloService)
+
+	// store content of hello.service to bodyOrig
+	bodyOrig, _, err := cluster.Fleetctl(m, "cat", helloFilename)
+	if err != nil {
+		return fmt.Errorf("Failed to run cat %s: %v", helloFilename, err)
+	}
+
+	// replace the unit and assert it shows up
+	err = util.GenNewFleetService(tmpHelloService, fxtHelloService, "sleep 2", "sleep 1")
+	if err != nil {
+		return fmt.Errorf("Failed to generate a temp fleet service: %v", err)
+	}
+	if _, _, err := cluster.Fleetctl(m, cmd, "--replace", tmpHelloService); err != nil {
+		return fmt.Errorf("Unable to replace fleet unit: %v", err)
+	}
+	if err := WaitForNUnitsCmd(cmd, 1); err != nil {
+		return fmt.Errorf("Did not find 1 unit in cluster: %v", err)
+	}
+
+	// store content of the replaced unit hello.service to bodyNew
+	bodyNew, _, err := cluster.Fleetctl(m, "cat", helloFilename)
+	if err != nil {
+		return fmt.Errorf("Failed to run cat %s: %v", helloFilename, err)
+	}
+
+	if bodyOrig == bodyNew {
+		return fmt.Errorf("Error. the unit %s has not been replaced.", helloFilename)
+	}
+
+	os.Remove(tmpHelloService)
+
+	if _, _, err := cluster.Fleetctl(m, "destroy", fxtHelloService); err != nil {
+		return fmt.Errorf("Failed to destroy unit: %v", err)
+	}
+	if err := WaitForNUnitsCmd(cmd, 0); err != nil {
+		return fmt.Errorf("Failed to get every unit to be cleaned up: %v", err)
 	}
 
 	return nil

--- a/functional/util/util.go
+++ b/functional/util/util.go
@@ -177,3 +177,39 @@ func NewMachineID() string {
 	// drop the standard separators to match systemd
 	return strings.Replace(uuid.New(), "-", "", -1)
 }
+
+// CopyFile()
+func CopyFile(newFile, oldFile string) error {
+	input, err := ioutil.ReadFile(oldFile)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(newFile, []byte(input), 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GenNewFleetService() is a helper for generating a temporary fleet service
+// that reads from oldFile, replaces oldVal with newVal, and stores the result
+// to newFile.
+func GenNewFleetService(newFile, oldFile, newVal, oldVal string) error {
+	input, err := ioutil.ReadFile(oldFile)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(input), "\n")
+
+	for i, line := range lines {
+		if strings.Contains(line, oldVal) {
+			lines[i] = strings.Replace(line, oldVal, newVal, len(oldVal))
+		}
+	}
+	output := strings.Join(lines, "\n")
+	err = ioutil.WriteFile(newFile, []byte(output), 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/registry/job.go
+++ b/registry/job.go
@@ -326,14 +326,14 @@ func (r *EtcdRegistry) CreateUnit(u *job.Unit) (err error) {
 	}
 
 	opts := &etcd.SetOptions{
-		PrevExist: etcd.PrevNoExist,
+		// Since we support replacing units, just ignore previous
+		// job keys if they exist, this allows us to update the
+		// job object key with a new unit.
+		PrevExist: etcd.PrevIgnore,
 	}
 	key := r.prefixed(jobPrefix, u.Name, "object")
 	_, err = r.kAPI.Set(r.ctx(), key, val, opts)
 	if err != nil {
-		if isEtcdError(err, etcd.ErrorCodeNodeExist) {
-			err = errors.New("job already exists")
-		}
 		return
 	}
 

--- a/unit/unit.go
+++ b/unit/unit.go
@@ -136,6 +136,16 @@ func (u *UnitFile) Hash() Hash {
 	return Hash(sha1.Sum(u.Bytes()))
 }
 
+// MatchUnitFiles compares two unitFiles
+// Returns true if the units match, false otherwise.
+func MatchUnitFiles(a *UnitFile, b *UnitFile) bool {
+	if a.Hash() == b.Hash() {
+		return true
+	}
+
+	return false
+}
+
 // RecognizedUnitType determines whether or not the given unit name represents
 // a recognized unit type.
 func RecognizedUnitType(name string) bool {


### PR DESCRIPTION
This PR allows units to be replaced with "submit", "load" and "start" commands. Just add the new "--replace" switch.

The previous discussion was about overwrite in this PR https://github.com/coreos/fleet/pull/1295

This PR tries to fix: https://github.com/coreos/fleet/issues/760
