### PR TITLE
*: fixed broken template and metadata

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -175,11 +175,14 @@ func (j *Job) requirements() map[string][]string {
 		}
 
 		if uni != nil {
+			processedValues := make([]string, len(values))
 			for i, v := range values {
-				values[i] = unitPrintf(v, *uni)
+				processedValues[i] = unitPrintf(v, *uni)
 			}
+			requirements[key] = processedValues
+		} else {
+			requirements[key] = values
 		}
-		requirements[key] = values
 	}
 
 	return requirements

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -195,6 +195,11 @@ Zzz=something
 		}
 	}
 
+	jOrig := NewJob("ssh@2.service", *newUnit(t, contents))
+	// Now ensure that Contents was not modified
+	if !reflect.DeepEqual(jOrig.Unit.Contents, j.Unit.Contents) {
+		t.Errorf("Contents data was eventually modified, want:\n%#v\ngot:\n%#v", jOrig.Unit.Contents, j.Unit.Contents)
+	}
 }
 
 func TestParseRequirementsMissingSection(t *testing.T) {

--- a/registry/job.go
+++ b/registry/job.go
@@ -101,9 +101,25 @@ func (r *EtcdRegistry) Units() ([]job.Unit, error) {
 		return nil, err
 	}
 
+	// Fetch all units by hash recursively to avoid sending N requests to Etcd.
+	hashToUnit, err := r.getAllUnitsHashMap()
+	if err != nil {
+		log.Errorf("failed fetching all Units from etcd: %v", err)
+		return nil, err
+	}
+	unitHashLookupFunc := func(hash unit.Hash) *unit.UnitFile {
+		stringHash := hash.String()
+		unit, ok := hashToUnit[stringHash]
+		if !ok {
+			log.Errorf("did not find Unit %v in list of all units", stringHash)
+			return nil
+		}
+		return unit
+	}
+
 	uMap := make(map[string]*job.Unit)
 	for _, dir := range res.Node.Nodes {
-		u, err := r.dirToUnit(dir)
+		u, err := r.dirToUnit(dir, unitHashLookupFunc)
 		if err != nil {
 			log.Errorf("Failed to parse Unit from etcd: %v", err)
 			continue
@@ -143,12 +159,12 @@ func (r *EtcdRegistry) Unit(name string) (*job.Unit, error) {
 		return nil, err
 	}
 
-	return r.dirToUnit(res.Node)
+	return r.dirToUnit(res.Node, r.getUnitByHash)
 }
 
 // dirToUnit takes a Node containing a Job's constituent objects (in child
 // nodes) and returns a *job.Unit, or any error encountered
-func (r *EtcdRegistry) dirToUnit(dir *etcd.Node) (*job.Unit, error) {
+func (r *EtcdRegistry) dirToUnit(dir *etcd.Node, unitHashLookupFunc func(unit.Hash) *unit.UnitFile) (*job.Unit, error) {
 	objKey := path.Join(dir.Key, "object")
 	var objNode *etcd.Node
 	for _, node := range dir.Nodes {
@@ -160,7 +176,7 @@ func (r *EtcdRegistry) dirToUnit(dir *etcd.Node) (*job.Unit, error) {
 	if objNode == nil {
 		return nil, nil
 	}
-	u, err := r.getUnitFromObjectNode(objNode)
+	u, err := r.getUnitFromObjectNode(objNode, unitHashLookupFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +270,7 @@ func dirToHeartbeat(dir *etcd.Node) (heartbeat string) {
 // getUnitFromObject takes a *etcd.Node containing a Unit's jobModel, and
 // instantiates and returns a representative *job.Unit, transitively fetching the
 // associated UnitFile as necessary
-func (r *EtcdRegistry) getUnitFromObjectNode(node *etcd.Node) (*job.Unit, error) {
+func (r *EtcdRegistry) getUnitFromObjectNode(node *etcd.Node, unitHashLookupFunc func(unit.Hash) *unit.UnitFile) (*job.Unit, error) {
 	var err error
 	var jm jobModel
 	if err = unmarshal(node.Value, &jm); err != nil {
@@ -263,7 +279,7 @@ func (r *EtcdRegistry) getUnitFromObjectNode(node *etcd.Node) (*job.Unit, error)
 
 	var unit *unit.UnitFile
 
-	unit = r.getUnitByHash(jm.UnitHash)
+	unit = unitHashLookupFunc(jm.UnitHash)
 	if unit == nil {
 		log.Warningf("No Unit found in Registry for Job(%s)", jm.Name)
 		return nil, nil

--- a/unit/unit.go
+++ b/unit/unit.go
@@ -17,6 +17,7 @@ package unit
 import (
 	"bytes"
 	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -167,6 +168,19 @@ func (h Hash) Short() string {
 
 func (h *Hash) Empty() bool {
 	return *h == Hash{}
+}
+
+func HashFromHexString(key string) (Hash, error) {
+	h := Hash{}
+	out, err := hex.DecodeString(key)
+	if err != nil {
+		return h, err
+	}
+	if len(out) != sha1.Size {
+		return h, fmt.Errorf("size of key %q (%d) differs from SHA1 size (%d)", out, len(out), sha1.Size)
+	}
+	copy(h[:], out[:sha1.Size])
+	return h, nil
 }
 
 // UnitState encodes the current state of a unit loaded into a fleet agent

--- a/unit/unit_test.go
+++ b/unit/unit_test.go
@@ -42,7 +42,16 @@ func TestUnitHash(t *testing.T) {
 	if !eh.Empty() {
 		t.Fatalf("Empty hash check failed: %v", eh.Empty())
 	}
+}
 
+func TestHashFromHexString(t *testing.T) {
+	u, err := NewUnitFile("[Service]\nExecStart=/bin/sleep 100\n")
+	if err != nil {
+		t.Fatalf("Unexpected error encountered creating unit: %v", err)
+	}
+	gotHash := u.Hash()
+
+	expectHashString := "1c6fb6f3684bafb0c173d8b8b957ceff031180c1"
 	rehashed, err := HashFromHexString(expectHashString)
 	if err != nil {
 		t.Fatalf("HashFromHexString failed with: %v", err)

--- a/unit/unit_test.go
+++ b/unit/unit_test.go
@@ -42,6 +42,14 @@ func TestUnitHash(t *testing.T) {
 	if !eh.Empty() {
 		t.Fatalf("Empty hash check failed: %v", eh.Empty())
 	}
+
+	rehashed, err := HashFromHexString(expectHashString)
+	if err != nil {
+		t.Fatalf("HashFromHexString failed with: %v", err)
+	}
+	if rehashed != gotHash {
+		t.Fatalf("HashFromHexString not equal to original hash")
+	}
 }
 
 func TestRecognizedUnitTypes(t *testing.T) {


### PR DESCRIPTION
Resolves #1514

The problem was caused by the [code optimization](https://github.com/coreos/fleet/pull/1376). Before that each unit was stored in its own variable. Then this code was optimized and units became stored in hash map (`getAllUnitsHashMap`). Each hash was assigned to the unit's pointer. And when template unit was checked by `requirements()` function, its content was modified by `values[i] = unitPrintf(v, *uni)` code. Once templated unit was modified, all related units (which have same hash) were modified too, because they are related to one pointer.

Now we don't modify source contents.