### PR TITLE
Cleanup: functional tests: Drop gratuitous `sudo` from various commands

### DIFF
--- a/functional/node_test.go
+++ b/functional/node_test.go
@@ -77,7 +77,7 @@ func TestNodeShutdown(t *testing.T) {
 	}
 
 	// The member's unit should actually stop running, too
-	stdout, _ = cluster.MemberCommand(m0, "sudo", "systemctl", "status", "hello.service")
+	stdout, _ = cluster.MemberCommand(m0, "systemctl", "status", "hello.service")
 	if !strings.Contains(stdout, "Active: inactive") {
 		t.Fatalf("Unit hello.service not reported as inactive:\n%s\n", stdout)
 	}

--- a/functional/shutdown_test.go
+++ b/functional/shutdown_test.go
@@ -44,11 +44,11 @@ func TestShutdown(t *testing.T) {
 	}
 
 	// Check expected state after stop.
-	stdout, _ := cluster.MemberCommand(m0, "sudo", "systemctl", "show", "--property=ActiveState", "fleet")
+	stdout, _ := cluster.MemberCommand(m0, "systemctl", "show", "--property=ActiveState", "fleet")
 	if strings.TrimSpace(stdout) != "ActiveState=inactive" {
 		t.Fatalf("Fleet unit not reported as inactive: %s", stdout)
 	}
-	stdout, _ = cluster.MemberCommand(m0, "sudo", "systemctl", "show", "--property=Result", "fleet")
+	stdout, _ = cluster.MemberCommand(m0, "systemctl", "show", "--property=Result", "fleet")
 	if strings.TrimSpace(stdout) != "Result=success" {
 		t.Fatalf("Result for fleet unit not reported as success: %s", stdout)
 	}
@@ -91,11 +91,11 @@ func TestShutdownVsMonitor(t *testing.T) {
 	}
 
 	// Verify that fleetd was shut down cleanly in spite of the concurrent restart.
-	stdout, _ := cluster.MemberCommand(m0, "sudo", "systemctl", "show", "--property=ActiveState", "fleet")
+	stdout, _ := cluster.MemberCommand(m0, "systemctl", "show", "--property=ActiveState", "fleet")
 	if strings.TrimSpace(stdout) != "ActiveState=inactive" {
 		t.Fatalf("Fleet unit not reported as inactive: %s", stdout)
 	}
-	stdout, _ = cluster.MemberCommand(m0, "sudo", "systemctl", "show", "--property=Result", "fleet")
+	stdout, _ = cluster.MemberCommand(m0, "systemctl", "show", "--property=Result", "fleet")
 	if strings.TrimSpace(stdout) != "Result=success" {
 		t.Fatalf("Result for fleet unit not reported as success: %s", stdout)
 	}


### PR DESCRIPTION
Diagnostic commands such as `systemctl status` don't need elevated
permissions.

One notable exception is `journalctl`, which is actually privileged
(when accessing system journals), as it might reveal sensitive
information...