### PR TITLE
ssh: define the list of Key Algorithms of remote hosts before handshake

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -171,7 +171,7 @@ func SSHAgentClient() (gosshagent.Agent, error) {
 	return gosshagent.NewClient(agent), nil
 }
 
-func sshClientConfig(user string, checker *HostKeyChecker) (*gossh.ClientConfig, error) {
+func sshClientConfig(user string, checker *HostKeyChecker, addr string) (*gossh.ClientConfig, error) {
 	agentClient, err := SSHAgentClient()
 	if err != nil {
 		return nil, err
@@ -191,6 +191,7 @@ func sshClientConfig(user string, checker *HostKeyChecker) (*gossh.ClientConfig,
 
 	if checker != nil {
 		cfg.HostKeyCallback = checker.Check
+		cfg.HostKeyAlgorithms = checker.GetHostKeyAlgorithms(addr)
 	}
 
 	return &cfg, nil
@@ -204,12 +205,12 @@ func maybeAddDefaultPort(addr string) string {
 }
 
 func NewSSHClient(user, addr string, checker *HostKeyChecker, agentForwarding bool, timeout time.Duration) (*SSHForwardingClient, error) {
-	clientConfig, err := sshClientConfig(user, checker)
+	addr = maybeAddDefaultPort(addr)
+
+	clientConfig, err := sshClientConfig(user, checker, addr)
 	if err != nil {
 		return nil, err
 	}
-
-	addr = maybeAddDefaultPort(addr)
 
 	var client *gossh.Client
 	dialFunc := func(echan chan error) {
@@ -226,13 +227,13 @@ func NewSSHClient(user, addr string, checker *HostKeyChecker, agentForwarding bo
 }
 
 func NewTunnelledSSHClient(user, tunaddr, tgtaddr string, checker *HostKeyChecker, agentForwarding bool, timeout time.Duration) (*SSHForwardingClient, error) {
-	clientConfig, err := sshClientConfig(user, checker)
+	tunaddr = maybeAddDefaultPort(tunaddr)
+	tgtaddr = maybeAddDefaultPort(tgtaddr)
+
+	clientConfig, err := sshClientConfig(user, checker, tunaddr)
 	if err != nil {
 		return nil, err
 	}
-
-	tunaddr = maybeAddDefaultPort(tunaddr)
-	tgtaddr = maybeAddDefaultPort(tgtaddr)
 
 	var tunnelClient *gossh.Client
 	dialFunc := func(echan chan error) {


### PR DESCRIPTION
Retrieve remote host Key Algorithms from known_host if they are there
and use them to perform ssh handshake. Otherwise fallback to default
values suggested by remote.

This patch is based from a previous patch written by:
kayrus <kay.diam@gmail.com>

Resolves #1526 and coreos/bugs#1186