### PR TITLE
ssh: Do not leak ssh sessions on errors

### DIFF
--- a/ssh/proxy.go
+++ b/ssh/proxy.go
@@ -29,21 +29,25 @@ func DialCommand(client *SSHForwardingClient, cmd string) (net.Conn, error) {
 
 	stdout, err := session.StdoutPipe()
 	if err != nil {
+		session.Close()
 		return nil, err
 	}
 
 	stdin, err := session.StdinPipe()
 	if err != nil {
+		session.Close()
 		return nil, err
 	}
 
 	err = client.ForwardAgentAuthentication(session)
 	if err != nil {
+		session.Close()
 		return nil, err
 	}
 
 	err = session.Start(cmd)
 	if err != nil {
+		session.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
Hello there. We recently ran into a problem where we were not able to do proper connection handling across ssh tunnels. It turned out that this was partially caused by some buggy code on our side in combination with the things being fixed here in this PR. In case ssh sessions are created, we need to make sure to close them properly even in error cases. The fix proposed here works for us. What do you guys think? Thanks to @zeisss helping out debugging and fixing this issue. 