### PR TITLE
Fixing docker build script.

### DIFF
--- a/build-docker
+++ b/build-docker
@@ -2,4 +2,4 @@
 
 CDIR=$(cd `dirname $0` && pwd)
 
-docker run --rm -v $CDIR:/opt/fleet -u $(id -u):$(id -g) google/golang:1.5 /bin/bash -c "cd /opt/fleet && ./build"
+docker run --rm -v $CDIR:/opt/fleet -u $(id -u):$(id -g) golang:1.5 /bin/bash -c "cd /opt/fleet && ./build"


### PR DESCRIPTION
The Docker repository `google/golang` has been deprecated and `golang` should be used instead. 