### PR TITLE
functional: more fleetctl unit action tests

### DIFF
--- a/functional/platform/cluster.go
+++ b/functional/platform/cluster.go
@@ -35,7 +35,9 @@ type Cluster interface {
 	// client operations
 	Fleetctl(m Member, args ...string) (string, string, error)
 	FleetctlWithInput(m Member, input string, args ...string) (string, string, error)
+	WaitForNUnits(Member, int) (map[string][]util.UnitState, error)
 	WaitForNActiveUnits(Member, int) (map[string][]util.UnitState, error)
+	WaitForNUnitFiles(Member, int) (map[string][]util.UnitFileState, error)
 	WaitForNMachines(Member, int) ([]string, error)
 }
 

--- a/functional/util/util.go
+++ b/functional/util/util.go
@@ -97,12 +97,28 @@ type UnitState struct {
 	Machine     string
 }
 
+type UnitFileState struct {
+	Name         string
+	DesiredState string
+	State        string
+}
+
 func ParseUnitStates(units []string) (states []UnitState) {
 	for _, unit := range units {
 		cols := strings.Fields(unit)
 		if len(cols) == 3 {
 			machine := strings.SplitN(cols[2], "/", 2)[0]
 			states = append(states, UnitState{cols[0], cols[1], machine})
+		}
+	}
+	return states
+}
+
+func ParseUnitFileStates(units []string) (states []UnitFileState) {
+	for _, unit := range units {
+		cols := strings.Fields(unit)
+		if len(cols) == 3 {
+			states = append(states, UnitFileState{cols[0], cols[1], cols[2]})
 		}
 	}
 	return states


### PR DESCRIPTION
In order to make functional tests cover more fleetctl commands, do the following:

* define ``util.UnitFileState`` for handling output of list-unit-files
* aadd new cluster operations ``WaitForNUnits`` and ``WaitForNUnitFiles``, wrappers based on ``util.WaitForState``.
* introduce a new test ``TestUnitCat`` for "``fleetctl cat``".
* introduce a new test ``TestUnitStatus`` for "``fleetctl status``".
* improve an existing test ``TestUnitSubmit``.
* introduce a new test ``TestUnitLoad`` for ``fleetctl load``.