### PR TITLE
build-aci: no need to set the docker uid

### DIFF
--- a/build-aci
+++ b/build-aci
@@ -13,7 +13,7 @@ tgt=$(mktemp -d)
 CDIR=$(cd `dirname $0` && pwd)
 
 # Build fleet inside
-docker run --rm -v $CDIR:/opt/fleet -u $(id -u):$(id -g) google/golang:1.5 /bin/bash -c "cd /opt/fleet && ./build"
+docker run --rm -v $CDIR:/opt/fleet google/golang:1.5 /bin/bash -c "cd /opt/fleet && ./build"
 
 # Generate manifest into target tmp dir
 cat <<DF >${tgt}/manifest


### PR DESCRIPTION
This reverts parts of 98f185061c0085 which bumped go version but at the
same time added docker switches to set the uid in order to build
binaries under that user, this is supposed to be used as a build aci
where fleetd is under root.