### PR TITLE
functional: support testing multiple units

### DIFF
--- a/functional/platform/cluster.go
+++ b/functional/platform/cluster.go
@@ -35,7 +35,9 @@ type Cluster interface {
 	// client operations
 	Fleetctl(m Member, args ...string) (string, string, error)
 	FleetctlWithInput(m Member, input string, args ...string) (string, string, error)
+	WaitForNUnits(Member, int) (map[string][]util.UnitState, error)
 	WaitForNActiveUnits(Member, int) (map[string][]util.UnitState, error)
+	WaitForNUnitFiles(Member, int) (map[string][]util.UnitFileState, error)
 	WaitForNMachines(Member, int) ([]string, error)
 }
 

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -100,59 +100,8 @@ func TestUnitLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	unitFile := "fixtures/units/hello.service"
-
-	// load a unit and assert it shows up
-	_, _, err = cluster.Fleetctl(m, "load", unitFile)
-	if err != nil {
-		t.Fatalf("Unable to load fleet unit: %v", err)
-	}
-
-	// wait until the unit gets loaded up to 15 seconds
-	listUnitStates, err := cluster.WaitForNUnits(m, 1)
-	if err != nil {
-		t.Fatalf("Failed to run list-units: %v", err)
-	}
-
-	// given unit name must be there in list-units
-	_, found := listUnitStates[path.Base(unitFile)]
-	if len(listUnitStates) != 1 || !found {
-		t.Fatalf("Expected %s to be unit, got %v", path.Base(unitFile), listUnitStates)
-	}
-
-	// unload the unit and ensure it disappears from the unit list
-	_, _, err = cluster.Fleetctl(m, "unload", unitFile)
-	if err != nil {
-		t.Fatalf("Failed to unload unit: %v", err)
-	}
-
-	// wait until the unit gets unloaded up to 15 seconds
-	listUnitStates, err = cluster.WaitForNUnits(m, 0)
-	if err != nil {
-		t.Fatalf("Failed to run list-units: %v", err)
-	}
-
-	// given unit name must be there in list-units
-	if len(listUnitStates) != 0 {
-		t.Fatalf("Expected nil unit list, got %v", listUnitStates)
-	}
-
-	// loading the unit after destruction should succeed
-	_, _, err = cluster.Fleetctl(m, "load", unitFile)
-	if err != nil {
-		t.Fatalf("Unable to load fleet unit: %v", err)
-	}
-
-	// wait until the unit gets loaded up to 15 seconds
-	listUnitStates, err = cluster.WaitForNUnits(m, 1)
-	if err != nil {
-		t.Fatalf("Failed to run list-units: %v", err)
-	}
-
-	// given unit name must be there in list-units
-	_, found = listUnitStates[path.Base(unitFile)]
-	if len(listUnitStates) != 1 || !found {
-		t.Fatalf("Expected %s to be unit, got %v", path.Base(unitFile), listUnitStates)
+	if err := doMultipleUnitsCmd(cluster, m, "load", 6); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -15,12 +15,14 @@
 package functional
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path"
 	"strings"
 	"testing"
 
 	"github.com/coreos/fleet/functional/platform"
+	"github.com/coreos/fleet/functional/util"
 )
 
 // TestUnitRunnable is the simplest test possible, deplying a single-node
@@ -74,58 +76,8 @@ func TestUnitSubmit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	unitFile := "fixtures/units/hello.service"
-
-	// submit a unit and assert it shows up
-	if _, _, err := cluster.Fleetctl(m, "submit", unitFile); err != nil {
-		t.Fatalf("Unable to submit fleet unit: %v", err)
-	}
-
-	// wait until the unit gets submitted up to 15 seconds
-	listUnitStates, err := cluster.WaitForNUnitFiles(m, 1)
-	if err != nil {
-		t.Fatalf("Failed to run list-unit-files: %v", err)
-	}
-
-	// given unit name must be there in list-unit-files
-	_, found := listUnitStates[path.Base(unitFile)]
-	if len(listUnitStates) != 1 || !found {
-		t.Fatalf("Expected %s to be unit file, got %v", path.Base(unitFile), listUnitStates)
-	}
-
-	// submitting the same unit should not fail
-	if _, _, err = cluster.Fleetctl(m, "submit", unitFile); err != nil {
-		t.Fatalf("Expected no failure when double-submitting unit, got this: %v", err)
-	}
-
-	// destroy the unit and ensure it disappears from the unit list
-	if _, _, err := cluster.Fleetctl(m, "destroy", unitFile); err != nil {
-		t.Fatalf("Failed to destroy unit: %v", err)
-	}
-	// wait until the unit gets destroyed up to 15 seconds
-	listUnitStates, err = cluster.WaitForNUnitFiles(m, 0)
-	if err != nil {
-		t.Fatalf("Failed to run list-unit-files: %v", err)
-	}
-	if len(listUnitStates) != 0 {
-		t.Fatalf("Expected nil unit file list, got %v", listUnitStates)
-	}
-
-	// submitting the unit after destruction should succeed
-	if _, _, err := cluster.Fleetctl(m, "submit", unitFile); err != nil {
-		t.Fatalf("Unable to submit fleet unit: %v", err)
-	}
-
-	// wait until the unit gets submitted up to 15 seconds
-	listUnitStates, err = cluster.WaitForNUnitFiles(m, 1)
-	if err != nil {
-		t.Fatalf("Failed to run list-unit-files: %v", err)
-	}
-
-	// given unit name must be there in list-unit-files
-	_, found = listUnitStates[path.Base(unitFile)]
-	if len(listUnitStates) != 1 || !found {
-		t.Fatalf("Expected %s to be unit file, got %v", path.Base(unitFile), listUnitStates)
+	if err := doMultipleUnitsCmd(cluster, m, "submit", 9); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -403,4 +355,126 @@ func TestUnitStatus(t *testing.T) {
 		t.Errorf("Could not find expected string in status output:\n%s\nstderr:\n%s",
 			stdout, stderr)
 	}
+}
+
+func doMultipleUnitsCmd(cluster platform.Cluster, m platform.Member, cmd string, numUnits int) error {
+	launchUnitsCmd := func(cmd string, numUnits int) (unitFiles []string, err error) {
+		args := []string{cmd}
+		for i := 0; i < numUnits; i++ {
+			unitFile := fmt.Sprintf("fixtures/units/hello@%d.service", i+1)
+			args = append(args, unitFile)
+			unitFiles = append(unitFiles, path.Base(unitFile))
+		}
+
+		if stdout, stderr, err := cluster.Fleetctl(m, args...); err != nil {
+			return nil,
+				fmt.Errorf("Unable to %s batch of units: \nstdout: %s\nstderr: %s\nerr: %v",
+					cmd, stdout, stderr, err)
+		} else if strings.Contains(stderr, "Error") {
+			return nil,
+				fmt.Errorf("Failed to correctly %s batch of units: \nstdout: %s\nstderr: %s\nerr: %v",
+					cmd, stdout, stderr, err)
+		}
+
+		return unitFiles, nil
+	}
+
+	checkListUnits := func(cmd string, unitFiles []string, inNumUnits int) (err error) {
+		// wait until the unit gets processed up to 15 seconds
+		if cmd == "submit" {
+			listUnitStates, err := cluster.WaitForNUnitFiles(m, inNumUnits)
+			if err != nil {
+				return fmt.Errorf("Failed to run list-unit-files: %v", err)
+			}
+
+			if inNumUnits == 0 && len(listUnitStates) != 0 {
+				return fmt.Errorf("Expected nil unit file list, got %v", listUnitStates)
+			}
+
+			// given unit name must be there in list-unit-files
+			for i := 0; i < inNumUnits; i++ {
+				_, found := listUnitStates[unitFiles[i]]
+				if len(listUnitStates) != inNumUnits || !found {
+					return fmt.Errorf("Expected %s to be unit file, got %v",
+						unitFiles[i], listUnitStates)
+				}
+			}
+		} else {
+			// cmd == "load" or "start"
+			var listUnitStates map[string][]util.UnitState
+			if cmd == "load" {
+				listUnitStates, err = cluster.WaitForNUnits(m, inNumUnits)
+			} else {
+				listUnitStates, err = cluster.WaitForNActiveUnits(m, inNumUnits)
+			}
+			if err != nil {
+				return fmt.Errorf("Failed to run list-unit-files: %v", err)
+			}
+
+			if inNumUnits == 0 && len(listUnitStates) != 0 {
+				return fmt.Errorf("Expected nil unit file list, got %v", listUnitStates)
+			}
+
+			// given unit name must be there in list-unit-files
+			for i := 0; i < inNumUnits; i++ {
+				_, found := listUnitStates[unitFiles[i]]
+				if len(listUnitStates) != inNumUnits || !found {
+					return fmt.Errorf("Expected %s to be unit file, got %v",
+						unitFiles[i], listUnitStates)
+				}
+			}
+		}
+
+		return nil
+	}
+
+	destroyUnits := func(dcmd string, unitFiles []string, numUnits int) (err error) {
+		for i := 0; i < numUnits; i++ {
+			if _, _, err := cluster.Fleetctl(m, dcmd, unitFiles[i]); err != nil {
+				return fmt.Errorf("Failed to %s unit: %v", dcmd, err)
+			}
+		}
+		return nil
+	}
+
+	dcmd := make(map[string]string, 0)
+	dcmd["submit"] = "destroy"
+	dcmd["load"] = "unload"
+	dcmd["start"] = "stop"
+
+	// launch a batch of processing units
+	unitFiles, err := launchUnitsCmd(cmd, numUnits)
+	if err != nil {
+		return err
+	}
+	if err := checkListUnits(cmd, unitFiles, numUnits); err != nil {
+		return err
+	}
+
+	// destroy the unit and ensure it disappears from the unit list
+	if err := destroyUnits(dcmd[cmd], unitFiles, numUnits); err != nil {
+		return err
+	}
+	if err := checkListUnits(cmd, unitFiles, 0); err != nil {
+		return err
+	}
+
+	// launch a batch of processing units
+	unitFiles, err = launchUnitsCmd(cmd, numUnits)
+	if err != nil {
+		return err
+	}
+	if err := checkListUnits(cmd, unitFiles, numUnits); err != nil {
+		return err
+	}
+
+	// destroy the unit again, not to affect the next tests for multiple units
+	if err := destroyUnits(dcmd[cmd], unitFiles, numUnits); err != nil {
+		return err
+	}
+	if err := checkListUnits(cmd, unitFiles, 0); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -105,7 +105,7 @@ func TestUnitLoad(t *testing.T) {
 	}
 }
 
-func TestUnitRestart(t *testing.T) {
+func TestUnitStart(t *testing.T) {
 	cluster, err := platform.NewNspawnCluster("smoke")
 	if err != nil {
 		t.Fatal(err)
@@ -121,42 +121,9 @@ func TestUnitRestart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if stdout, stderr, err := cluster.Fleetctl(m, "start", "fixtures/units/hello.service"); err != nil {
-		t.Fatalf("Unable to start fleet unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
-	}
-
-	units, err := cluster.WaitForNActiveUnits(m, 1)
-	if err != nil {
+	if err := doMultipleUnitsCmd(cluster, m, "start", 3); err != nil {
 		t.Fatal(err)
 	}
-	_, found := units["hello.service"]
-	if len(units) != 1 || !found {
-		t.Fatalf("Expected hello.service to be sole active unit, got %v", units)
-	}
-
-	if _, _, err := cluster.Fleetctl(m, "stop", "hello.service"); err != nil {
-		t.Fatal(err)
-	}
-	units, err = cluster.WaitForNActiveUnits(m, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(units) != 0 {
-		t.Fatalf("Zero units should be running, found %v", units)
-	}
-
-	if stdout, stderr, err := cluster.Fleetctl(m, "start", "hello.service"); err != nil {
-		t.Fatalf("Unable to start fleet unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
-	}
-	units, err = cluster.WaitForNActiveUnits(m, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, found = units["hello.service"]
-	if len(units) != 1 || !found {
-		t.Fatalf("Expected hello.service to be sole active unit, got %v", units)
-	}
-
 }
 
 func TestUnitSSHActions(t *testing.T) {

--- a/functional/util/util.go
+++ b/functional/util/util.go
@@ -97,12 +97,28 @@ type UnitState struct {
 	Machine     string
 }
 
+type UnitFileState struct {
+	Name         string
+	DesiredState string
+	State        string
+}
+
 func ParseUnitStates(units []string) (states []UnitState) {
 	for _, unit := range units {
 		cols := strings.Fields(unit)
 		if len(cols) == 3 {
 			machine := strings.SplitN(cols[2], "/", 2)[0]
 			states = append(states, UnitState{cols[0], cols[1], machine})
+		}
+	}
+	return states
+}
+
+func ParseUnitFileStates(units []string) (states []UnitFileState) {
+	for _, unit := range units {
+		cols := strings.Fields(unit)
+		if len(cols) == 3 {
+			states = append(states, UnitFileState{cols[0], cols[1], cols[2]})
 		}
 	}
 	return states


### PR DESCRIPTION
Make ``TestUnit{Submit,Load,Start}()`` capable of testing multiple units. After launching multiple units for activation, they become deactivated via correspondent commands: ``"submit"`` and ``"destroy"``, ``"load"`` and ``"unload"``, ``"start"`` and ``"stop"`` are coupled respectively. These are based on a common function ``doMultipleUnitsCmd()`` to be used by different tests.

This PR depends on #1544.