### PR TITLE
functional: support testing multiple units

### DIFF
--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -102,59 +102,8 @@ func TestUnitLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	unitFile := "fixtures/units/hello.service"
-
-	// load a unit and assert it shows up
-	_, _, err = cluster.Fleetctl(m, "load", unitFile)
-	if err != nil {
-		t.Fatalf("Unable to load fleet unit: %v", err)
-	}
-
-	// wait until the unit gets loaded up to 15 seconds
-	listUnitStates, err := cluster.WaitForNUnits(m, 1)
-	if err != nil {
-		t.Fatalf("Failed to run list-units: %v", err)
-	}
-
-	// given unit name must be there in list-units
-	_, found := listUnitStates[path.Base(unitFile)]
-	if len(listUnitStates) != 1 || !found {
-		t.Fatalf("Expected %s to be unit, got %v", path.Base(unitFile), listUnitStates)
-	}
-
-	// unload the unit and ensure it disappears from the unit list
-	_, _, err = cluster.Fleetctl(m, "unload", unitFile)
-	if err != nil {
-		t.Fatalf("Failed to unload unit: %v", err)
-	}
-
-	// wait until the unit gets unloaded up to 15 seconds
-	listUnitStates, err = cluster.WaitForNUnits(m, 0)
-	if err != nil {
-		t.Fatalf("Failed to run list-units: %v", err)
-	}
-
-	// given unit name must be there in list-units
-	if len(listUnitStates) != 0 {
-		t.Fatalf("Expected nil unit list, got %v", listUnitStates)
-	}
-
-	// loading the unit after destruction should succeed
-	_, _, err = cluster.Fleetctl(m, "load", unitFile)
-	if err != nil {
-		t.Fatalf("Unable to load fleet unit: %v", err)
-	}
-
-	// wait until the unit gets loaded up to 15 seconds
-	listUnitStates, err = cluster.WaitForNUnits(m, 1)
-	if err != nil {
-		t.Fatalf("Failed to run list-units: %v", err)
-	}
-
-	// given unit name must be there in list-units
-	_, found = listUnitStates[path.Base(unitFile)]
-	if len(listUnitStates) != 1 || !found {
-		t.Fatalf("Expected %s to be unit, got %v", path.Base(unitFile), listUnitStates)
+	if err := doMultipleUnitsCmd(cluster, m, "load", 6); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -107,7 +107,7 @@ func TestUnitLoad(t *testing.T) {
 	}
 }
 
-func TestUnitRestart(t *testing.T) {
+func TestUnitStart(t *testing.T) {
 	cluster, err := platform.NewNspawnCluster("smoke")
 	if err != nil {
 		t.Fatal(err)
@@ -123,42 +123,9 @@ func TestUnitRestart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if stdout, stderr, err := cluster.Fleetctl(m, "start", "fixtures/units/hello.service"); err != nil {
-		t.Fatalf("Unable to start fleet unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
-	}
-
-	units, err := cluster.WaitForNActiveUnits(m, 1)
-	if err != nil {
+	if err := doMultipleUnitsCmd(cluster, m, "start", 3); err != nil {
 		t.Fatal(err)
 	}
-	_, found := units["hello.service"]
-	if len(units) != 1 || !found {
-		t.Fatalf("Expected hello.service to be sole active unit, got %v", units)
-	}
-
-	if _, _, err := cluster.Fleetctl(m, "stop", "hello.service"); err != nil {
-		t.Fatal(err)
-	}
-	units, err = cluster.WaitForNActiveUnits(m, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(units) != 0 {
-		t.Fatalf("Zero units should be running, found %v", units)
-	}
-
-	if stdout, stderr, err := cluster.Fleetctl(m, "start", "hello.service"); err != nil {
-		t.Fatalf("Unable to start fleet unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
-	}
-	units, err = cluster.WaitForNActiveUnits(m, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, found = units["hello.service"]
-	if len(units) != 1 || !found {
-		t.Fatalf("Expected hello.service to be sole active unit, got %v", units)
-	}
-
 }
 
 func TestUnitSSHActions(t *testing.T) {


### PR DESCRIPTION
Make ``TestUnit{Submit,Load,Start}()`` capable of testing multiple units. After launching multiple units for activation, they become deactivated via correspondent commands: ``"submit"`` and ``"destroy"``, ``"load"`` and ``"unload"``, ``"start"`` and ``"stop"`` are coupled respectively. These are based on a common function ``doMultipleUnitsCmd()`` to be used by different tests.

This PR depends on #1544.
