### PR TITLE
fleetd: get filtered list of units instead of all units

### DIFF
--- a/vendor.manifest
+++ b/vendor.manifest
@@ -3,9 +3,9 @@ github.com/coreos/etcd/client b2d33e6dcb24cddc0395f1bbe2213a27aef0fb46
 github.com/coreos/etcd/pkg/pathutil b2d33e6dcb24cddc0395f1bbe2213a27aef0fb46
 github.com/coreos/etcd/pkg/types b2d33e6dcb24cddc0395f1bbe2213a27aef0fb46
 github.com/coreos/go-semver/semver a9a0c39c7e4a2929f73d4b757d1860fbb8e66d06
-github.com/coreos/go-systemd/activation 1f2251651d199b698a0be8c8bf2283178a2a97ed
-github.com/coreos/go-systemd/dbus 1f2251651d199b698a0be8c8bf2283178a2a97ed
-github.com/coreos/go-systemd/unit 1f2251651d199b698a0be8c8bf2283178a2a97ed
+github.com/coreos/go-systemd/activation 6dc8b843c670f2027cc26b164935635840a40526
+github.com/coreos/go-systemd/dbus 6dc8b843c670f2027cc26b164935635840a40526
+github.com/coreos/go-systemd/unit 6dc8b843c670f2027cc26b164935635840a40526
 github.com/godbus/dbus 9bb9dbf0e53309fa81d26e7230cbb6cff9373cad
 github.com/golang/protobuf/proto dda510ac0fd43b39770f22ac6260eb91d377bce3
 github.com/jonboulle/clockwork b473f398c464f1988327f67c9e6aa7fba62f80d2

--- a/vendor/github.com/coreos/go-systemd/activation/listeners.go
+++ b/vendor/github.com/coreos/go-systemd/activation/listeners.go
@@ -15,6 +15,7 @@
 package activation
 
 import (
+	"crypto/tls"
 	"net"
 )
 
@@ -34,4 +35,28 @@ func Listeners(unsetEnv bool) ([]net.Listener, error) {
 		}
 	}
 	return listeners, nil
+}
+
+// TLSListeners returns a slice containing a net.listener for each matching TCP socket type
+// passed to this process.
+// It uses default Listeners func and forces TCP sockets handlers to use TLS based on tlsConfig.
+func TLSListeners(unsetEnv bool, tlsConfig *tls.Config) ([]net.Listener, error) {
+	listeners, err := Listeners(unsetEnv)
+
+	if listeners == nil || err != nil {
+		return nil, err
+	}
+
+	if tlsConfig != nil && err == nil {
+		tlsConfig.NextProtos = []string{"http/1.1"}
+
+		for i, l := range listeners {
+			// Activate TLS only for TCP sockets
+			if l.Addr().Network() == "tcp" {
+				listeners[i] = tls.NewListener(l, tlsConfig)
+			}
+		}
+	}
+
+	return listeners, err
 }

--- a/vendor/github.com/coreos/go-systemd/dbus/methods.go
+++ b/vendor/github.com/coreos/go-systemd/dbus/methods.go
@@ -199,6 +199,11 @@ func (c *Conn) GetUnitProperty(unit string, propertyName string) (*Property, err
 	return c.getProperty(unit, "org.freedesktop.systemd1.Unit", propertyName)
 }
 
+// GetServiceProperty returns property for given service name and property name
+func (c *Conn) GetServiceProperty(service string, propertyName string) (*Property, error) {
+	return c.getProperty(service, "org.freedesktop.systemd1.Service", propertyName)
+}
+
 // GetUnitTypeProperties returns the extra properties for a unit, specific to the unit type.
 // Valid values for unitType: Service, Socket, Target, Device, Mount, Automount, Snapshot, Timer, Swap, Path, Slice, Scope
 // return "dbus.Error: Unknown interface" if the unitType is not the correct type of the unit
@@ -221,12 +226,24 @@ func (c *Conn) GetUnitTypeProperty(unit string, unitType string, propertyName st
 	return c.getProperty(unit, "org.freedesktop.systemd1."+unitType, propertyName)
 }
 
-// ListUnits returns an array with all currently loaded units. Note that
-// units may be known by multiple names at the same time, and hence there might
-// be more unit names loaded than actual units behind them.
-func (c *Conn) ListUnits() ([]UnitStatus, error) {
+type UnitStatus struct {
+	Name        string          // The primary unit name as string
+	Description string          // The human readable description string
+	LoadState   string          // The load state (i.e. whether the unit file has been loaded successfully)
+	ActiveState string          // The active state (i.e. whether the unit is currently started or not)
+	SubState    string          // The sub state (a more fine-grained version of the active state that is specific to the unit type, which the active state is not)
+	Followed    string          // A unit that is being followed in its state by this unit, if there is any, otherwise the empty string.
+	Path        dbus.ObjectPath // The unit object path
+	JobId       uint32          // If there is a job queued for the job unit the numeric job id, 0 otherwise
+	JobType     string          // The job type as string
+	JobPath     dbus.ObjectPath // The job object path
+}
+
+type storeFunc func(retvalues ...interface{}) error
+
+func (c *Conn) listUnitsInternal(f storeFunc) ([]UnitStatus, error) {
 	result := make([][]interface{}, 0)
-	err := c.sysobj.Call("org.freedesktop.systemd1.Manager.ListUnits", 0).Store(&result)
+	err := f(&result)
 	if err != nil {
 		return nil, err
 	}
@@ -250,17 +267,74 @@ func (c *Conn) ListUnits() ([]UnitStatus, error) {
 	return status, nil
 }
 
-type UnitStatus struct {
-	Name        string          // The primary unit name as string
-	Description string          // The human readable description string
-	LoadState   string          // The load state (i.e. whether the unit file has been loaded successfully)
-	ActiveState string          // The active state (i.e. whether the unit is currently started or not)
-	SubState    string          // The sub state (a more fine-grained version of the active state that is specific to the unit type, which the active state is not)
-	Followed    string          // A unit that is being followed in its state by this unit, if there is any, otherwise the empty string.
-	Path        dbus.ObjectPath // The unit object path
-	JobId       uint32          // If there is a job queued for the job unit the numeric job id, 0 otherwise
-	JobType     string          // The job type as string
-	JobPath     dbus.ObjectPath // The job object path
+// ListUnits returns an array with all currently loaded units. Note that
+// units may be known by multiple names at the same time, and hence there might
+// be more unit names loaded than actual units behind them.
+func (c *Conn) ListUnits() ([]UnitStatus, error) {
+	return c.listUnitsInternal(c.sysobj.Call("org.freedesktop.systemd1.Manager.ListUnits", 0).Store)
+}
+
+// ListUnitsFiltered returns an array with units filtered by state.
+// It takes a list of units' statuses to filter.
+func (c *Conn) ListUnitsFiltered(states []string) ([]UnitStatus, error) {
+	return c.listUnitsInternal(c.sysobj.Call("org.freedesktop.systemd1.Manager.ListUnitsFiltered", 0, states).Store)
+}
+
+// ListUnitsByPatterns returns an array with units.
+// It takes a list of units' statuses and names to filter.
+// Note that units may be known by multiple names at the same time,
+// and hence there might be more unit names loaded than actual units behind them.
+func (c *Conn) ListUnitsByPatterns(states []string, patterns []string) ([]UnitStatus, error) {
+	return c.listUnitsInternal(c.sysobj.Call("org.freedesktop.systemd1.Manager.ListUnitsByPatterns", 0, states, patterns).Store)
+}
+
+// ListUnitsByNames returns an array with units. It takes a list of units'
+// names and returns an UnitStatus array. Comparing to ListUnitsByPatterns
+// method, this method returns statuses even for inactive or non-existing
+// units. Input array should contain exact unit names, but not patterns.
+func (c *Conn) ListUnitsByNames(units []string) ([]UnitStatus, error) {
+	return c.listUnitsInternal(c.sysobj.Call("org.freedesktop.systemd1.Manager.ListUnitsByNames", 0, units).Store)
+}
+
+type UnitFile struct {
+	Path string
+	Type string
+}
+
+func (c *Conn) listUnitFilesInternal(f storeFunc) ([]UnitFile, error) {
+	result := make([][]interface{}, 0)
+	err := f(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	resultInterface := make([]interface{}, len(result))
+	for i := range result {
+		resultInterface[i] = result[i]
+	}
+
+	files := make([]UnitFile, len(result))
+	fileInterface := make([]interface{}, len(files))
+	for i := range files {
+		fileInterface[i] = &files[i]
+	}
+
+	err = dbus.Store(resultInterface, fileInterface...)
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+// ListUnitFiles returns an array of all available units on disk.
+func (c *Conn) ListUnitFiles() ([]UnitFile, error) {
+	return c.listUnitFilesInternal(c.sysobj.Call("org.freedesktop.systemd1.Manager.ListUnitFiles", 0).Store)
+}
+
+// ListUnitFilesByPatterns returns an array of all available units on disk matched the patterns.
+func (c *Conn) ListUnitFilesByPatterns(states []string, patterns []string) ([]UnitFile, error) {
+	return c.listUnitFilesInternal(c.sysobj.Call("org.freedesktop.systemd1.Manager.ListUnitFilesByPatterns", 0, states, patterns).Store)
 }
 
 type LinkUnitFileChange EnableUnitFileChange

--- a/vendor/github.com/coreos/go-systemd/dbus/methods_test.go
+++ b/vendor/github.com/coreos/go-systemd/dbus/methods_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -70,6 +71,24 @@ func linkUnit(target string, conn *Conn, t *testing.T) {
 	}
 }
 
+func getUnitStatus(units []UnitStatus, name string) *UnitStatus {
+	for _, u := range units {
+		if u.Name == name {
+			return &u
+		}
+	}
+	return nil
+}
+
+func getUnitFile(units []UnitFile, name string) *UnitFile {
+	for _, u := range units {
+		if path.Base(u.Path) == name {
+			return &u
+		}
+	}
+	return nil
+}
+
 // Ensure that basic unit starting and stopping works.
 func TestStartStopUnit(t *testing.T) {
 	target := "start-stop.service"
@@ -92,18 +111,11 @@ func TestStartStopUnit(t *testing.T) {
 
 	units, err := conn.ListUnits()
 
-	var unit *UnitStatus
-	for _, u := range units {
-		if u.Name == target {
-			unit = &u
-		}
-	}
+	unit := getUnitStatus(units, target)
 
 	if unit == nil {
 		t.Fatalf("Test unit not found in list")
-	}
-
-	if unit.ActiveState != "active" {
+	} else if unit.ActiveState != "active" {
 		t.Fatalf("Test unit not active")
 	}
 
@@ -118,15 +130,166 @@ func TestStartStopUnit(t *testing.T) {
 
 	units, err = conn.ListUnits()
 
-	unit = nil
-	for _, u := range units {
-		if u.Name == target {
-			unit = &u
-		}
-	}
+	unit = getUnitStatus(units, target)
 
 	if unit != nil {
 		t.Fatalf("Test unit found in list, should be stopped")
+	}
+}
+
+// Ensure that ListUnitsByNames works.
+func TestListUnitsByNames(t *testing.T) {
+	target1 := "systemd-journald.service"
+	target2 := "unexisting.service"
+
+	conn := setupConn(t)
+
+	units, err := conn.ListUnitsByNames([]string{target1, target2})
+
+	if err != nil {
+		t.Skip(err)
+	}
+
+	unit := getUnitStatus(units, target1)
+
+	if unit == nil {
+		t.Fatalf("%s unit not found in list", target1)
+	} else if unit.ActiveState != "active" {
+		t.Fatalf("%s unit should be active but it is %s", target1, unit.ActiveState)
+	}
+
+	unit = getUnitStatus(units, target2)
+
+	if unit == nil {
+		t.Fatalf("Unexisting test unit not found in list")
+	} else if unit.ActiveState != "inactive" {
+		t.Fatalf("Test unit should be inactive")
+	}
+}
+
+// Ensure that ListUnitsByPatterns works.
+func TestListUnitsByPatterns(t *testing.T) {
+	target1 := "systemd-journald.service"
+	target2 := "unexisting.service"
+
+	conn := setupConn(t)
+
+	units, err := conn.ListUnitsByPatterns([]string{}, []string{"systemd-journald*", target2})
+
+	if err != nil {
+		t.Skip(err)
+	}
+
+	unit := getUnitStatus(units, target1)
+
+	if unit == nil {
+		t.Fatalf("%s unit not found in list", target1)
+	} else if unit.ActiveState != "active" {
+		t.Fatalf("Test unit should be active")
+	}
+
+	unit = getUnitStatus(units, target2)
+
+	if unit != nil {
+		t.Fatalf("Unexisting test unit found in list")
+	}
+}
+
+// Ensure that ListUnitsFiltered works.
+func TestListUnitsFiltered(t *testing.T) {
+	target := "systemd-journald.service"
+
+	conn := setupConn(t)
+
+	units, err := conn.ListUnitsFiltered([]string{"active"})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unit := getUnitStatus(units, target)
+
+	if unit == nil {
+		t.Fatalf("%s unit not found in list", target)
+	} else if unit.ActiveState != "active" {
+		t.Fatalf("Test unit should be active")
+	}
+
+	units, err = conn.ListUnitsFiltered([]string{"inactive"})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unit = getUnitStatus(units, target)
+
+	if unit != nil {
+		t.Fatalf("Inactive unit should not be found in list")
+	}
+}
+
+// Ensure that ListUnitFilesByPatterns works.
+func TestListUnitFilesByPatterns(t *testing.T) {
+	target1 := "systemd-journald.service"
+	target2 := "exit.target"
+
+	conn := setupConn(t)
+
+	units, err := conn.ListUnitFilesByPatterns([]string{"static"}, []string{"systemd-journald*", target2})
+
+	if err != nil {
+		t.Skip(err)
+	}
+
+	unit := getUnitFile(units, target1)
+
+	if unit == nil {
+		t.Fatalf("%s unit not found in list", target1)
+	} else if unit.Type != "static" {
+		t.Fatalf("Test unit file should be static")
+	}
+
+	units, err = conn.ListUnitFilesByPatterns([]string{"disabled"}, []string{"systemd-journald*", target2})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unit = getUnitFile(units, target2)
+
+	if unit == nil {
+		t.Fatalf("%s unit not found in list", target2)
+	} else if unit.Type != "disabled" {
+		t.Fatalf("%s unit file should be disabled", target2)
+	}
+}
+
+func TestListUnitFiles(t *testing.T) {
+	target1 := "systemd-journald.service"
+	target2 := "exit.target"
+
+	conn := setupConn(t)
+
+	units, err := conn.ListUnitFiles()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unit := getUnitFile(units, target1)
+
+	if unit == nil {
+		t.Fatalf("%s unit not found in list", target1)
+	} else if unit.Type != "static" {
+		t.Fatalf("Test unit file should be static")
+	}
+
+	unit = getUnitFile(units, target2)
+
+	if unit == nil {
+		t.Fatalf("%s unit not found in list", target2)
+	} else if unit.Type != "disabled" {
+		t.Fatalf("%s unit file should be disabled", target2)
 	}
 }
 
@@ -230,6 +393,28 @@ func TestGetUnitPropertiesRejectsInvalidName(t *testing.T) {
 	}
 }
 
+// TestGetServiceProperty reads the `systemd-udevd.service` which should exist
+// on all systemd systems and ensures that one of its property is valid.
+func TestGetServiceProperty(t *testing.T) {
+	conn := setupConn(t)
+
+	service := "systemd-udevd.service"
+
+	prop, err := conn.GetServiceProperty(service, "Type")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if prop.Name != "Type" {
+		t.Fatal("unexpected property name")
+	}
+
+	value := prop.Value.Value().(string)
+	if value != "notify" {
+		t.Fatal("unexpected property value")
+	}
+}
+
 // TestSetUnitProperties changes a cgroup setting on the `tmp.mount`
 // which should exist on all systemd systems and ensures that the
 // property was set.
@@ -276,18 +461,11 @@ func TestStartStopTransientUnit(t *testing.T) {
 
 	units, err := conn.ListUnits()
 
-	var unit *UnitStatus
-	for _, u := range units {
-		if u.Name == target {
-			unit = &u
-		}
-	}
+	unit := getUnitStatus(units, target)
 
 	if unit == nil {
 		t.Fatalf("Test unit not found in list")
-	}
-
-	if unit.ActiveState != "active" {
+	} else if unit.ActiveState != "active" {
 		t.Fatalf("Test unit not active")
 	}
 
@@ -302,12 +480,7 @@ func TestStartStopTransientUnit(t *testing.T) {
 
 	units, err = conn.ListUnits()
 
-	unit = nil
-	for _, u := range units {
-		if u.Name == target {
-			unit = &u
-		}
-	}
+	unit = getUnitStatus(units, target)
 
 	if unit != nil {
 		t.Fatalf("Test unit found in list, should be stopped")


### PR DESCRIPTION
resolves #478. Code works with these systemd changes: https://github.com/endocode/systemd/commit/5b4452a643d924015ed25972d071ad8802aad29c
Otherwise fleet will fallback to the normal `ListUnits` method.

I don't like this code: https://github.com/endocode/fleet/blob/9828ed19752bdaae167d79e458fd7200ca3cb305/systemd/manager.go#L248

Instead of calling several times for each unit's status I'd like to implement new method called `GetUnitsProperties`

This PR contains godeps diffs only for test purposes. These changes are also introduced in go-systemd repo: https://github.com/coreos/go-systemd/pull/150

/cc @jonboulle @tixxdz @antrik 