### PR TITLE
fleetctl: check also systemd states after starting units

### DIFF
--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -87,5 +87,10 @@ func runStartUnit(cCmd *cobra.Command, args []string) (exit int) {
 		return exitVal
 	}
 
+	exitVal = tryWaitForSystemdActiveState(starting)
+	if exitVal != 0 {
+		return exitVal
+	}
+
 	return 0
 }

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -604,6 +604,18 @@ func checkListUnits(cl platform.Cluster, m platform.Member, cmd string, ufs []st
 		if lenLists != nu || !found {
 			return fmt.Errorf("Expected %s to be unit file", ufs[i])
 		}
+
+		if cmd == "start" {
+			// Check expected systemd state after starting units
+			stdout, _ := cl.MemberCommand(m, "systemctl", "show", "--property=ActiveState", ufs[i])
+			if strings.TrimSpace(stdout) != "ActiveState=active" {
+				return fmt.Errorf("Fleet unit not reported as active: %s", stdout)
+			}
+			stdout, _ = cl.MemberCommand(m, "systemctl", "show", "--property=Result", ufs[i])
+			if strings.TrimSpace(stdout) != "Result=success" {
+				return fmt.Errorf("Result for fleet unit not reported as success: %s", stdout)
+			}
+		}
 	}
 	return err
 }


### PR DESCRIPTION
To resolve inconsistency between ``"systemctl start"`` and ``"fleetctl start"``, fleetctl needs to check systemd states after starting units. If the systemd state is not a desired one, wait until it gets an active state.

Fixes: https://github.com/coreos/fleet/issues/1025
