### PR TITLE
fleetd: introduce Replaces option in unit files

### DIFF
--- a/Documentation/unit-files-and-scheduling.md
+++ b/Documentation/unit-files-and-scheduling.md
@@ -23,6 +23,7 @@ Note that these requirements are derived directly from systemd, with the only ex
 | `MachineMetadata` | Limit eligible machines to those with this specific metadata. |
 | `Conflicts` | Prevent a unit from being collocated with other units using glob-matching on the other unit names. |
 | `Global` | Schedule this unit on all agents in the cluster. A unit is considered invalid if options other than `MachineMetadata` are provided alongside `Global=true`. |
+| `Replaces` | Schedule a specified unit on another machine. A unit is considered invalid if options `Global` or `Conflicts` are provided alongside `Replaces=`. A circular replacement between multiple units is not allowed. |
 
 See [more information][unit-scheduling] on these parameters and how they impact scheduling decisions.
 

--- a/agent/reconcile_test.go
+++ b/agent/reconcile_test.go
@@ -386,6 +386,30 @@ func TestAbleToRun(t *testing.T) {
 			job:  newTestJobWithXFleetValues(t, "Conflicts=ping.service"),
 			want: false,
 		},
+
+		// no replaces found
+		{
+			dState: &AgentState{
+				MState: &machine.MachineState{ID: "123"},
+				Units: map[string]*job.Unit{
+					"ping.service": &job.Unit{Name: "ping.service"},
+				},
+			},
+			job:  newTestJobWithXFleetValues(t, "Replaces=pong.service"),
+			want: true,
+		},
+
+		// replaces found
+		{
+			dState: &AgentState{
+				MState: &machine.MachineState{ID: "123"},
+				Units: map[string]*job.Unit{
+					"ping.service": &job.Unit{Name: "ping.service"},
+				},
+			},
+			job:  newTestJobWithXFleetValues(t, "Replaces=ping.service"),
+			want: false,
+		},
 	}
 
 	for i, tt := range tests {

--- a/engine/reconciler.go
+++ b/engine/reconciler.go
@@ -110,10 +110,15 @@ func (r *Reconciler) calculateClusterTasks(clust *clusterState, stopchan chan st
 				}
 
 				var able bool
-				if able, reason = as.AbleToRun(j); !able {
+				var ableReason string
+				if able, ableReason = as.AbleToRun(j); !able {
 					unschedule = true
-					reason = fmt.Sprintf("target Machine(%s) unable to run unit", j.TargetMachineID)
-					metrics.ReportEngineReconcileFailure(metrics.RunFailure)
+					if ableReason == job.JobReschedule {
+						reason = ableReason
+					} else {
+						reason = fmt.Sprintf("target Machine(%s) unable to run unit", j.TargetMachineID)
+						metrics.ReportEngineReconcileFailure(metrics.RunFailure)
+					}
 					return
 				}
 

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -327,6 +327,24 @@ MachineOf=zxcvq`),
 Global=true
 Conflicts=bar`),
 		},
+		{
+			"foo.service",
+			newUnitFile(t, `[X-Fleet]
+Global=true
+Replaces=bar`),
+		},
+		{
+			"foo.service",
+			newUnitFile(t, `[X-Fleet]
+Conflicts=bar
+Replaces=bar`),
+		},
+		{
+			"foo.service",
+			newUnitFile(t, `[X-Fleet]
+MachineOf=abcd
+Replaces=abcd`),
+		},
 	}
 	for i, tt = range testCases {
 		un = tt.name

--- a/functional/fixtures/units/replace.0.service
+++ b/functional/fixtures/units/replace.0.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=Test Unit
+
+[Service]
+ExecStart=/bin/bash -c "while true; do echo Hello, World!; sleep 1; done"

--- a/functional/fixtures/units/replace.1.service
+++ b/functional/fixtures/units/replace.1.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Test Unit
+
+[Service]
+ExecStart=/bin/bash -c "while true; do echo Hello, World!; sleep 1; done"
+
+[X-Fleet]
+Replaces=replace.0.service

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -88,6 +88,29 @@ Conflicts=*bar*
 	}
 }
 
+func TestJobReplaces(t *testing.T) {
+	testCases := []struct {
+		contents string
+		replaces []string
+	}{
+		{``, []string{}},
+		{`[Unit]
+Description=Testing
+
+[X-Fleet]
+Replaces=*bar*
+`, []string{"*bar*"}},
+	}
+	for i, tt := range testCases {
+		j := NewJob("echo.service", *newUnit(t, tt.contents))
+		replaces := j.Replaces()
+		if !reflect.DeepEqual(replaces, tt.replaces) {
+			t.Errorf("case %d: unexpected replaces: got %#v, want %#v", i, replaces, tt.replaces)
+		}
+
+	}
+}
+
 func TestParseRequirements(t *testing.T) {
 	testCases := []struct {
 		contents string
@@ -567,6 +590,7 @@ func TestValidateRequirements(t *testing.T) {
 		"X-ConditionMachineMetadata=up=down",
 		"MachineMetadata=true=false",
 		"Global=true",
+		"Replaces=foo",
 	}
 	for i, req := range tests {
 		contents := fmt.Sprintf("[X-Fleet]\n%s", req)


### PR DESCRIPTION
Introduce a new option ``'Replaces'`` in X-Fleet the section, to get an existing unit rescheduled to another machine. This option basically works like an existing option ``'Conflicts'``, except that circular replaces in 2 units are not allowed. Also ``Conflicts`` cannot be used together with ``Replaces``, ``Global`` cannot be used together with ``Replaces``.

Fixes: https://github.com/coreos/fleet/issues/1394

/cc @onlyjob @kayrus @tixxdz 