### PR TITLE
functional: retry to check states also after connectivity got alive

### DIFF
--- a/functional/connectivity-loss_test.go
+++ b/functional/connectivity-loss_test.go
@@ -206,7 +206,15 @@ func TestSingleNodeConnectivityLoss(t *testing.T) {
 	time.Sleep(ttl + agentReconcileInterval + slack)
 
 	// Check state after reconnect.
-	if isExpected, expected, actual := checkExpectedStates(); !isExpected {
+	var expected, actual map[string]string
+	var isExpected bool
+	timeout, err = util.WaitForState(
+		func() bool { isExpected, expected, actual = checkExpectedStates(); return isExpected },
+	)
+	if err != nil {
+		t.Fatalf("Failed to reach expected initial state within %v.", timeout)
+	}
+	if !isExpected {
 		t.Fatalf("Units not in expected state after restoring connectivity.\nExpected: %v\nActual: %v", expected, actual)
 	}
 


### PR DESCRIPTION
``TestSingleNodeConnectivityLoss`` sometimes fails with the following error:

>  FAIL: TestSingleNodeConnectivityLoss (26.50s)
>  connectivity-loss_test.go:98: Failed listing unit files: exit status 1
>  connectivity-loss_test.go:210: Units not in expected state after restoring connectivity.

This is because the test runs ``checkExpectedStates()`` only once, without retrying to check the states repeatedly. While the test had already made use of ``util.WaitForState()`` earlier in the test by itself, it actually does not call ``util.WaitForState`` after being reattached to etcd. Fix it by using ``util.WaitForState()`` correctly to avoid such occasional errors, especially on semaphoreci.

/cc @tixxdz @kayrus 