### PR TITLE
fleetctl: support truthy values in boolean unit options

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -113,7 +113,7 @@ func (u *Unit) IsGlobal() bool {
 	}
 	// Last value found wins
 	last := values[len(values)-1]
-	return strings.ToLower(last) == "true"
+	return isTruthyValue(last)
 }
 
 // NewJob creates a new Job based on the given name and Unit.
@@ -300,4 +300,11 @@ func unitPrintf(s string, nu unit.UnitNameInfo) (out string) {
 	out = strings.Replace(out, "%p", nu.Prefix, -1)
 	out = strings.Replace(out, "%i", nu.Instance, -1)
 	return
+}
+
+// isTruthyValue returns true if a given string is any of "truthy" value,
+// i.e. "true", "yes", "1", "on", or "t".
+func isTruthyValue(s string) bool {
+	chl := strings.ToLower(s)
+	return chl == "true" || chl == "yes" || chl == "1" || chl == "on" || chl == "t"
 }

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -509,6 +509,11 @@ func TestUnitIsGlobal(t *testing.T) {
 		// correct specifications
 		{"[X-Fleet]\nMachineOf=foo\nGlobal=true", true},
 		{"[X-Fleet]\nMachineOf=foo\nGlobal=True", true},
+		{"[X-Fleet]\nMachineOf=foo\nGlobal=Yes", true},
+		{"[X-Fleet]\nMachineOf=foo\nGlobal=On", true},
+		{"[X-Fleet]\nMachineOf=foo\nGlobal=1", true},
+		{"[X-Fleet]\nMachineOf=foo\nGlobal=t", true},
+		{"[X-Fleet]\nMachineOf=foo\nGlobal=12", false},
 		// multiple parameters - last wins
 		{"[X-Fleet]\nGlobal=true\nGlobal=false", false},
 		{"[X-Fleet]\nGlobal=false\nGlobal=true", true},
@@ -519,6 +524,33 @@ func TestUnitIsGlobal(t *testing.T) {
 		got := u.IsGlobal()
 		if got != tt.want {
 			t.Errorf("case %d: IsGlobal returned %t, want %t", i, got, tt.want)
+		}
+	}
+}
+
+func TestUnitIsTruthy(t *testing.T) {
+	for i, tt := range []struct {
+		contents string
+		want     bool
+	}{
+		// empty string
+		{"", false},
+		// bad values
+		{"false", false},
+		{"no", false},
+		{"0", false},
+		{"off", false},
+		{"f", false},
+		// correct values
+		{"true", true},
+		{"yes", true},
+		{"1", true},
+		{"on", true},
+		{"t", true},
+	} {
+		got := isTruthyValue(tt.contents)
+		if got != tt.want {
+			t.Errorf("case %d: isTruthyValue returned %t, want %t", i, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
Support truthy values in boolean unit options(true, yes, on, 1, t).

Originally written by @wuqixuan
Supersedes https://github.com/coreos/fleet/pull/1271
Fixes: https://github.com/coreos/fleet/issues/1108