### PR TITLE
fleetctl: print out result message explicitly

### DIFF
--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -85,6 +85,11 @@ func runStopUnit(args []string) (exit int) {
 	}
 
 	exit = tryWaitForUnitStates(stopping, "stop", job.JobStateLoaded, getBlockAttempts(), os.Stdout)
+	if exit == 0 {
+		stderr("Successfully stopped units %v.", stopping)
+	} else {
+		stderr("Failed to stop units %v. exit == %d.", stopping, exit)
+	}
 
 	return
 }

--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -66,6 +66,11 @@ func runUnloadUnit(args []string) (exit int) {
 	}
 
 	exit = tryWaitForUnitStates(wait, "unload", job.JobStateInactive, getBlockAttempts(), os.Stdout)
+	if exit == 0 {
+		stderr("Successfully unloaded units %v.", wait)
+	} else {
+		stderr("Failed to unload units %v. exit == %d.", wait, exit)
+	}
 
 	return
 }


### PR DESCRIPTION
``Fleetctl stop`` or ``unload`` has been always printing out somewhat ambiguous messages like below:

```
  Unit app.service loaded on 0eb1b9b6.../coreos1
```

For better usability, print out a better result message, either about stopping (or unloading) successfully, or failing to do.

Partially resolves: https://github.com/coreos/fleet/issues/1432

/cc @kayrus @tixxdz 