### PR TITLE
registry: use etcd.Config.HeaderTimeoutPerRequest instead of internal timeout

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -462,8 +462,9 @@ func getRegistryClient() (client.API, error) {
 	}
 
 	eCfg := etcd.Config{
-		Endpoints: strings.Split(globalFlags.Endpoint, ","),
-		Transport: trans,
+		Endpoints:               strings.Split(globalFlags.Endpoint, ","),
+		Transport:               trans,
+		HeaderTimeoutPerRequest: getRequestTimeoutFlag(),
 	}
 
 	eClient, err := etcd.New(eCfg)
@@ -472,7 +473,7 @@ func getRegistryClient() (client.API, error) {
 	}
 
 	kAPI := etcd.NewKeysAPI(eClient)
-	reg := registry.NewEtcdRegistry(kAPI, globalFlags.EtcdKeyPrefix, getRequestTimeoutFlag())
+	reg := registry.NewEtcdRegistry(kAPI, globalFlags.EtcdKeyPrefix)
 
 	if msg, ok := checkVersion(reg); !ok {
 		stderr(msg)

--- a/pkg/lease/etcd.go
+++ b/pkg/lease/etcd.go
@@ -97,18 +97,16 @@ func serializeLeaseMetadata(machID string, ver int) (string, error) {
 }
 
 type etcdLeaseManager struct {
-	kAPI       etcd.KeysAPI
-	keyPrefix  string
-	reqTimeout time.Duration
+	kAPI      etcd.KeysAPI
+	keyPrefix string
 }
 
-func NewEtcdLeaseManager(kAPI etcd.KeysAPI, keyPrefix string, reqTimeout time.Duration) *etcdLeaseManager {
-	return &etcdLeaseManager{kAPI: kAPI, keyPrefix: keyPrefix, reqTimeout: reqTimeout}
+func NewEtcdLeaseManager(kAPI etcd.KeysAPI, keyPrefix string) *etcdLeaseManager {
+	return &etcdLeaseManager{kAPI: kAPI, keyPrefix: keyPrefix}
 }
 
 func (r *etcdLeaseManager) ctx() context.Context {
-	ctx, _ := context.WithTimeout(context.Background(), r.reqTimeout)
-	return ctx
+	return context.Background()
 }
 
 func (r *etcdLeaseManager) leasePath(name string) string {

--- a/registry/etcd.go
+++ b/registry/etcd.go
@@ -16,32 +16,23 @@ package registry
 
 import (
 	"path"
-	"time"
 
 	etcd "github.com/coreos/etcd/client"
-	"golang.org/x/net/context"
 )
 
 const DefaultKeyPrefix = "/_coreos.com/fleet/"
 
-func NewEtcdRegistry(kAPI etcd.KeysAPI, keyPrefix string, reqTimeout time.Duration) *EtcdRegistry {
+func NewEtcdRegistry(kAPI etcd.KeysAPI, keyPrefix string) *EtcdRegistry {
 	return &EtcdRegistry{
-		kAPI:       kAPI,
-		keyPrefix:  keyPrefix,
-		reqTimeout: reqTimeout,
+		kAPI:      kAPI,
+		keyPrefix: keyPrefix,
 	}
 }
 
 // EtcdRegistry fulfils the Registry interface and uses etcd as a backend
 type EtcdRegistry struct {
-	kAPI       etcd.KeysAPI
-	keyPrefix  string
-	reqTimeout time.Duration
-}
-
-func (r *EtcdRegistry) ctx() context.Context {
-	ctx, _ := context.WithTimeout(context.Background(), r.reqTimeout)
-	return ctx
+	kAPI      etcd.KeysAPI
+	keyPrefix string
 }
 
 func (r *EtcdRegistry) prefixed(p ...string) string {

--- a/registry/job.go
+++ b/registry/job.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	etcd "github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
 
 	"github.com/coreos/fleet/job"
 	"github.com/coreos/fleet/log"
@@ -38,7 +39,7 @@ func (r *EtcdRegistry) Schedule() ([]job.ScheduledUnit, error) {
 		Sort:      true,
 		Recursive: true,
 	}
-	res, err := r.kAPI.Get(r.ctx(), key, opts)
+	res, err := r.kAPI.Get(context.Background(), key, opts)
 	if err != nil {
 		if isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
 			err = nil
@@ -94,7 +95,7 @@ func (r *EtcdRegistry) Units() ([]job.Unit, error) {
 		Sort:      true,
 		Recursive: true,
 	}
-	res, err := r.kAPI.Get(r.ctx(), key, opts)
+	res, err := r.kAPI.Get(context.Background(), key, opts)
 	if err != nil {
 		if isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
 			err = nil
@@ -142,7 +143,7 @@ func (r *EtcdRegistry) Unit(name string) (*job.Unit, error) {
 	opts := &etcd.GetOptions{
 		Recursive: true,
 	}
-	res, err := r.kAPI.Get(r.ctx(), key, opts)
+	res, err := r.kAPI.Get(context.Background(), key, opts)
 	if err != nil {
 		if isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
 			err = nil
@@ -192,7 +193,7 @@ func (r *EtcdRegistry) ScheduledUnit(name string) (*job.ScheduledUnit, error) {
 	opts := &etcd.GetOptions{
 		Recursive: true,
 	}
-	res, err := r.kAPI.Get(r.ctx(), key, opts)
+	res, err := r.kAPI.Get(context.Background(), key, opts)
 	if err != nil {
 		if isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
 			err = nil
@@ -224,7 +225,7 @@ func (r *EtcdRegistry) UnscheduleUnit(name, machID string) error {
 	opts := &etcd.DeleteOptions{
 		PrevValue: machID,
 	}
-	_, err := r.kAPI.Delete(r.ctx(), key, opts)
+	_, err := r.kAPI.Delete(context.Background(), key, opts)
 	if isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
 		err = nil
 	}
@@ -297,7 +298,7 @@ func (r *EtcdRegistry) DestroyUnit(name string) error {
 	opts := &etcd.DeleteOptions{
 		Recursive: true,
 	}
-	_, err := r.kAPI.Delete(r.ctx(), key, opts)
+	_, err := r.kAPI.Delete(context.Background(), key, opts)
 	if err != nil {
 		if isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
 			err = errors.New("job does not exist")
@@ -332,7 +333,7 @@ func (r *EtcdRegistry) CreateUnit(u *job.Unit) (err error) {
 		PrevExist: etcd.PrevIgnore,
 	}
 	key := r.prefixed(jobPrefix, u.Name, "object")
-	_, err = r.kAPI.Set(r.ctx(), key, val, opts)
+	_, err = r.kAPI.Set(context.Background(), key, val, opts)
 	if err != nil {
 		return
 	}
@@ -342,7 +343,7 @@ func (r *EtcdRegistry) CreateUnit(u *job.Unit) (err error) {
 
 func (r *EtcdRegistry) SetUnitTargetState(name string, state job.JobState) error {
 	key := r.jobTargetStatePath(name)
-	_, err := r.kAPI.Set(r.ctx(), key, string(state), nil)
+	_, err := r.kAPI.Set(context.Background(), key, string(state), nil)
 	return err
 }
 
@@ -351,7 +352,7 @@ func (r *EtcdRegistry) ScheduleUnit(name string, machID string) error {
 	opts := &etcd.SetOptions{
 		PrevExist: etcd.PrevNoExist,
 	}
-	_, err := r.kAPI.Set(r.ctx(), key, machID, opts)
+	_, err := r.kAPI.Set(context.Background(), key, machID, opts)
 	return err
 }
 

--- a/registry/job_state.go
+++ b/registry/job_state.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	etcd "github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
 
 	"github.com/coreos/fleet/job"
 	"github.com/coreos/fleet/unit"
@@ -51,13 +52,13 @@ func (r *EtcdRegistry) UnitHeartbeat(name, machID string, ttl time.Duration) err
 	opts := &etcd.SetOptions{
 		TTL: ttl,
 	}
-	_, err := r.kAPI.Set(r.ctx(), key, machID, opts)
+	_, err := r.kAPI.Set(context.Background(), key, machID, opts)
 	return err
 }
 
 func (r *EtcdRegistry) ClearUnitHeartbeat(name string) {
 	key := r.jobHeartbeatPath(name)
-	r.kAPI.Delete(r.ctx(), key, nil)
+	r.kAPI.Delete(context.Background(), key, nil)
 }
 
 func (r *EtcdRegistry) jobHeartbeatPath(jobName string) string {

--- a/registry/machine.go
+++ b/registry/machine.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	etcd "github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
 
 	"github.com/coreos/fleet/machine"
 )
@@ -34,7 +35,7 @@ func (r *EtcdRegistry) Machines() (machines []machine.MachineState, err error) {
 		Recursive: true,
 	}
 
-	resp, err := r.kAPI.Get(r.ctx(), key, opts)
+	resp, err := r.kAPI.Get(context.Background(), key, opts)
 	if err != nil {
 		if isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
 			err = nil
@@ -72,7 +73,7 @@ func (r *EtcdRegistry) CreateMachineState(ms machine.MachineState, ttl time.Dura
 		PrevExist: etcd.PrevNoExist,
 		TTL:       ttl,
 	}
-	resp, err := r.kAPI.Set(r.ctx(), key, val, opts)
+	resp, err := r.kAPI.Set(context.Background(), key, val, opts)
 	if err != nil {
 		return uint64(0), err
 	}
@@ -91,7 +92,7 @@ func (r *EtcdRegistry) SetMachineState(ms machine.MachineState, ttl time.Duratio
 		PrevExist: etcd.PrevExist,
 		TTL:       ttl,
 	}
-	resp, err := r.kAPI.Set(r.ctx(), key, val, opts)
+	resp, err := r.kAPI.Set(context.Background(), key, val, opts)
 	if err == nil {
 		return resp.Node.ModifiedIndex, nil
 	}
@@ -100,7 +101,7 @@ func (r *EtcdRegistry) SetMachineState(ms machine.MachineState, ttl time.Duratio
 	// in the cluster know this is a new member
 	opts.PrevExist = etcd.PrevNoExist
 
-	resp, err = r.kAPI.Set(r.ctx(), key, val, opts)
+	resp, err = r.kAPI.Set(context.Background(), key, val, opts)
 	if err != nil {
 		return uint64(0), err
 	}
@@ -110,7 +111,7 @@ func (r *EtcdRegistry) SetMachineState(ms machine.MachineState, ttl time.Duratio
 
 func (r *EtcdRegistry) RemoveMachineState(machID string) error {
 	key := r.prefixed(machinePrefix, machID, "object")
-	_, err := r.kAPI.Delete(r.ctx(), key, nil)
+	_, err := r.kAPI.Delete(context.Background(), key, nil)
 	if isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
 		err = nil
 	}

--- a/registry/unit.go
+++ b/registry/unit.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	etcd "github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
 
 	"github.com/coreos/fleet/log"
 	"github.com/coreos/fleet/metrics"
@@ -44,7 +45,7 @@ func (r *EtcdRegistry) storeOrGetUnitFile(u unit.UnitFile) (err error) {
 		PrevExist: etcd.PrevNoExist,
 	}
 	start := time.Now()
-	_, err = r.kAPI.Set(r.ctx(), key, val, opts)
+	_, err = r.kAPI.Set(context.Background(), key, val, opts)
 	// unit is already stored
 	if isEtcdError(err, etcd.ErrorCodeNodeExist) {
 		// TODO(jonboulle): verify more here?
@@ -65,7 +66,7 @@ func (r *EtcdRegistry) getUnitByHash(hash unit.Hash) *unit.UnitFile {
 		Recursive: true,
 	}
 	start := time.Now()
-	resp, err := r.kAPI.Get(r.ctx(), key, opts)
+	resp, err := r.kAPI.Get(context.Background(), key, opts)
 	if err != nil {
 		if isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
 			err = nil
@@ -86,7 +87,7 @@ func (r *EtcdRegistry) getAllUnitsHashMap() (map[string]*unit.UnitFile, error) {
 	}
 	hashToUnit := map[string]*unit.UnitFile{}
 	start := time.Now()
-	resp, err := r.kAPI.Get(r.ctx(), key, opts)
+	resp, err := r.kAPI.Get(context.Background(), key, opts)
 	if err != nil {
 		metrics.ReportRegistryOpFailure(metrics.GetAll)
 		return nil, err

--- a/registry/version.go
+++ b/registry/version.go
@@ -19,6 +19,7 @@ import (
 
 	etcd "github.com/coreos/etcd/client"
 	"github.com/coreos/go-semver/semver"
+	"golang.org/x/net/context"
 )
 
 // LatestDaemonVersion attempts to retrieve the latest version of fleetd
@@ -46,7 +47,7 @@ func (r *EtcdRegistry) LatestDaemonVersion() (*semver.Version, error) {
 
 // EngineVersion implements the ClusterRegistry interface
 func (r *EtcdRegistry) EngineVersion() (int, error) {
-	res, err := r.kAPI.Get(r.ctx(), r.engineVersionPath(), nil)
+	res, err := r.kAPI.Get(context.Background(), r.engineVersionPath(), nil)
 	if err != nil {
 		// no big deal, either the cluster is new or is just
 		// upgrading from old unversioned code
@@ -69,7 +70,7 @@ func (r *EtcdRegistry) UpdateEngineVersion(from, to int) error {
 	opts := &etcd.SetOptions{
 		PrevValue: strFrom,
 	}
-	_, err := r.kAPI.Set(r.ctx(), key, strTo, opts)
+	_, err := r.kAPI.Set(context.Background(), key, strTo, opts)
 	if err == nil {
 		return nil
 	} else if !isEtcdError(err, etcd.ErrorCodeKeyNotFound) {
@@ -79,7 +80,7 @@ func (r *EtcdRegistry) UpdateEngineVersion(from, to int) error {
 	opts = &etcd.SetOptions{
 		PrevExist: etcd.PrevNoExist,
 	}
-	_, err = r.kAPI.Set(r.ctx(), key, strTo, opts)
+	_, err = r.kAPI.Set(context.Background(), key, strTo, opts)
 	return err
 }
 


### PR DESCRIPTION
As etcd's ``keysAPI`` already supports ``HeaderTimeoutPerRequest``, fleet should not handle request timeout on its own, but just pass on the timeout value to the etcd client. For that, set timeout only in ``etcd.Config.HeaderTimeoutPerRequest``, and get rid of internal timeout handling from both ``EtcdRegistry`` and ``LeaseManager``.

Suggested-by @jonboulle 
Partially resolves https://github.com/coreos/fleet/issues/1397