### PR TITLE
[WIP] functional: run systemctl daemon-reload before fleetctl start --replace

### DIFF
--- a/functional/platform/cluster.go
+++ b/functional/platform/cluster.go
@@ -33,6 +33,7 @@ type Cluster interface {
 	Members() []Member
 	MemberCommand(Member, ...string) (string, error)
 	Destroy(t *testing.T) error
+	SystemdReload() error
 
 	// client operations
 	Fleetctl(m Member, args ...string) (string, string, error)

--- a/functional/platform/nspawn.go
+++ b/functional/platform/nspawn.go
@@ -651,7 +651,7 @@ func (nc *nspawnCluster) DestroyMember(m Member) error {
 	// in time, which can result in subsequent tests failing
 	run(fmt.Sprintf("ip link del vb-%s", label))
 
-	if err := nc.systemdReload(); err != nil {
+	if err := nc.SystemdReload(); err != nil {
 		log.Printf("Failed systemd daemon-reload: %v", err)
 	}
 
@@ -660,7 +660,7 @@ func (nc *nspawnCluster) DestroyMember(m Member) error {
 	return nil
 }
 
-func (nc *nspawnCluster) systemdReload() error {
+func (nc *nspawnCluster) SystemdReload() error {
 	conn, err := dbus.New()
 	if err != nil {
 		return err

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -701,6 +701,11 @@ func TestReplaceSerialization(t *testing.T) {
 		t.Fatalf("Failed to generate a temp fleet service: %v", err)
 	}
 
+	// run once systemctl daemon-reload as its unit file has changed
+	if err := cluster.SystemdReload(); err != nil {
+		t.Fatalf("Failed systemd daemon-reload: %v", err)
+	}
+
 	stdout, stderr, err = cluster.Fleetctl(m, "start", "--replace", tmpSyncService)
 	if err != nil {
 		t.Fatalf("Failed to replace unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)


### PR DESCRIPTION
We should run once ``"systemctl daemon-reload"``, just before doing
``"fleetctl start --replace"``, to be able to (hopefully) avoid occasional
conflicts like:

```
  unit_action_test.go:711: Did not find 1 unit in cluster, unit replace
  failed: failed to find 1 active units within 15s (last found: 0)
```

NOTE: highly experimental. do not merge.