### PR TITLE
functional: fix path to user_data to /var/lib/coreos-install

### DIFF
--- a/functional/platform/nspawn.go
+++ b/functional/platform/nspawn.go
@@ -344,7 +344,7 @@ func (nc *nspawnCluster) insertBin(src string, dst string) error {
 }
 
 func (nc *nspawnCluster) buildConfigDrive(dir, ip string) error {
-	latest := path.Join(dir, "media/configdrive/openstack/latest")
+	latest := path.Join(dir, "var/lib/coreos-install")
 	userPath := path.Join(latest, "user_data")
 	if err := os.MkdirAll(latest, 0755); err != nil {
 		return err


### PR DESCRIPTION
Since CoreOS alpha (1000), coreos-cloudinit doesn't seem to watch
on ``/media/configdrive/openstack/latest/user_data``. That's why
functional tests haven't been running, as systemd-nspawn container
runs without any configurations.
Fix it by changing into ``/var/lib/coreos-install/user_data``.

Fixes: https://github.com/coreos/fleet/issues/1532

/cc @kayrus 