### PR TITLE
functional: poweroff machine using machinectl instead of systemctl

### DIFF
--- a/functional/platform/nspawn.go
+++ b/functional/platform/nspawn.go
@@ -591,15 +591,9 @@ func (nc *nspawnCluster) ReplaceMember(m Member) (Member, error) {
 	count := len(nc.members)
 	label := fmt.Sprintf("%s%s", nc.name, m.ID())
 
-	// The `machinectl poweroff` command does not cleanly shut down
-	// the nspawn container, so we must use systemctl
-	cmd := fmt.Sprintf("systemctl -M %s poweroff", label)
-	if _, stderr, _ := run(cmd); !strings.Contains(stderr, "Success") {
-		if strings.Contains(stderr, "Warning! D-Bus connection terminated.") {
-			log.Printf("poweroff failed: %s", stderr)
-		} else {
-			return nil, fmt.Errorf("poweroff failed: %s", stderr)
-		}
+	cmd := fmt.Sprintf("machinectl poweroff %s", label)
+	if _, _, err := run(cmd); err != nil {
+		return nil, fmt.Errorf("poweroff failed: %v", err)
 	}
 
 	var mN Member


### PR DESCRIPTION
So far ``ReplaceMember`` has been checking for error, by looking up an explicit string ``"Success"`` in stderr from ``"systemctl -M <ID> poweroff"``. However, with systemd v229 or newer, systemctl poweroff does not print out ``"Success"`` even if poweroff succeeded. This causes ``TestKnownHostsVerification`` to always return error like:

```
  --- FAIL: TestKnownHostsVerification (2.66s)
      client_test.go:60: Failed replacing machine: poweroff failed:
```

Fix it by changing the systemctl call to ``"machinectl poweroff <ID>"``, which should return error correctly. This would be better in the long run, than checking for messages in stderr.

Fixes: https://github.com/coreos/fleet/issues/1586