### PR TITLE
functional: allow run-in-qemu to run based on a custom base image

### DIFF
--- a/functional/run-in-qemu
+++ b/functional/run-in-qemu
@@ -6,6 +6,9 @@ USAGE="Usage: $0 [options]
 Options:
     -c|--channel CHANNEL
                 channel name (stable/beta/alpha)               [default: stable]
+    -i|--base-image BASE_IMAGE
+                path to base image
+                      [default: ~/.qemu/coreos_stable_production_qemu_image.img]
     -p|--ssh-port PORT
                 The port on localhost to map to the VM's sshd. [default: 2244]
     -v|--verbose  Make verbose
@@ -24,6 +27,9 @@ while [ $# -ge 1 ]; do
     case "$1" in
         -c|--channel)
             OPTVAL_CHANNEL="$2"
+            shift 2 ;;
+        -i|--base-image)
+            OPTVAL_BASE_IMAGE="$2"
             shift 2 ;;
         -p|--ssh-port)
             OPTVAL_SSH_PORT="$2"
@@ -86,7 +92,11 @@ if [ -n "$OPTVAL_CHANNEL" ]; then
   COREOS_CHANNEL=$OPTVAL_CHANNEL
 fi
 
-BASE_IMAGE=$QEMU_DIR/coreos_${COREOS_CHANNEL}_production_qemu_image.img
+: ${BASE_IMAGE:=${QEMU_DIR}/coreos_${COREOS_CHANNEL}_production_qemu_image.img}
+if [ -n "$OPTVAL_BASE_IMAGE" ]; then
+  BASE_IMAGE=$OPTVAL_BASE_IMAGE
+fi
+
 IMAGE=$QEMU_DIR/coreos_${COREOS_CHANNEL}_fleet_test.qcow2
 
 IMG_URL="https://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/current/coreos_production_qemu_image.img.bz2"

--- a/functional/run-in-qemu
+++ b/functional/run-in-qemu
@@ -4,12 +4,12 @@ BASENAME=$(basename $0)
 
 USAGE="Usage: $0 [options]
 Options:
-    -c|-channel CHANNEL
+    -c|--channel CHANNEL
                 channel name (stable/beta/alpha)               [default: stable]
-    -p|-ssh-port PORT
+    -p|--ssh-port PORT
                 The port on localhost to map to the VM's sshd. [default: 2244]
-    -v          Make verbose
-    -h          this help message
+    -v|--verbose  Make verbose
+    -h|--help     this help message
 
 This script is a wrapper around qemu for starting CoreOS virtual machines,
 especially for running functional tests automatically.
@@ -22,13 +22,13 @@ and port number can be also overridden by environment variable COREOS_SSH_PORT.
 
 while [ $# -ge 1 ]; do
     case "$1" in
-        -c|-channel)
+        -c|--channel)
             OPTVAL_CHANNEL="$2"
             shift 2 ;;
-        -p|-ssh-port)
+        -p|--ssh-port)
             OPTVAL_SSH_PORT="$2"
             shift 2 ;;
-        -v|-verbose)
+        -v|--verbose)
             set -x
             shift ;;
         -h|-help|--help)


### PR DESCRIPTION
Allow run-in-qemu to run with a given custom base image, e.g. ``coreos_developer_qemu_image.img`` which was built by CoreOS SDK.

```
  $ ./run-in-qemu -c alpha -i ~/.qemu/coreos_developer_qemu_image.img
```

/cc @kayrus 