### PR TITLE
functional: write machine ID into nspawn container

### DIFF
--- a/functional/platform/nspawn.go
+++ b/functional/platform/nspawn.go
@@ -466,6 +466,11 @@ func (nc *nspawnCluster) createMember(id string) (m Member, err error) {
 			0644,
 		},
 		{
+			"/etc/machine-id",
+			nm.ID(),
+			0644,
+		},
+		{
 			"/home/core/.bash_profile",
 			"export PATH=/opt/fleet:$PATH",
 			0644,


### PR DESCRIPTION
As systemd v230 or newer requires ``/etc/machine-id`` on a nspawn container, we need to write the container's own machine ID into ``/etc/machine-id``. Otherwise, functional tests don't start at all like:

```
  --- FAIL: TestKnownHostsVerification (10.80s)
    client_test.go:36: unable to detect machine PID
```

Fixes: https://github.com/coreos/fleet/issues/1594
See also https://github.com/systemd/systemd/pull/3014
See also https://github.com/coreos/rkt/pull/2440