### PR TITLE
functional: shorten interval for replace serialization

### DIFF
--- a/functional/fixtures/units/replace-sync.service
+++ b/functional/fixtures/units/replace-sync.service
@@ -2,4 +2,4 @@
 ExecStartPre=/bin/bash -c "echo 'sync'"
 ExecStart=/bin/bash -c "while true; do echo Hello, World!; sleep 1; done"
 ExecStop=/bin/bash -c "echo 'stopping'"
-ExecStopPost=/bin/bash -c "sleep 3; touch /tmp/fleetSyncReplaceFile"
+ExecStopPost=/bin/bash -c "sleep 1; touch /tmp/fleetSyncReplaceFile"


### PR DESCRIPTION
We should shorten the interval between the old unit and new unit, so that across ``"fleetctl start --replace"`` the old unit's ExecStopPost doesn't overlap with the next unit's ExecStartPre directive. This workaround is necessary to (hopefully) avoid occasional conflicts like:

```
  unit_action_test.go:711: Did not find 1 unit in cluster, unit replace
  failed: failed to find 1 active units within 15s (last found: 0)
```

Although this change doesn't completely solve underlying issues between systemd and fleet, it can reduce the number of failures.