### PR TITLE
build: move definition of $VERSION to build-env

### DIFF
--- a/build
+++ b/build
@@ -5,7 +5,6 @@ cd $CDIR
 
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/fleet"
-VERSION=$(git describe --dirty)
 
 if [ ! $(command -v go 2>/dev/null) ]; then
   echo "build: failed to locate Go binaries."

--- a/build-env
+++ b/build-env
@@ -11,6 +11,7 @@ fi
 
 export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
+export VERSION=$(git describe --dirty)
 export GLDFLAGS="-X github.com/coreos/fleet/version.Version=${VERSION}"
 eval $(go env)
 export PATH="${GOROOT}/bin:${PATH}"

--- a/functional/test
+++ b/functional/test
@@ -49,7 +49,6 @@ HOME=$(getent passwd "${USER_ID}" | cut -d: -f6)
 TAIL_LOGS=30
 
 cd ${CDIR}/../
-export VERSION=$(git describe --dirty)
 export GOROOT=${HOME}/go
 export PATH=${HOME}/go/bin:${PATH}
 
@@ -66,14 +65,14 @@ if [[ ! $(go version 2>/dev/null) ]]; then
   functional/provision/install_go.sh
 fi
 
+source build-env
+eval $(go env)
+
 if [ ! -x "bin/fleetd" ] || \
    [ ! -x "bin/fleetctl" ] || \
    [ ! $(bin/fleetctl | grep "${VERSION}") ]; then
   ./build
 fi
-
-source build-env
-eval $(go env)
 
 go test github.com/coreos/fleet/functional -ldflags "${GLDFLAGS}" -v "$@" 2>&1 | tee functional/functional-tests.log
 TESTS_RETURN_CODE_1=${PIPESTATUS[0]}


### PR DESCRIPTION
VERSION should be defined in ``build-env``, not in individual scripts like ``build`` or ``functional/test``. Otherwise, a simple change in one of the scripts could cause unexpected version mismatch failures during functional tests.

I stumbled across this issue while rebasing giantswarm's gRPC branch on top of master.

/cc @hectorj2f