### PR TITLE
fleetctl: fix races in unit tests

### DIFF
--- a/fleetctl/destroy_test.go
+++ b/fleetctl/destroy_test.go
@@ -68,7 +68,9 @@ func TestRunDestroyUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
+		cmu.Lock()
 		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
+		cmu.Unlock()
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -112,6 +112,8 @@ var (
 		SSHPort       int
 	}{}
 
+	smu sync.Mutex
+
 	// current command being executed
 	currentCommand string
 

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -74,6 +74,8 @@ var (
 	// global API client used by commands
 	cAPI client.API
 
+	cmu sync.Mutex
+
 	// flags used by all commands
 	globalFlags = struct {
 		Debug   bool
@@ -299,6 +301,8 @@ func getFlagsFromEnv(prefix string, fs *flag.FlagSet) {
 
 func getClientAPI(cCmd *cobra.Command) client.API {
 	var err error
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI, err = getClient(cCmd)
 	if err != nil {
 		stderr("Unable to initialize client: %v", err)
@@ -1024,6 +1028,8 @@ func checkUnitState(name string, js job.JobState, maxAttempts int, out io.Writer
 func assertUnitState(name string, js job.JobState, out io.Writer) (ret bool) {
 	var state string
 
+	cmu.Lock()
+	defer cmu.Unlock()
 	u, err := cAPI.Unit(name)
 	if err != nil {
 		log.Warningf("Error retrieving Unit(%s) from Registry: %v", name, err)

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -243,6 +243,8 @@ func TestGetBlockAttempts(t *testing.T) {
 		{false, 9999, 9999},
 	}
 
+	smu.Lock()
+	defer smu.Unlock()
 	for _, tt := range blocktests {
 		sharedFlags.NoBlock = tt.noBlock
 		sharedFlags.BlockAttempts = tt.blockAttempts

--- a/fleetctl/fleetctl_test.go
+++ b/fleetctl/fleetctl_test.go
@@ -264,6 +264,8 @@ func TestCreateUnitFails(t *testing.T) {
 	type fakeAPI struct {
 		client.API
 	}
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = fakeAPI{}
 	var i int
 	var un string

--- a/fleetctl/list_unit_files_test.go
+++ b/fleetctl/list_unit_files_test.go
@@ -27,6 +27,8 @@ func TestListUnitFilesFieldsToStrings(t *testing.T) {
 	type fakeAPI struct {
 		client.API
 	}
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = fakeAPI{}
 	u := schema.Unit{
 		Name:    "foo.service",
@@ -91,6 +93,8 @@ func TestMapTargetField(t *testing.T) {
 	type fakeAPI struct {
 		client.API
 	}
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = fakeAPI{}
 	// seeding the cache for the following test cases
 	machineStates = map[string]*machine.MachineState{

--- a/fleetctl/list_units_test.go
+++ b/fleetctl/list_units_test.go
@@ -40,6 +40,8 @@ func TestListUnitsFieldsToStrings(t *testing.T) {
 	type fakeAPI struct {
 		client.API
 	}
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = fakeAPI{}
 
 	// nil UnitState shouldn't happen, but just in case

--- a/fleetctl/load_test.go
+++ b/fleetctl/load_test.go
@@ -36,6 +36,8 @@ func checkLoadUnitState(unit schema.Unit, loadRet int, errchan chan error) {
 }
 
 func doLoadUnits(t *testing.T, r commandTestResults, errchan chan error) {
+	smu.Lock()
+	defer smu.Unlock()
 	sharedFlags.NoBlock = true
 	exit := runLoadUnit(cmdLoad, r.units)
 	if exit != r.expectedExit {

--- a/fleetctl/load_test.go
+++ b/fleetctl/load_test.go
@@ -88,7 +88,9 @@ func TestRunLoadUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
+		cmu.Lock()
 		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
+		cmu.Unlock()
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/ssh_test.go
+++ b/fleetctl/ssh_test.go
@@ -80,6 +80,8 @@ func newFakeRegistryForSsh() client.API {
 }
 
 func TestSshUnknownMachine(t *testing.T) {
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = newFakeRegistryForSsh()
 
 	_, ok, _ := findAddressInMachineList("asdf")
@@ -89,6 +91,8 @@ func TestSshUnknownMachine(t *testing.T) {
 }
 
 func TestSshFindMachine(t *testing.T) {
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = newFakeRegistryForSsh()
 
 	ip, _, _ := findAddressInMachineList("c31e44e1-f858-436e-933e-59c642517860")
@@ -98,6 +102,8 @@ func TestSshFindMachine(t *testing.T) {
 }
 
 func TestSshFindMachineByUnknownUnitName(t *testing.T) {
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = newFakeRegistryForSsh()
 
 	_, ok, _ := findAddressInRunningUnits("asdf")
@@ -107,6 +113,8 @@ func TestSshFindMachineByUnknownUnitName(t *testing.T) {
 }
 
 func TestSshFindMachineByUnitName(t *testing.T) {
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = newFakeRegistryForSsh()
 
 	ip, _, _ := findAddressInRunningUnits("j1")
@@ -116,6 +124,8 @@ func TestSshFindMachineByUnitName(t *testing.T) {
 }
 
 func TestGlobalLookupByUnknownArgument(t *testing.T) {
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = newFakeRegistryForSsh()
 
 	_, err := globalMachineLookup([]string{"asdf"})
@@ -125,6 +135,8 @@ func TestGlobalLookupByUnknownArgument(t *testing.T) {
 }
 
 func TestGlobalLookupByMachineID(t *testing.T) {
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = newFakeRegistryForSsh()
 
 	ip, err := globalMachineLookup([]string{"c31e44e1-f858-436e-933e-59c642517860"})
@@ -138,6 +150,8 @@ func TestGlobalLookupByMachineID(t *testing.T) {
 }
 
 func TestGlobalLookupByUnitName(t *testing.T) {
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = newFakeRegistryForSsh()
 
 	ip, err := globalMachineLookup([]string{"j1"})
@@ -151,6 +165,8 @@ func TestGlobalLookupByUnitName(t *testing.T) {
 }
 
 func TestGlobalLookupWithAmbiguousArgument(t *testing.T) {
+	cmu.Lock()
+	defer cmu.Unlock()
 	cAPI = newFakeRegistryForSsh()
 
 	_, err := globalMachineLookup([]string{"hello.service"})

--- a/fleetctl/start_test.go
+++ b/fleetctl/start_test.go
@@ -64,7 +64,9 @@ func runStartUnits(t *testing.T, unitPrefix string, results []commandTestResults
 			unitsCount = len(r.units)
 		}
 
+		cmu.Lock()
 		cAPI = newFakeRegistryForCommands(unitPrefix, unitsCount, template)
+		cmu.Unlock()
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/fleetctl/start_test.go
+++ b/fleetctl/start_test.go
@@ -36,6 +36,8 @@ func checkStartUnitState(unit schema.Unit, startRet int, errchan chan error) {
 }
 
 func doStartUnits(t *testing.T, r commandTestResults, errchan chan error) {
+	smu.Lock()
+	defer smu.Unlock()
 	sharedFlags.NoBlock = true
 	exit := runStartUnit(cmdStart, r.units)
 	if exit != r.expectedExit {

--- a/fleetctl/stop_test.go
+++ b/fleetctl/stop_test.go
@@ -78,7 +78,9 @@ func TestRunStopUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
+		cmu.Lock()
 		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
+		cmu.Unlock()
 
 		wg.Add(2)
 		go func() {

--- a/fleetctl/stop_test.go
+++ b/fleetctl/stop_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func doStopUnits(t *testing.T, r commandTestResults, errchan chan error) {
+	smu.Lock()
+	defer smu.Unlock()
 	sharedFlags.NoBlock = true
 	exit := runStopUnit(cmdStop, r.units)
 	if exit != r.expectedExit {

--- a/fleetctl/submit_test.go
+++ b/fleetctl/submit_test.go
@@ -67,7 +67,9 @@ func runSubmitUnitsTests(t *testing.T, unitPrefix string, results []commandTestR
 			unitsCount = len(r.units)
 		}
 
+		cmu.Lock()
 		cAPI = newFakeRegistryForCommands(unitPrefix, unitsCount, template)
+		cmu.Unlock()
 
 		wg.Add(1)
 		go func() {

--- a/fleetctl/submit_test.go
+++ b/fleetctl/submit_test.go
@@ -156,6 +156,8 @@ func TestRunSubmitUnits(t *testing.T) {
 		},
 	}
 
+	smu.Lock()
+	defer smu.Unlock()
 	sharedFlags.NoBlock = true
 	runSubmitUnitsTests(t, unitPrefix, results, false)
 	runSubmitUnitsTests(t, unitPrefix, templateResults, true)

--- a/fleetctl/unload_test.go
+++ b/fleetctl/unload_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func doUnloadUnits(t *testing.T, r commandTestResults, errchan chan error) {
+	smu.Lock()
+	defer smu.Unlock()
 	sharedFlags.NoBlock = true
 	exit := runUnloadUnit(cmdUnload, r.units)
 	if exit != r.expectedExit {

--- a/fleetctl/unload_test.go
+++ b/fleetctl/unload_test.go
@@ -78,7 +78,9 @@ func TestRunUnloadUnits(t *testing.T) {
 		var wg sync.WaitGroup
 		errchan := make(chan error)
 
+		cmu.Lock()
 		cAPI = newFakeRegistryForCommands(unitPrefix, len(r.units), false)
+		cmu.Unlock()
 
 		wg.Add(2)
 		go func() {


### PR DESCRIPTION
Introduce 2 mutexes, ``cmu`` for accessing cAPI and ``smu`` for accessing sharedFlags, to avoid races during unit tests.

For example, output from ``"go test --race"``:

```
    WARNING: DATA RACE
    Write by goroutine 26:
      github.com/coreos/fleet/fleetctl.doUnloadUnits()
          /home/dpark/go/src/github.com/coreos/fleet/fleetctl/unload_test.go:26 +0x60
      github.com/coreos/fleet/fleetctl.TestRunUnloadUnits.func3()
          /home/dpark/go/src/github.com/coreos/fleet/fleetctl/unload_test.go:92 +0x89
    
    Previous write by goroutine 25:
      github.com/coreos/fleet/fleetctl.doUnloadUnits()
          /home/dpark/go/src/github.com/coreos/fleet/fleetctl/unload_test.go:26 +0x60
      github.com/coreos/fleet/fleetctl.TestRunUnloadUnits.func2()
          /home/dpark/go/src/github.com/coreos/fleet/fleetctl/unload_test.go:88 +0x89
```
