### PR TITLE
build-env: determine GO15VENDOREXPERIMENT correctly

### DIFF
--- a/build-env
+++ b/build-env
@@ -1,19 +1,26 @@
-version=$(go version)
-regex="go([0-9]+).([0-9]+)."
-if [[ $version =~ $regex ]]; then
-  if [ ${BASH_REMATCH[1]} -eq "1" -a ${BASH_REMATCH[2]} -eq "5" ]; then
-    export GO${BASH_REMATCH[1]}${BASH_REMATCH[2]}VENDOREXPERIMENT=1
+function check_go15ve() {
+  version=$(go version)
+  regex="go([0-9]+).([0-9]+)."
+  if [[ $version =~ $regex ]]; then
+    if [ ${BASH_REMATCH[1]} -eq "1" -a ${BASH_REMATCH[2]} -eq "5" ]; then
+      export GO${BASH_REMATCH[1]}${BASH_REMATCH[2]}VENDOREXPERIMENT=1
+    else
+      export GO15VENDOREXPERIMENT=0
+    fi
+  else
+    echo "could not determine Go version"
+    exit 1
   fi
-else
-  echo "could not determine Go version"
-  exit 1
-fi
+}
 
 export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 export VERSION=$(git describe --dirty)
 export GLDFLAGS="-X github.com/coreos/fleet/version.Version=${VERSION}"
+
 eval $(go env)
+check_go15ve
+
 export PATH="${GOROOT}/bin:${PATH}"
 export FLEETD_BIN="$(pwd)/bin/fleetd"
 export FLEETCTL_BIN="$(pwd)/bin/fleetctl"


### PR DESCRIPTION
Build environment has been buggy as it always set ``GO15VENDOREXPERIMENT`` to 1, even when a local go 1.6 compiler is used on a host where the default go compiler is 1.5. A typical example is functional test, which automatically installs go 1.6 runtime under ``/home/core/go`` for every test, while ``/usr/bin/go`` still remains as 1.5. Then ``GO15VENDOREXPERIMENT`` is set to 1 before running the functional test, but it's not set back to 0, even when a 1.6 compiler is supposed to be used. For instance, this bug breaks a build of ``github.com/ugorji/go``, which is going to be necessary for building dependencies in the future.

So the fix is to set ``GO15VENDOREXPERIMENT`` to 0, when go compiler is not 1.5. Also such action must run after ``"eval $(go env)"``, otherwise that value could become back to 1.