### PR TITLE
functional: increase RAM to 1024MB to fix build errors

### DIFF
--- a/functional/config.rb
+++ b/functional/config.rb
@@ -42,7 +42,7 @@ $update_channel='stable'
 
 # Customize VMs
 #$vm_gui = false
-$vm_memory = 512
+$vm_memory = 1024
 $vm_cpus = 1
 
 # Share additional folders to the CoreOS VMs

--- a/functional/run-in-qemu
+++ b/functional/run-in-qemu
@@ -139,7 +139,7 @@ qemu-img create -f qcow2 -b $BASE_IMAGE $IMAGE || print_error "Failed to create 
 
 qemu-system-x86_64 \
   -name $NAME \
-  -m 512 \
+  -m 1024 \
   -net nic,vlan=0,model=virtio \
   -net user,vlan=0,hostfwd=tcp:127.0.0.1:$COREOS_SSH_PORT-:22,hostname=$NAME \
   -drive if=virtio,file=$IMAGE \


### PR DESCRIPTION
Increase RAM of test VM from 512MB to 1024MB, to fix build errors when compiling packages like ``github.com/ugorji/go``, which will be needed in the future for dependencies. Without this change, build with go 1.6 or higher fails like that:

```
  github.com/ugorji/go/codec: /home/core/go/pkg/tool/linux_amd64/compile: signal: killed
```