### PR TITLE
travis: add tip to the compiler and update build-env.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ matrix:
     - go: 1.5.4
       env: GO15VENDOREXPERIMENT=1
     - go: 1.6.2
+    - go: tip
+  allow_failures:
+    - go: tip
 
 script:
  - ./test

--- a/build-env
+++ b/build-env
@@ -1,12 +1,16 @@
 version=$(go version)
-regex="go([0-9]+).([0-9]+)."
-if [[ $version =~ $regex ]]; then
+regex_release="go([0-9]+).([0-9]+)."
+regex_devel="devel\s+\+([a-f0-9]+)\s+"
+if [[ $version =~ $regex_release ]]; then
   if [ ${BASH_REMATCH[1]} -eq "1" -a ${BASH_REMATCH[2]} -eq "5" ]; then
     export GO${BASH_REMATCH[1]}${BASH_REMATCH[2]}VENDOREXPERIMENT=1
   fi
 else
-  echo "could not determine Go version"
-  exit 1
+  if ! [[ $version =~ $regex_devel ]]; then
+    echo "could not determine Go version"
+    echo "version = \"$version\""
+    exit 1
+  fi
 fi
 
 export GOBIN=${PWD}/bin


### PR DESCRIPTION
Allow travis to build fleet also with the most recent go compiler, "tip".
For example, as of 2016-06-22, go "tip" compiler's version is ``"devel +1f44643 Wed Jun 22 00:12:55 2016 +0000"``.
To make it work, build-env needs to be also updated, not to exit with error in case of the devel version.