### PR TITLE
fleetd: check that eStream is available before accessing to that

### DIFF
--- a/pkg/reconcile.go
+++ b/pkg/reconcile.go
@@ -58,6 +58,9 @@ func (r *reconciler) Run(stop <-chan struct{}) {
 	go func() {
 		abort := make(chan struct{})
 		for {
+			if r.eStream == nil {
+				return
+			}
 			select {
 			case <-stop:
 				close(abort)

--- a/server/server.go
+++ b/server/server.go
@@ -189,7 +189,7 @@ func (s *Server) Run() {
 				break
 			}
 		}
-		log.Errorf("Server register machine failed: %v", err)
+		log.Warningf("Server register machine failed: %v, retrying in %d sec.", err, sleep)
 		time.Sleep(sleep)
 	}
 


### PR DESCRIPTION
To avoid potential nil-dereferences in agent reconciliation, check that eStream is available before accessing to ``eStream``. Otherwise, just return.
    
Example error logs:
```
ERROR server.go:192: Server register machine failed: 105: Key already exists
(/_coreos.com/fleet/machines/d5ca2e9d4039e480807464280c9ab4a2/object) [203153266]
INFO server.go:188: hrt.Register() success
INFO server.go:198: Starting server components
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x4bc024]
goroutine 49 [running]:
panic(0xc06080, 0xc82000a0a0)
        /usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/coreos/fleet/pkg.(*reconciler).Run.func1(0xc8201cef00, 0xc8201b9560, 0xc8201cf2c0)
/opt/fleet/gopath/src/github.com/coreos/fleet/pkg/reconcile.go:65 +0x74
created by github.com/coreos/fleet/pkg.(*reconciler).Run
/opt/fleet/gopath/src/github.com/coreos/fleet/pkg/reconcile.go:69 +0x89
systemd[1]: fleet.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
systemd[1]: fleet.service: Unit entered failed state.
systemd[1]: fleet.service: Failed with result 'exit-code'.
```
    
Fixes: https://github.com/coreos/fleet/issues/1622
