### PR TITLE
fleetctl: status and restart commands with global units

### DIFF
--- a/fleetctl/restart.go
+++ b/fleetctl/restart.go
@@ -1,0 +1,125 @@
+// Copyright 2016 The fleet Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/coreos/fleet/job"
+	"github.com/coreos/fleet/log"
+	"github.com/coreos/fleet/schema"
+)
+
+var cmdRestart = &cobra.Command{
+	Use:   "restart [--block-attempts=N] UNIT...",
+	Short: "Instruct systemd to rolling restart one or more units in the cluster.",
+	Long: `Restarts one or more units in the cluster. If they are stopped it starts them.
+
+Instructs systemd on the host machine to stop then start the unit, deferring to systemd
+completely for any custom restart directives (i.e. ExecStop options in the unit
+file).
+
+For units which are not global, restart operations are performed synchronously,
+which means fleetctl will block until it detects that the unit(s) have
+transitioned to a stopped state and then back to a started state. This behaviour can be configured with the
+respective --block-attempts options. Restart operations on global
+units are always non-blocking.
+
+Restart a single unit:
+	fleetctl restart foo.service
+
+Restart an entire directory of units with glob matching, without waiting:
+	fleetctl restart myservice/*`,
+	Run: runWrapper(runRestartUnit),
+}
+
+func init() {
+	cmdFleet.AddCommand(cmdRestart)
+
+	cmdRestart.Flags().IntVar(&sharedFlags.BlockAttempts, "block-attempts", 0, "Wait until the units are stopped/started, performing up to N attempts before giving up. A value of 0 indicates no limit. Does not apply to global units.")
+}
+
+func runRestartUnit(cCmd *cobra.Command, args []string) (exit int) {
+	if len(args) == 0 {
+		stderr("No units given")
+		return 0
+	}
+	units, err := findUnits(args)
+	if err != nil {
+		stderr("%v", err)
+		return 1
+	}
+
+	if err := lazyCreateUnits(cCmd, args); err != nil {
+		stderr("Error creating units: %v", err)
+		return 1
+	}
+
+	globalUnits := make([]schema.Unit, 0)
+	for _, unit := range units {
+		if suToGlobal(unit) {
+			globalUnits = append(globalUnits, unit)
+			continue
+		}
+		if job.JobState(unit.CurrentState) == job.JobStateInactive {
+			stderr("Unable to restart unit %s in state %s", unit.Name, job.JobStateInactive)
+			continue
+		} else if job.JobState(unit.CurrentState) == job.JobStateLoaded {
+			log.Infof("Unit(%s) already %s, starting.", unit.Name, job.JobStateLoaded)
+
+			exit = setUnitStateAndWait(unit, job.JobStateLaunched, getBlockAttempts(cCmd))
+			if exit == 1 {
+				return exit
+			}
+			continue
+		} else {
+			//stop and start it
+			exit = setUnitStateAndWait(unit, job.JobStateLoaded, getBlockAttempts(cCmd))
+			if exit == 1 {
+				return exit
+			}
+			exit = setUnitStateAndWait(unit, job.JobStateLaunched, getBlockAttempts(cCmd))
+			if exit == 1 {
+				return exit
+			}
+		}
+		log.Infof("Unit(%s) was restarted.", unit.Name)
+	}
+
+	if err := cmdGlobalMachineState(cCmd, globalUnits); err != nil {
+		stderr("Error restarting global units %v err:%v", globalUnits, err)
+		return 1
+	}
+
+	return
+}
+
+func setUnitStateAndWait(unit schema.Unit, targetState job.JobState, blockAttempts int) (exit int) {
+	err := cAPI.SetUnitTargetState(unit.Name, string(targetState))
+	if err != nil {
+		stderr("Error setting target state for unit %s: %v", unit.Name, err)
+		return 1
+	}
+
+	err = tryWaitForUnitStates([]string{unit.Name}, "restart", job.JobStateLaunched, blockAttempts, os.Stdout)
+	if err != nil {
+		stderr("Error waiting for unit states, exit status: %v", err)
+		return 1
+	}
+
+	return 0
+}

--- a/fleetctl/restart_test.go
+++ b/fleetctl/restart_test.go
@@ -1,0 +1,136 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/coreos/fleet/schema"
+)
+
+func checkRestartUnitState(unit schema.Unit, restartRet int, errchan chan error) {
+	if restartRet != 0 && unit.DesiredState != "" {
+		// if the whole restart operation failed, then no unit
+		// should have a DesiredState set
+		errchan <- fmt.Errorf("Error: Unit(%s) DesiredState was set to (%s)", unit.Name, unit.DesiredState)
+	}
+}
+
+func doRestartUnits(t *testing.T, r commandTestResults, errchan chan error) {
+	sharedFlags.NoBlock = true
+	exit := runRestartUnit(cmdRestart, r.units)
+	if exit != r.expectedExit {
+		errchan <- fmt.Errorf("%s: expected exit code %d but received %d", r.description, r.expectedExit, exit)
+		return
+	}
+
+	real_units, err := findUnits(r.units)
+	if err != nil {
+		errchan <- err
+		return
+	}
+
+	for _, v := range real_units {
+		checkRestartUnitState(v, r.expectedExit, errchan)
+	}
+}
+
+func runRestartUnits(t *testing.T, unitPrefix string, results []commandTestResults, template bool) {
+	unitsCount := 0
+	for _, r := range results {
+		var wg_res sync.WaitGroup
+
+		if !template {
+			unitsCount = len(r.units)
+		}
+
+		cAPI = newFakeRegistryForCommands(unitPrefix, unitsCount, template)
+
+		errchan_res := make(chan error)
+		wg_res.Add(1)
+		go func() {
+			defer wg_res.Done()
+			doRestartUnits(t, r, errchan_res)
+		}()
+
+		go func() {
+			wg_res.Wait()
+			close(errchan_res)
+		}()
+
+		for err := range errchan_res {
+			t.Errorf("%v", err)
+		}
+	}
+}
+
+func TestRunRestartUnits(t *testing.T) {
+	unitPrefix := "restart"
+	oldNoBlock := sharedFlags.NoBlock
+	defer func() {
+		sharedFlags.NoBlock = oldNoBlock
+	}()
+
+	results := []commandTestResults{
+		{
+			"restart available units",
+			[]string{"restart1", "restart2", "restart3", "restart4", "restart5", "restart6"},
+			0,
+		},
+		{
+			"restart non-available units",
+			[]string{"y1", "y2"},
+			1,
+		},
+		{
+			"restart available and non-available units",
+			[]string{"y1", "y2", "y3", "y4", "restart1", "restart2", "restart3", "restart4", "restart5", "restart6", "y0"},
+			1,
+		},
+		{
+			"restart a unit from a non-available template",
+			[]string{"foo-template@1"},
+			1,
+		},
+		{
+			"restart null input",
+			[]string{},
+			0,
+		},
+	}
+
+	templateResults := []commandTestResults{
+		{
+			"restart a unit from a non-available template",
+			[]string{"restart-foo@1"},
+			1,
+		},
+		{
+			"restart units from an available template",
+			[]string{"restart@1", "restart@100", "restart@1000"},
+			0,
+		},
+		{
+			"restart same unit from an available template",
+			[]string{"restart@1", "restart@1", "restart@1"},
+			0,
+		},
+	}
+
+	runRestartUnits(t, unitPrefix, results, false)
+	runRestartUnits(t, unitPrefix, templateResults, true)
+}

--- a/functional/scheduling_test.go
+++ b/functional/scheduling_test.go
@@ -617,12 +617,14 @@ func TestScheduleGlobalUnits(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cluster.Destroy(t)
-	members, err := platform.CreateNClusterMembers(cluster, 3)
+	numGUnits := 3
+	numAllUnits := 5
+	members, err := platform.CreateNClusterMembers(cluster, numGUnits)
 	if err != nil {
 		t.Fatal(err)
 	}
 	m0 := members[0]
-	machines, err := cluster.WaitForNMachines(m0, 3)
+	machines, err := cluster.WaitForNMachines(m0, numGUnits)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -640,19 +642,21 @@ func TestScheduleGlobalUnits(t *testing.T) {
 	}
 
 	// Now add a global unit
-	stdout, stderr, err = cluster.Fleetctl(m0, "start", "--no-block", "fixtures/units/global.service")
+	globalLongPath := "fixtures/units/global.service"
+	stdout, stderr, err = cluster.Fleetctl(m0, "start", "--no-block", globalLongPath)
 	if err != nil {
 		t.Fatalf("Failed starting unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
 	}
 
 	// Should see 2 + 3 units
-	states, err := cluster.WaitForNActiveUnits(m0, 5)
+	states, err := cluster.WaitForNActiveUnits(m0, numAllUnits)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Each machine should have a single global unit
-	us := states["global.service"]
+	globalBase := path.Base(globalLongPath)
+	us := states[globalBase]
 	for _, mach := range machines {
 		var found bool
 		for _, state := range us {
@@ -668,6 +672,27 @@ func TestScheduleGlobalUnits(t *testing.T) {
 				t.Logf("%#v", state)
 			}
 		}
+	}
+
+	stdout, stderr, err = cluster.Fleetctl(m0, "status", "--no-block", globalBase)
+	if err != nil {
+		t.Fatalf("Failed getting unit status: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
+	}
+
+	// restarting global units
+	cmd := "restart"
+	stdout, stderr, err = cluster.Fleetctl(m0, cmd, globalBase)
+	if err != nil {
+		t.Fatalf("Failed restarting global unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
+	}
+
+	outmap, err := waitForNUnitsStart(cluster, m0, numAllUnits)
+	if err != nil {
+		t.Fatalf("Failed listing global units: %v", err)
+	}
+	glist, _ := outmap[globalBase]
+	if len(glist) != numGUnits {
+		t.Fatalf("Did not find %d global units: got %d", numGUnits, len(glist))
 	}
 }
 

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -35,9 +35,10 @@ const (
 )
 
 var cleanCmd = map[string]string{
-	"submit": "destroy",
-	"load":   "unload",
-	"start":  "stop",
+	"submit":  "destroy",
+	"load":    "unload",
+	"start":   "stop",
+	"restart": "stop",
 }
 
 // TestUnitRunnable is the simplest test possible, deplying a single-node
@@ -161,6 +162,41 @@ func TestUnitLoadReplace(t *testing.T) {
 // hello.service" works or not.
 func TestUnitStartReplace(t *testing.T) {
 	if err := replaceUnitCommon(t, "start", 3); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUnitRestart checks if a unit becomes started and restarted successfully.
+// First it starts a unit, and restarts the unit, verifies it's restarted.
+func TestUnitRestart(t *testing.T) {
+	cluster, err := platform.NewNspawnCluster("smoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cluster.Destroy(t)
+
+	m, err := cluster.CreateMember()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cluster.WaitForNMachines(m, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	numUnits := 3
+
+	// first start units before restarting them
+	unitFiles, err := launchUnitsCmd(cluster, m, "start", numUnits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkListUnits(cluster, m, "start", unitFiles, numUnits); err != nil {
+		t.Fatal(err)
+	}
+
+	// now restart
+	if err := unitStartCommon(cluster, m, "restart", numUnits); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -582,6 +618,8 @@ func checkListUnits(cl platform.Cluster, m platform.Member, cmd string, ufs []st
 		lenLists = len(lus)
 		break
 	case "start":
+		fallthrough
+	case "restart":
 		lus, err = waitForNUnitsStart(cl, m, nu)
 		lenLists = len(lus)
 		break
@@ -642,6 +680,8 @@ func waitForNUnitsCmd(cl platform.Cluster, m platform.Member, cmd string, nu int
 		_, err = waitForNUnitsLoad(cl, m, nu)
 		break
 	case "start":
+		fallthrough
+	case "restart":
 		_, err = waitForNUnitsStart(cl, m, nu)
 		break
 	default:

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -604,18 +604,6 @@ func checkListUnits(cl platform.Cluster, m platform.Member, cmd string, ufs []st
 		if lenLists != nu || !found {
 			return fmt.Errorf("Expected %s to be unit file", ufs[i])
 		}
-
-		if cmd == "start" {
-			// Check expected systemd state after starting units
-			stdout, stderr, err := cl.MemberCommand(m, "systemctl", "show", "--property=ActiveState", ufs[i])
-			if strings.TrimSpace(stdout) != "ActiveState=active" {
-				return fmt.Errorf("Fleet unit not reported as active:\nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
-			}
-			stdout, stderr, err = cl.MemberCommand(m, "systemctl", "show", "--property=Result", ufs[i])
-			if strings.TrimSpace(stdout) != "Result=success" {
-				return fmt.Errorf("Result for fleet unit not reported as success:\nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
-			}
-		}
 	}
 	return err
 }


### PR DESCRIPTION
This PR is _yet another_ revision of a long-running issue, `fleetctl restart` and `status` with global units.
- First allow `"fleetctl status"` to run with global units. For the purpose, implement a helper `cmdGlobalMachineState()` that filters a list of machines only with unique entries.
- Introduce a new command `"fleetctl restart"`. This part is originally taken from https://github.com/coreos/fleet/pull/1238 written by "Kyle Boorky kboorky@turbine.com", committed by @hhoover . 
- Introduce unit test and functional test for `fleetctl restart`.
- Add new tests for global tests in `TestScheduleGlobalUnits()`.

This PR is not about changing API or metadata format in etcd registry. It's not introducing any new mechanism, because I don't think I can afford changing such design at the moment. It's rather a compromise between practical requirements and the current design of fleet. Though we still need to think about how to decrease number of ssh connections when restarting global units, as suggested by @kayrus. See also https://github.com/coreos/fleet/issues/1559.

Fixes https://github.com/coreos/fleet/issues/975
