### PR TITLE
test: Updated GPG pub key ID

### DIFF
--- a/functional/run-in-qemu
+++ b/functional/run-in-qemu
@@ -102,7 +102,7 @@ IMAGE=$QEMU_DIR/coreos_${COREOS_CHANNEL}_fleet_test.qcow2
 IMG_URL="https://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/current/coreos_production_qemu_image.img.bz2"
 SIG_URL="https://${COREOS_CHANNEL}.release.core-os.net/amd64-usr/current/coreos_production_qemu_image.img.bz2.sig"
 GPG_PUB_KEY="https://coreos.com/security/image-signing-key/CoreOS_Image_Signing_Key.asc"
-GPG_PUB_KEY_ID="50E0885593D2DCB4"
+GPG_PUB_KEY_ID="48F9B96A2E16137F"
 
 set +e
 if gpg --version > /dev/null 2>&1; then


### PR DESCRIPTION
CoreOS has changed GPG keys for new releases. If we don't use `48F9B96A2E16137F` here and there is already imported old GPG key, it will be not updated and GPG check will fail.