### PR TITLE
functional: tune intervals in etcd config to avoid connectivity errors

### DIFF
--- a/functional/user-data
+++ b/functional/user-data
@@ -5,6 +5,8 @@ coreos:
   etcd2:
     advertise-client-urls: http://$private_ipv4:2379
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    heartbeat-interval: 600
+    election-timeout: 6000
   units:
   - name: etcd2.service
     command: start


### PR DESCRIPTION
In etcd config, increase ``heartbeat-interval`` from 100 to 600, also ``election-timeout`` from 1000 to 6000. This is a workaround for avoiding occasional failures of ``TestSingleNodeConnectivityLoss`` like below:

```
--- FAIL: TestSingleNodeConnectivityLoss (41.41s)
    connectivity-loss_test.go:98: Failed listing unit files:
        stdout:
        stderr: Error retrieving list of units from repository:
googleapi: Error 503: fleet server unable to  communicate with etcd

        err: exit status 1
```

See also https://github.com/coreos/fleet/issues/1289#issuecomment-146424680
Workaround for https://github.com/coreos/fleet/issues/1250