### PR TITLE
config: add basic etcd authentication

### DIFF
--- a/Documentation/deployment-and-configuration.md
+++ b/Documentation/deployment-and-configuration.md
@@ -248,8 +248,8 @@ Default: false
 [api-doc]: api-v1.md
 [config]: /fleet.conf.sample
 [etcd]: https://github.com/coreos/docs/blob/master/etcd/getting-started-with-etcd.md
-[etcd-security]: https://github.com/coreos/etcd/blob/master/Documentation/security.md
-[etcd-authentication]: https://github.com/coreos/etcd/blob/master/Documentation/authentication.md
+[etcd-security]: https://github.com/coreos/etcd/blob/master/Documentation/v2/security.md
+[etcd-authentication]: https://github.com/coreos/etcd/blob/master/Documentation/v2/authentication.md
 [fleet-inject-ssh]: /scripts/fleetctl-inject-ssh.sh
 [fleet-scale]: fleet-scaling.md#implemented-quick-wins
 [socket-unit]: http://www.freedesktop.org/software/systemd/man/systemd.socket.html

--- a/Documentation/deployment-and-configuration.md
+++ b/Documentation/deployment-and-configuration.md
@@ -46,6 +46,40 @@ etcd_certfile=/etc/ssl/etcd/client.pem
 etcd_keyfile=/etc/ssl/etcd/client-key.pem
 ```
 
+### Basic Authentication
+
+If your etcd cluster has [Basic authentication][etcd-authentication] enabled, you will need to configure fleet to use an username/password combination for a valid user in the system. Also, because [Basic authentication][etcd-authentication] is Base64 encoded and easily deciphered, it is recommended to also use [TLS authentication][etcd-security] for transport level encryption by providing an `etcd_cafile`. *Authentication is only available since etcd 2.1.X and greater.*
+The examples below show how to achieve this:
+
+#### Using systemd Drop-Ins
+
+```ini
+[Service]
+Environment="FLEET_ETCD_SERVERS=https://192.0.2.12:2379"
+Environment="FLEET_ETCD_USERNAME=root"
+Environment="FLEET_ETCD_PASSWORD=coreos"
+```
+
+#### Using CoreOS Cloud Config
+
+```yaml
+#cloud-config
+
+coreos:
+  fleet:
+    etcd_servers: "https://192.0.2.12:2379"
+    etcd_username: root
+    etcd_password: coreos
+```
+
+#### Using fleet configuration file
+
+```ini
+etcd_servers=["https://192.0.2.12:2379"]
+etcd_username=root
+etcd_password=coreos
+```
+
 ## systemd
 
 The `fleetd` daemon communicates with systemd (v207+) running locally on a given machine. It requires D-Bus (v1.6.12+) to do this.
@@ -215,6 +249,7 @@ Default: false
 [config]: /fleet.conf.sample
 [etcd]: https://github.com/coreos/docs/blob/master/etcd/getting-started-with-etcd.md
 [etcd-security]: https://github.com/coreos/etcd/blob/master/Documentation/security.md
+[etcd-authentication]: https://github.com/coreos/etcd/blob/master/Documentation/authentication.md
 [fleet-inject-ssh]: /scripts/fleetctl-inject-ssh.sh
 [fleet-scale]: fleet-scaling.md#implemented-quick-wins
 [socket-unit]: http://www.freedesktop.org/software/systemd/man/systemd.socket.html

--- a/Documentation/using-the-client.md
+++ b/Documentation/using-the-client.md
@@ -23,6 +23,12 @@ FLEETCTL_ENDPOINT=http://<IP:[PORT]> fleetctl list-units
 
 *It is not recommended to listen fleet API TCP socket over public and even private networks.* Fleet API socket doesn't support encryption and authorization so it could cause full root access to your machine. Please use [ssh tunnel][ssh-tunnel] to access remote fleet API.
 
+### Using etcd Authentication
+
+If your `etcd` cluster is configured with authentication enabled, use the `--etcd-username` and `--etc-password` flags to provide credentials to the command-line tool.
+
+*It is not recommended to use Authentication without also using TLS Transport by also providing the `--ca-file` flag*
+
 ### From an External Host
 
 If you prefer to execute fleetctl from an external host (i.e. your laptop), the `--tunnel` flag can be used to tunnel communication with your fleet cluster over SSH:
@@ -37,7 +43,7 @@ One can also provide `--tunnel` through the environment variable `FLEETCTL_TUNNE
 FLEETCTL_TUNNEL=<IP[:PORT]> fleetctl list-units
 ```
 
-When using `--tunnel` and `--endpoint` together, it is important to note that all etcd requests will be made through the SSH tunnel. 
+When using `--tunnel` and `--endpoint` together, it is important to note that all etcd requests will be made through the SSH tunnel.
 The address in the `--endpoint` flag must be routable from the server hosting the tunnel.
 
 If the external host requires a username other than `core`, the `--ssh-username` flag can be used to set an alternative username.
@@ -158,7 +164,7 @@ hello.service	ping.service	pong.service
 $ fleetctl submit examples/*
 ```
 
-Submission of units to a fleet cluster does not cause them to be scheduled. 
+Submission of units to a fleet cluster does not cause them to be scheduled.
 The unit will be visible in a `fleetctl list-unit-files` command, but have no reported state in `fleetctl list-units`.
 
 A unit can be removed from a cluster with the `destroy` command:

--- a/Documentation/using-the-client.md
+++ b/Documentation/using-the-client.md
@@ -25,7 +25,7 @@ FLEETCTL_ENDPOINT=http://<IP:[PORT]> fleetctl list-units
 
 ### Using etcd Authentication
 
-If your `etcd` cluster is configured with authentication enabled, use the `--etcd-username` and `--etc-password` flags to provide credentials to the command-line tool.
+If your `etcd` cluster is configured with authentication enabled, set `etcd_username` and `etcd_password` options in fleet.conf to provide credentials. It is not possible to provide credentials to the command-line tool.
 
 *It is not recommended to use Authentication without also using TLS Transport by also providing the `--ca-file` flag*
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,8 @@ import (
 
 type Config struct {
 	EtcdServers             []string
+	EtcdUsername            string
+	EtcdPassword            string
 	EtcdKeyPrefix           string
 	EtcdKeyFile             string
 	EtcdCertFile            string

--- a/fleet.conf.sample
+++ b/fleet.conf.sample
@@ -16,6 +16,10 @@
 # etcd_keyfile=/path/to/keyfile
 # etcd_certfile=/path/to/certfile
 
+# Provide Authentication configuration when basic authentication is enabled in etcd endpoints
+# etcd_username=root
+# etcd_password=coreos
+
 # IP address that should be published with any socket information. By default,
 # no IP address is published.
 # public_ip=""

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -77,6 +77,8 @@ func main() {
 	cfgset := flag.NewFlagSet("fleet", flag.ExitOnError)
 	cfgset.Int("verbosity", 0, "Logging level")
 	cfgset.Var(&pkg.StringSlice{"http://127.0.0.1:2379", "http://127.0.0.1:4001"}, "etcd_servers", "List of etcd endpoints")
+	cfgset.String("etcd_username", "", "username for secure etcd communication")
+	cfgset.String("etcd_password", "", "password for secure etcd communication")
 	cfgset.String("etcd_keyfile", "", "SSL key file used to secure etcd communication")
 	cfgset.String("etcd_certfile", "", "SSL certification file used to secure etcd communication")
 	cfgset.String("etcd_cafile", "", "SSL Certificate Authority file used to secure etcd communication")
@@ -215,6 +217,8 @@ func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error
 	cfg := config.Config{
 		Verbosity:               (*flagset.Lookup("verbosity")).Value.(flag.Getter).Get().(int),
 		EtcdServers:             (*flagset.Lookup("etcd_servers")).Value.(flag.Getter).Get().(pkg.StringSlice),
+		EtcdUsername:            (*flagset.Lookup("etcd_username")).Value.(flag.Getter).Get().(string),
+		EtcdPassword:            (*flagset.Lookup("etcd_password")).Value.(flag.Getter).Get().(string),
 		EtcdKeyPrefix:           (*flagset.Lookup("etcd_key_prefix")).Value.(flag.Getter).Get().(string),
 		EtcdKeyFile:             (*flagset.Lookup("etcd_keyfile")).Value.(flag.Getter).Get().(string),
 		EtcdCertFile:            (*flagset.Lookup("etcd_certfile")).Value.(flag.Getter).Get().(string),

--- a/server/server.go
+++ b/server/server.go
@@ -94,7 +94,10 @@ func New(cfg config.Config, listeners []net.Listener) (*Server, error) {
 		Transport:               &http.Transport{TLSClientConfig: tlsConfig},
 		Endpoints:               cfg.EtcdServers,
 		HeaderTimeoutPerRequest: (time.Duration(cfg.EtcdRequestTimeout*1000) * time.Millisecond),
+		Username:                cfg.EtcdUsername,
+		Password:                cfg.EtcdPassword,
 	}
+
 	eClient, err := etcd.New(eCfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Expose ``username`` and ``password`` as options for configuration to etcd endpoints.

Originally written by @jipperinbham.

Fixes https://github.com/coreos/fleet/pull/1505
Supersedes https://github.com/coreos/fleet/pull/1506
