### PR TITLE
functional: introduce a test TestFleetctlWithEnv

### DIFF
--- a/functional/client_test.go
+++ b/functional/client_test.go
@@ -81,3 +81,30 @@ func TestKnownHostsVerification(t *testing.T) {
 	}
 
 }
+
+// TestFleetctlWithEnv runs simply fleetctl list-machines, but by setting an
+// environment variable FLEETCTL_ENDPOINT, instead of the cmdline option
+// '--endpoint'.
+func TestFleetctlWithEnv(t *testing.T) {
+	cluster, err := platform.NewNspawnCluster("smoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cluster.Destroy(t)
+
+	m, err := cluster.CreateMember()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = cluster.WaitForNMachines(m, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := cluster.FleetctlWithEnv(m, "list-machines")
+	if err != nil {
+		t.Fatalf("Failed to run with env var FLEETCTL_ENDPOINT:\nstdout: %s\nstderr: %s\nerr: %v",
+			stdout, stderr, err)
+	}
+}

--- a/functional/platform/cluster.go
+++ b/functional/platform/cluster.go
@@ -37,6 +37,7 @@ type Cluster interface {
 	// client operations
 	Fleetctl(m Member, args ...string) (string, string, error)
 	FleetctlWithInput(m Member, input string, args ...string) (string, string, error)
+	FleetctlWithEnv(m Member, args ...string) (string, string, error)
 	WaitForNUnits(Member, int) (map[string][]util.UnitState, error)
 	WaitForNActiveUnits(Member, int) (map[string][]util.UnitState, error)
 	WaitForNUnitFiles(Member, int) (map[string][]util.UnitFileState, error)


### PR DESCRIPTION
``TestFleetctlWithEnv`` runs simply fleetctl list-machines, but by setting an environment variable ``FLEETCTL_ENDPOINT``, instead of the cmdline option ``'--endpoint'``. This way functional test is able to detect regressions like https://github.com/coreos/fleet/issues/1631.
