### PR TITLE
travis,functional: bump golang to 1.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
     - go: 1.5.4
       env: GO15VENDOREXPERIMENT=1
-    - go: 1.6.2
+    - go: 1.6.3
     - go: tip
   allow_failures:
     - go: tip

--- a/functional/provision/install_go.sh
+++ b/functional/provision/install_go.sh
@@ -6,7 +6,7 @@ HOME=$(getent passwd "${USER_ID}" | cut -d: -f6)
 export GOROOT=${HOME}/go
 export PATH=${HOME}/go/bin:${PATH}
 
-gover=1.6.2
+gover=1.6.3
 gotar=go${gover}.linux-amd64.tar.gz
 if [ ! -f ${HOME}/${gotar} ]; then
   # Remove unfinished archive when you press Ctrl+C


### PR DESCRIPTION
A new golang 1.6.3 is available especially for a security fix.