### PR TITLE
fleetctl: fix error message when fleetctl ssh fails

### DIFF
--- a/fleetctl/ssh.go
+++ b/fleetctl/ssh.go
@@ -235,7 +235,7 @@ func runCommand(cCmd *cobra.Command, machID string, cmd string, args ...string) 
 			addr := findSSHPort(cCmd, ms.PublicIP)
 			err, retcode = runRemoteCommand(cCmd, addr, cmd, args...)
 			if err != nil {
-				stderr("Error running remote command: %v", err)
+				stderr("Unable to SSH to remote host: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
Error message of fleetctl ssh should be ``"Unable to SSH to remote host"``.

Fixes https://github.com/coreos/fleet/issues/995