### PR TITLE
fleetctl: print out friendly error message from fleetctl list-machines

### DIFF
--- a/fleetctl/list_machines.go
+++ b/fleetctl/list_machines.go
@@ -89,7 +89,10 @@ func runListMachines(cCmd *cobra.Command, args []string) (exit int) {
 
 	machines, err := cAPI.Machines()
 	if err != nil {
-		stderr("Error retrieving list of active machines: %v", err)
+		stderr("Error retrieving list of active machines from fleet API (%v)", err)
+		stderr("Possible issues:")
+		stderr("  etcd is unhealthy and/or lost quorum")
+		stderr("  connection cannot be established to any etcd servers")
 		return 1
 	}
 


### PR DESCRIPTION
Print out friendly error message when ``fleetctl list-machines`` fails. Indicate that the API isn't working correctly instead of being unavailable. Also mention the most likely culprit, which is something to do with etcd.

Note that I didn't remove the prefix ``"googleapi:"`` as suggested by the original issue, because the prefix doesn't come from fleet, but from the google API itself.

Suggested by @robszumski
Fixes https://github.com/coreos/fleet/issues/1203