### PR TITLE
agent: improve warning message in case of error after TriggerStop

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -100,7 +100,7 @@ func (a *Agent) unloadUnit(unitName string) {
 
 	errStop := a.um.TriggerStop(unitName)
 	if errStop != nil {
-		log.Warningf("Failed stopping unit(%s): %v", unitName, errStop)
+		log.Warningf("TriggerStop on systemd unit %s returned: %v", unitName, errStop)
 	} else {
 		log.Infof("Stopped unit(%s)", unitName)
 	}


### PR DESCRIPTION
Improve warning message from `TriggerStop()` in case of error, because it's just a trigger, not the actual stopping.

Suggested by @jonboulle