### PR TITLE
fleetd: process dependencies in [Install] section

### DIFF
--- a/functional/fixtures/units/discovery.service
+++ b/functional/fixtures/units/discovery.service
@@ -1,0 +1,11 @@
+[Unit]
+BindsTo=hello.service
+
+[Service]
+ExecStart=/bin/bash -c "while true; do echo discovery.service unit file; sleep 1; done"
+
+[Install]
+WantedBy=hello.service
+
+[X-Fleet]
+MachineOf=hello.service

--- a/functional/install_test.go
+++ b/functional/install_test.go
@@ -1,0 +1,89 @@
+// Copyright 2016 The fleet Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functional
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/coreos/fleet/functional/platform"
+	"github.com/coreos/fleet/functional/util"
+)
+
+// Load service and discovery units and test whether discovery unit adds itself as a dependency for the service.
+func TestInstallUnit(t *testing.T) {
+	cluster, err := platform.NewNspawnCluster("smoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cluster.Destroy(t)
+
+	// Start with a two-nodes cluster
+	members, err := platform.CreateNClusterMembers(cluster, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m0 := members[0]
+	_, err = cluster.WaitForNMachines(m0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Load unit files
+	stdout, stderr, err := cluster.Fleetctl(m0, "load", "fixtures/units/hello.service", "fixtures/units/discovery.service")
+	if err != nil {
+		t.Fatalf("Failed loading unit files: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
+	}
+
+	checkState := func(match string) bool {
+		stdout, _, err := cluster.Fleetctl(m0, "--strict-host-key-checking=false", "ssh", "discovery.service", "systemctl show --property=ActiveState discovery.service")
+		if err != nil {
+			t.Logf("Failed getting info using remote systemctl: %v", err)
+		}
+		stdout = strings.TrimSpace(stdout)
+		return stdout == fmt.Sprintf("ActiveState=%s", match)
+	}
+
+	// Verify that discovery.service unit is loaded but not started
+	timeout, err := util.WaitForState(func() bool { return checkState("inactive") })
+	if err != nil {
+		t.Fatalf("discovery.service unit is not reported as inactive within %v: %v", timeout, err)
+	}
+
+	// Start hello.service unit
+	stdout, stderr, err = cluster.Fleetctl(m0, "start", "fixtures/units/hello.service")
+	if err != nil {
+		t.Fatalf("Failed starting unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
+	}
+
+	// Verify that discovery.service unit was started
+	timeout, err = util.WaitForState(func() bool { return checkState("active") })
+	if err != nil {
+		t.Fatalf("discovery.service unit is not reported as active within %v:\n%v", timeout, err)
+	}
+
+	// Stop hello.service unit
+	stdout, stderr, err = cluster.Fleetctl(m0, "stop", "fixtures/units/hello.service")
+	if err != nil {
+		t.Fatalf("Failed stopping unit: \nstdout: %s\nstderr: %s\nerr: %v", stdout, stderr, err)
+	}
+
+	// Verify that discovery.service unit was stopped
+	timeout, err = util.WaitForState(func() bool { return checkState("inactive") })
+	if err != nil {
+		t.Fatalf("discovery.service unit is not reported as inactive within %v:\n%v", timeout, err)
+	}
+}

--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -108,6 +108,14 @@ func (m *systemdUnitManager) Load(name string, u unit.UnitFile) error {
 	if err != nil {
 		return err
 	}
+	if _, exists := u.Contents["Install"]; exists {
+		log.Debugf("Detected [Install] section in the systemd unit (%s)", name)
+		ok, err := m.enableUnit(name)
+		if err != nil || !ok {
+			m.removeUnit(name)
+			return fmt.Errorf("Failed to enable systemd unit %s: %v", name, err)
+		}
+	}
 	m.hashes[name] = u.Hash()
 	return nil
 }
@@ -267,6 +275,15 @@ func (m *systemdUnitManager) writeUnit(name string, contents string) error {
 
 	_, err = m.systemd.LinkUnitFiles([]string{ufPath}, true, true)
 	return err
+}
+
+func (m *systemdUnitManager) enableUnit(name string) (bool, error) {
+	log.Infof("Enabling systemd unit %s", name)
+
+	ufPath := m.getUnitFilePath(name)
+
+	ok, _, err := m.systemd.EnableUnitFiles([]string{ufPath}, true, true)
+	return ok, err
 }
 
 func (m *systemdUnitManager) removeUnit(name string) (err error) {


### PR DESCRIPTION
Introduce a section `[Install]` in unit files, to allow `WantedBy` in the section to be able to enable the dependent units.
This PR is just a rebased version of https://github.com/coreos/fleet/pull/1523, except for minor changes to fix build errors.

Resolves https://github.com/coreos/fleet/issues/1382
Supersedes https://github.com/coreos/fleet/pull/1523

/cc @kayrus 
