### PR TITLE
functional: run tests with enable_grpc turned both on and off

### DIFF
--- a/build-env
+++ b/build-env
@@ -23,3 +23,4 @@ eval $(go env)
 export PATH="${GOROOT}/bin:${PATH}"
 export FLEETD_BIN="${CDIR}/bin/fleetd"
 export FLEETCTL_BIN="${CDIR}/bin/fleetctl"
+export FLEETD_TEST_ENV="enable_grpc=false"

--- a/functional/test
+++ b/functional/test
@@ -74,16 +74,19 @@ if [ ! -x "bin/fleetd" ] || \
   ./build
 fi
 
-go test github.com/coreos/fleet/functional -ldflags "${GLDFLAGS}" -v "$@" 2>&1 | tee functional/functional-tests.log
+#go test github.com/coreos/fleet/functional -ldflags "${GLDFLAGS}" -v "$@" 2>&1 | tee functional/functional-tests.log
+
+# Phase 1: run tests with gRPC disabled
+export FLEETD_TEST_ENV="enable_grpc=false"
+go test github.com/coreos/fleet/functional -ldflags "${GLDFLAGS}" -v "$@" 2>&1 | sed -u -r "s/^(---\s+(:?PASS|SKIP|FAIL):\s+Test[^\(]*)/\\1(fleet.conf=\[$FLEETD_TEST_ENV\]) /g;s/^(=== RUN\s+Test.*)/\1 (fleet.conf=\[$FLEETD_TEST_ENV\])/g" | tee -a functional/functional-tests.log
+
 TESTS_RETURN_CODE_1=${PIPESTATUS[0]}
 
-# Run tests with cache enable on fleetd side
-# NOTE: this test with unit state cache doesn't need to run, as unit state
-# cache is going to be obsolete. But in the future, we could set $FLEETD_TEST_ENV
-# to an env variable to run another round of tests, if necessary. - 20160518 dpark
-#export FLEETD_TEST_ENV="enable_unitstate_cache=true"
-#go test github.com/coreos/fleet/functional -ldflags "${GLDFLAGS}" -v "$@" 2>&1 | sed -r "s/^(---\s+(:?PASS|SKIP|FAIL):\s+Test[^\(]*)/\\1(fleet.conf=\[$FLEETD_TEST_ENV\]) /g;s/^(=== RUN\s+Test.*)/\1 (fleet.conf=\[$FLEETD_TEST_ENV\])/g" | tee -a functional/functional-tests.log
-#TESTS_RETURN_CODE_2=${PIPESTATUS[0]}
-TESTS_RETURN_CODE_2=0
+# Phase 2: run tests with gRPC enabled
+export FLEETD_TEST_ENV="enable_grpc=true"
+go test github.com/coreos/fleet/functional -ldflags "${GLDFLAGS}" -v "$@" 2>&1 | sed -u -r "s/^(---\s+(:?PASS|SKIP|FAIL):\s+Test[^\(]*)/\\1(fleet.conf=\[$FLEETD_TEST_ENV\]) /g;s/^(=== RUN\s+Test.*)/\1 (fleet.conf=\[$FLEETD_TEST_ENV\])/g" | tee -a functional/functional-tests.log
+
+TESTS_RETURN_CODE_2=${PIPESTATUS[0]}
+#TESTS_RETURN_CODE_2=0
 
 print_results


### PR DESCRIPTION
As gRPC is being used, we need to run functional tests once with `enable_grpc` turned off, and again with `enable_grpc` turned on.

WIP: this PR must be merged after #1426 got merged.