### PR TITLE
functional: clean up obsolete commands that are commented out

### DIFF
--- a/functional/test
+++ b/functional/test
@@ -74,8 +74,6 @@ if [ ! -x "bin/fleetd" ] || \
   ./build
 fi
 
-#go test github.com/coreos/fleet/functional -ldflags "${GLDFLAGS}" -v "$@" 2>&1 | tee functional/functional-tests.log
-
 # Phase 1: run tests with gRPC disabled
 export FLEETD_TEST_ENV="enable_grpc=false"
 go test github.com/coreos/fleet/functional -ldflags "${GLDFLAGS}" -v "$@" 2>&1 | sed -u -r "s/^(---\s+(:?PASS|SKIP|FAIL):\s+Test[^\(]*)/\\1(fleet.conf=\[$FLEETD_TEST_ENV\]) /g;s/^(=== RUN\s+Test.*)/\1 (fleet.conf=\[$FLEETD_TEST_ENV\])/g" | tee -a functional/functional-tests.log
@@ -87,6 +85,5 @@ export FLEETD_TEST_ENV="enable_grpc=true"
 go test github.com/coreos/fleet/functional -ldflags "${GLDFLAGS}" -v "$@" 2>&1 | sed -u -r "s/^(---\s+(:?PASS|SKIP|FAIL):\s+Test[^\(]*)/\\1(fleet.conf=\[$FLEETD_TEST_ENV\]) /g;s/^(=== RUN\s+Test.*)/\1 (fleet.conf=\[$FLEETD_TEST_ENV\])/g" | tee -a functional/functional-tests.log
 
 TESTS_RETURN_CODE_2=${PIPESTATUS[0]}
-#TESTS_RETURN_CODE_2=0
 
 print_results


### PR DESCRIPTION
Just a cleanup for removing obsolete commands that have been already commented out.

Suggested by @jonboulle