### PR TITLE
travis,functional: add go 1.7 and exclude ./gopath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ matrix:
     - go: 1.5.4
       env: GO15VENDOREXPERIMENT=1
     - go: 1.6.3
+    - go: 1.7
     - go: tip
   allow_failures:
     - go: tip

--- a/functional/provision/install_go.sh
+++ b/functional/provision/install_go.sh
@@ -6,7 +6,7 @@ HOME=$(getent passwd "${USER_ID}" | cut -d: -f6)
 export GOROOT=${HOME}/go
 export PATH=${HOME}/go/bin:${PATH}
 
-gover=1.6.3
+gover=1.7
 gotar=go${gover}.linux-amd64.tar.gz
 if [ ! -f ${HOME}/${gotar} ]; then
   # Remove unfinished archive when you press Ctrl+C

--- a/test
+++ b/test
@@ -57,7 +57,7 @@ if [ -n "${vetRes}" ]; then
 fi
 
 echo "Checking for license header..."
-licRes=$(for file in $(find . -type f -iname '*.go' ! -path './vendor/*'); do
+licRes=$(for file in $(find . -type f -iname '*.go' ! -path './vendor/*' ! -path './gopath/*' ); do
 		head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)" || echo -e "  ${file}"
 	done;)
 if [ -n "${licRes}" ]; then


### PR DESCRIPTION
First, for travis, add go 1.7 to the list of required go compiler versions. Now that go 1.7 was released, the list of required go compiler versions should also include go 1.7.
Also in functional tests, install go 1.7 instead of 1.6.3.

And also exclude `./gopath` also from the list for checking license headers.