### PR TITLE
fleetctl: introduce an option --max-print-units

### DIFF
--- a/fleetctl/destroy.go
+++ b/fleetctl/destroy.go
@@ -40,6 +40,7 @@ func init() {
 
 	cmdDestroy.Flags().IntVar(&sharedFlags.BlockAttempts, "block-attempts", 0, "Wait until the units are destroyed, performing up to N attempts before giving up. A value of 0 indicates no limit. Does not apply to global units.")
 	cmdDestroy.Flags().BoolVar(&sharedFlags.NoBlock, "no-block", false, "Do not wait until the units are destroyed before exiting. Always the case for global units.")
+	cmdDestroy.Flags().IntVar(&sharedFlags.MaxPrintUnits, "max-print-units", 0, "Set maximum number of units to be printed")
 }
 
 func runDestroyUnit(cCmd *cobra.Command, args []string) (exit int) {
@@ -59,6 +60,7 @@ func runDestroyUnit(cCmd *cobra.Command, args []string) (exit int) {
 		return 0
 	}
 
+	allUnits := make([]string, 0)
 	for _, v := range units {
 		err := cAPI.DestroyUnit(v.Name)
 		if err != nil {
@@ -98,8 +100,13 @@ func runDestroyUnit(cCmd *cobra.Command, args []string) (exit int) {
 				time.Sleep(defaultSleepTime)
 			}
 		}
-
-		stdout("Destroyed %s", v.Name)
+		allUnits = append(allUnits, v.Name)
 	}
+
+	oUnits := omitUnits(allUnits, sharedFlags.MaxPrintUnits)
+	for _, u := range oUnits {
+		stdout("Destroyed %s", u)
+	}
+
 	return
 }

--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -110,6 +110,7 @@ var (
 		BlockAttempts int
 		Fields        string
 		SSHPort       int
+		MaxPrintUnits int
 	}{}
 
 	// current command being executed
@@ -1205,4 +1206,18 @@ func runWrapper(cf func(cCmd *cobra.Command, args []string) (exit int)) func(cCm
 		cAPI = getClientAPI(cCmd)
 		cmdExitCode = cf(cCmd, args)
 	}
+}
+
+// omitUnits cuts out from a unit slice starting form its maxUnits-th entry,
+// only when the size of input slice exceeds the max number of units.
+func omitUnits(units []string, maxUnits int) []string {
+	if maxUnits == 0 {
+		return units
+	}
+
+	if len(units) > maxUnits {
+		return units[0:maxUnits]
+	}
+
+	return units
 }

--- a/fleetctl/list_unit_files.go
+++ b/fleetctl/list_unit_files.go
@@ -101,6 +101,7 @@ func init() {
 	cmdListUnitFiles.Flags().BoolVar(&sharedFlags.Full, "full", false, "Do not ellipsize fields on output")
 	cmdListUnitFiles.Flags().BoolVar(&sharedFlags.NoLegend, "no-legend", false, "Do not print a legend (column headers)")
 	cmdListUnitFiles.Flags().StringVar(&listUnitFilesFieldsFlag, "fields", defaultListUnitFilesFields, fmt.Sprintf("Columns to print for each Unit file. Valid fields are %q", strings.Join(unitToFieldKeys(listUnitFilesFields), ",")))
+	cmdListUnitFiles.Flags().IntVar(&sharedFlags.MaxPrintUnits, "max-print-units", 0, "Set maximum number of units to be printed")
 }
 
 func runListUnitFiles(cCmd *cobra.Command, args []string) (exit int) {
@@ -132,10 +133,15 @@ func runListUnitFiles(cCmd *cobra.Command, args []string) (exit int) {
 	}
 
 	full, _ := cCmd.Flags().GetBool("full")
-	for _, u := range units {
+	maxUnits := sharedFlags.MaxPrintUnits
+	for i, u := range units {
 		var f []string
 		for _, c := range cols {
 			f = append(f, listUnitFilesFields[c](*u, full))
+		}
+		if maxUnits > 0 && i >= maxUnits {
+			stderr("Further units after %d-th are omitted", maxUnits)
+			break
 		}
 		fmt.Fprintln(out, strings.Join(f, "\t"))
 	}

--- a/fleetctl/list_units.go
+++ b/fleetctl/list_units.go
@@ -103,6 +103,7 @@ func init() {
 	cmdListUnits.Flags().BoolVar(&sharedFlags.Full, "l", false, "Shorthand for --full")
 	cmdListUnits.Flags().BoolVar(&sharedFlags.NoLegend, "no-legend", false, "Do not print a legend (column headers)")
 	cmdListUnits.Flags().StringVar(&listUnitsFieldsFlag, "fields", defaultListUnitsFields, fmt.Sprintf("Columns to print for each Unit. Valid fields are %q", strings.Join(usToFieldKeys(listUnitsFields), ",")))
+	cmdListUnits.Flags().IntVar(&sharedFlags.MaxPrintUnits, "max-print-units", 0, "Set maximum number of units to be printed")
 }
 
 func runListUnits(cCmd *cobra.Command, args []string) (exit int) {
@@ -131,10 +132,15 @@ func runListUnits(cCmd *cobra.Command, args []string) (exit int) {
 	}
 
 	full, _ := cCmd.Flags().GetBool("full")
-	for _, us := range states {
+	maxUnits := sharedFlags.MaxPrintUnits
+	for i, us := range states {
 		var f []string
 		for _, c := range cols {
 			f = append(f, listUnitsFields[c](us, full))
+		}
+		if maxUnits > 0 && i >= maxUnits {
+			stderr("Further units after %d-th are omitted", maxUnits)
+			break
 		}
 		fmt.Fprintln(out, strings.Join(f, "\t"))
 	}

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -52,6 +52,7 @@ func init() {
 
 	cmdStop.Flags().IntVar(&sharedFlags.BlockAttempts, "block-attempts", 0, "Wait until the units are stopped, performing up to N attempts before giving up. A value of 0 indicates no limit. Does not apply to global units.")
 	cmdStop.Flags().BoolVar(&sharedFlags.NoBlock, "no-block", false, "Do not wait until the units have stopped before exiting. Always the case for global units.")
+	cmdStop.Flags().IntVar(&sharedFlags.MaxPrintUnits, "max-print-units", 0, "Set maximum number of units to be printed")
 }
 
 func runStopUnit(cCmd *cobra.Command, args []string) (exit int) {
@@ -94,9 +95,9 @@ func runStopUnit(cCmd *cobra.Command, args []string) (exit int) {
 
 	exit = tryWaitForUnitStates(stopping, "stop", job.JobStateLoaded, getBlockAttempts(cCmd), os.Stdout)
 	if exit == 0 {
-		stderr("Successfully stopped units %v.", stopping)
+		stderr("Successfully stopped units %v.", omitUnits(stopping, sharedFlags.MaxPrintUnits))
 	} else {
-		stderr("Failed to stop units %v. exit == %d.", stopping, exit)
+		stderr("Failed to stop units %v. exit == %d.", omitUnits(stopping, sharedFlags.MaxPrintUnits), exit)
 	}
 
 	return

--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -34,6 +34,7 @@ func init() {
 
 	cmdUnload.Flags().IntVar(&sharedFlags.BlockAttempts, "block-attempts", 0, "Wait until the units are inactive, performing up to N attempts before giving up. A value of 0 indicates no limit.")
 	cmdUnload.Flags().BoolVar(&sharedFlags.NoBlock, "no-block", false, "Do not wait until the units have become inactive before exiting.")
+	cmdUnload.Flags().IntVar(&sharedFlags.MaxPrintUnits, "max-print-units", 0, "Set maximum number of units to be printed")
 }
 
 func runUnloadUnit(cCmd *cobra.Command, args []string) (exit int) {
@@ -73,9 +74,9 @@ func runUnloadUnit(cCmd *cobra.Command, args []string) (exit int) {
 
 	exit = tryWaitForUnitStates(wait, "unload", job.JobStateInactive, getBlockAttempts(cCmd), os.Stdout)
 	if exit == 0 {
-		stderr("Successfully unloaded units %v.", wait)
+		stderr("Successfully unloaded units %v.", omitUnits(wait, sharedFlags.MaxPrintUnits))
 	} else {
-		stderr("Failed to unload units %v. exit == %d.", wait, exit)
+		stderr("Failed to unload units %v. exit == %d.", omitUnits(wait, sharedFlags.MaxPrintUnits), exit)
 	}
 
 	return

--- a/functional/platform/cluster.go
+++ b/functional/platform/cluster.go
@@ -38,9 +38,9 @@ type Cluster interface {
 	Fleetctl(m Member, args ...string) (string, string, error)
 	FleetctlWithInput(m Member, input string, args ...string) (string, string, error)
 	FleetctlWithEnv(m Member, args ...string) (string, string, error)
-	WaitForNUnits(Member, int) (map[string][]util.UnitState, error)
-	WaitForNActiveUnits(Member, int) (map[string][]util.UnitState, error)
-	WaitForNUnitFiles(Member, int) (map[string][]util.UnitFileState, error)
+	WaitForNUnits(Member, int, ...string) (map[string][]util.UnitState, error)
+	WaitForNActiveUnits(Member, int, ...string) (map[string][]util.UnitState, error)
+	WaitForNUnitFiles(Member, int, ...string) (map[string][]util.UnitFileState, error)
 	WaitForNMachines(Member, int) ([]string, error)
 }
 

--- a/functional/platform/nspawn.go
+++ b/functional/platform/nspawn.go
@@ -143,11 +143,13 @@ func (nc *nspawnCluster) FleetctlWithEnv(m Member, args ...string) (string, stri
 // WaitForNUnits runs fleetctl list-units to verify the actual number of units
 // matched with the given expected number. It periodically runs list-units
 // waiting until list-units actually shows the expected units.
-func (nc *nspawnCluster) WaitForNUnits(m Member, expectedUnits int) (map[string][]util.UnitState, error) {
+func (nc *nspawnCluster) WaitForNUnits(m Member, expectedUnits int, opts ...string) (map[string][]util.UnitState, error) {
 	var nUnits int
 	retStates := make(map[string][]util.UnitState)
 	checkListUnits := func() bool {
-		outListUnits, _, err := nc.Fleetctl(m, "list-units", "--no-legend", "--full", "--fields", "unit,active,machine")
+		outListUnits, _, err := nc.Fleetctl(m,
+			"list-units", "--no-legend", "--full", "--fields", "unit,active,machine",
+			strings.Join(opts, " "))
 		if err != nil {
 			return false
 		}
@@ -181,13 +183,15 @@ func (nc *nspawnCluster) WaitForNUnits(m Member, expectedUnits int) (map[string]
 	return retStates, nil
 }
 
-func (nc *nspawnCluster) WaitForNActiveUnits(m Member, count int) (map[string][]util.UnitState, error) {
+func (nc *nspawnCluster) WaitForNActiveUnits(m Member, count int, opts ...string) (map[string][]util.UnitState, error) {
 	var nactive int
 	states := make(map[string][]util.UnitState)
 
 	timeout, err := util.WaitForState(
 		func() bool {
-			stdout, _, err := nc.Fleetctl(m, "list-units", "--no-legend", "--full", "--fields", "unit,active,machine")
+			stdout, _, err := nc.Fleetctl(m,
+				"list-units", "--no-legend", "--full", "--fields", "unit,active,machine",
+				strings.Join(opts, " "))
 			stdout = strings.TrimSpace(stdout)
 			if err != nil {
 				return false
@@ -221,12 +225,14 @@ func (nc *nspawnCluster) WaitForNActiveUnits(m Member, count int) (map[string][]
 // WaitForNUnitFiles runs fleetctl list-unit-files to verify the actual number of units
 // matched with the given expected number. It periodically runs list-unit-files
 // waiting until list-unit-files actually shows the expected units.
-func (nc *nspawnCluster) WaitForNUnitFiles(m Member, expectedUnits int) (map[string][]util.UnitFileState, error) {
+func (nc *nspawnCluster) WaitForNUnitFiles(m Member, expectedUnits int, opts ...string) (map[string][]util.UnitFileState, error) {
 	var nUnits int
 	retStates := make(map[string][]util.UnitFileState)
 
 	checkListUnitFiles := func() bool {
-		outListUnitFiles, _, err := nc.Fleetctl(m, "list-unit-files", "--no-legend", "--full", "--fields", "unit,dstate,state")
+		outListUnitFiles, _, err := nc.Fleetctl(m,
+			"list-unit-files", "--no-legend", "--full", "--fields", "unit,dstate,state",
+			strings.Join(opts, " "))
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
For users who want to limit number of units to be printed, introduce an option `"--max-print-units"` for these commands: destroy, unload, stop, list-unit-files, and list-units.

Note that the default value of `--max-print-units` should be 0, which means `"all units are printed"`, so that the default behavior should remain as before.

Fixes https://github.com/coreos/fleet/issues/1593

/cc @kayrus 