### PR TITLE
fleetctl: check systemd active state via client API

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -960,23 +960,23 @@ func getBlockAttempts(cCmd *cobra.Command) int {
 // wait, it will assume that all units reached their desired state.
 // If maxAttempts is zero tryWaitForUnitStates will retry forever, and
 // if it is greater than zero, it will retry up to the indicated value.
-// It returns 0 on success or 1 on errors.
-func tryWaitForUnitStates(units []string, state string, js job.JobState, maxAttempts int, out io.Writer) (ret int) {
+// It returns nil on success or error on failure.
+func tryWaitForUnitStates(units []string, state string, js job.JobState, maxAttempts int, out io.Writer) error {
 	// We do not wait just assume we reached the desired state
 	if maxAttempts <= -1 {
 		for _, name := range units {
 			stdout("Triggered unit %s %s", name, state)
 		}
-		return
+		return nil
 	}
 
 	errchan := waitForUnitStates(units, js, maxAttempts, out)
 	for err := range errchan {
 		stderr("Error waiting for units: %v", err)
-		ret = 1
+		return err
 	}
 
-	return
+	return nil
 }
 
 // waitForUnitStates polls each of the indicated units until each of their

--- a/fleetctl/load.go
+++ b/fleetctl/load.go
@@ -73,9 +73,9 @@ func runLoadUnit(cCmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	exitVal := tryWaitForUnitStates(loading, "load", job.JobStateLoaded, getBlockAttempts(cCmd), os.Stdout)
-	if exitVal != 0 {
-		stderr("Error waiting for unit states, exit status: %d", exitVal)
+	err = tryWaitForUnitStates(loading, "load", job.JobStateLoaded, getBlockAttempts(cCmd), os.Stdout)
+	if err != nil {
+		stderr("Error waiting for unit states, exit status: %v", err)
 		return 1
 	}
 

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -87,9 +87,9 @@ func runStartUnit(cCmd *cobra.Command, args []string) (exit int) {
 		return exitVal
 	}
 
-	exitVal = tryWaitForSystemdActiveState(starting)
-	if exitVal != 0 {
-		return exitVal
+	if err := tryWaitForSystemdActiveState(starting, getBlockAttempts(cCmd)); err != nil {
+		stderr("Error waiting for systemd unit states, err: %v", err)
+		return 1
 	}
 
 	return 0

--- a/fleetctl/start.go
+++ b/fleetctl/start.go
@@ -81,10 +81,9 @@ func runStartUnit(cCmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	exitVal := tryWaitForUnitStates(starting, "start", job.JobStateLaunched, getBlockAttempts(cCmd), os.Stdout)
-	if exitVal != 0 {
-		stderr("Error waiting for unit states, exit status: %d", exitVal)
-		return exitVal
+	if err := tryWaitForUnitStates(starting, "start", job.JobStateLaunched, getBlockAttempts(cCmd), os.Stdout); err != nil {
+		stderr("Error waiting for unit states, exit status: %v", err)
+		return 1
 	}
 
 	if err := tryWaitForSystemdActiveState(starting, getBlockAttempts(cCmd)); err != nil {

--- a/fleetctl/stop.go
+++ b/fleetctl/stop.go
@@ -92,12 +92,12 @@ func runStopUnit(cCmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	exit = tryWaitForUnitStates(stopping, "stop", job.JobStateLoaded, getBlockAttempts(cCmd), os.Stdout)
-	if exit == 0 {
-		stderr("Successfully stopped units %v.", stopping)
-	} else {
-		stderr("Failed to stop units %v. exit == %d.", stopping, exit)
+	err = tryWaitForUnitStates(stopping, "stop", job.JobStateLoaded, getBlockAttempts(cCmd), os.Stdout)
+	if err != nil {
+		stderr("Failed to stop units %v. err: %v", stopping, err)
+		return 1
 	}
 
-	return
+	stderr("Successfully stopped units %v.", stopping)
+	return 0
 }

--- a/fleetctl/unload.go
+++ b/fleetctl/unload.go
@@ -71,12 +71,12 @@ func runUnloadUnit(cCmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	exit = tryWaitForUnitStates(wait, "unload", job.JobStateInactive, getBlockAttempts(cCmd), os.Stdout)
-	if exit == 0 {
-		stderr("Successfully unloaded units %v.", wait)
-	} else {
-		stderr("Failed to unload units %v. exit == %d.", wait, exit)
+	err = tryWaitForUnitStates(wait, "unload", job.JobStateInactive, getBlockAttempts(cCmd), os.Stdout)
+	if err != nil {
+		stderr("Failed to unload units %v. err: %v", wait, err)
+		return 1
 	}
 
-	return
+	stderr("Successfully unloaded units %v.", wait)
+	return 0
 }


### PR DESCRIPTION
It's not appropriate to check systemd active states with DBUS connection, as that will return correct states only on the same machine. So we should also introduce a check using `cAPI.UnitStates()`, to check states on other machines.