### PR TITLE
api: support cAPI.UnitState() for a single unit

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -24,6 +24,7 @@ type API interface {
 
 	Unit(string) (*schema.Unit, error)
 	Units() ([]*schema.Unit, error)
+	UnitState(string) (*schema.UnitState, error)
 	UnitStates() ([]*schema.UnitState, error)
 
 	SetUnitTargetState(name, target string) error

--- a/client/http.go
+++ b/client/http.go
@@ -117,6 +117,14 @@ func (c *HTTPClient) UnitStates() ([]*schema.UnitState, error) {
 	return states, nil
 }
 
+func (c *HTTPClient) UnitState(name string) (*schema.UnitState, error) {
+	u, err := c.svc.UnitState.Get(name).Do()
+	if err != nil && !is404(err) {
+		return nil, err
+	}
+	return u, nil
+}
+
 func (c *HTTPClient) DestroyUnit(name string) error {
 	return c.svc.Units.Delete(name).Do()
 }

--- a/client/registry.go
+++ b/client/registry.go
@@ -86,6 +86,15 @@ func (rc *RegistryClient) CreateUnit(u *schema.Unit) error {
 	return rc.Registry.CreateUnit(&rUnit)
 }
 
+func (rc *RegistryClient) UnitState(name string) (*schema.UnitState, error) {
+	rUnitState, err := rc.Registry.UnitState(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return schema.MapUnitStateToSchemaUnitState(rUnitState), nil
+}
+
 func (rc *RegistryClient) UnitStates() ([]*schema.UnitState, error) {
 	rUnitStates, err := rc.Registry.UnitStates()
 	if err != nil {

--- a/protobuf/fleet.pb.go
+++ b/protobuf/fleet.pb.go
@@ -1592,6 +1592,7 @@ type RegistryClient interface {
 	GetUnit(ctx context.Context, in *UnitName, opts ...grpc.CallOption) (*MaybeUnit, error)
 	GetUnits(ctx context.Context, in *UnitFilter, opts ...grpc.CallOption) (*Units, error)
 	// global status <= pretty much like list-unit-files
+	GetUnitState(ctx context.Context, in *UnitName, opts ...grpc.CallOption) (*UnitState, error)
 	GetUnitStates(ctx context.Context, in *UnitStateFilter, opts ...grpc.CallOption) (*UnitStates, error)
 	ClearUnitHeartbeat(ctx context.Context, in *UnitName, opts ...grpc.CallOption) (*GenericReply, error)
 	CreateUnit(ctx context.Context, in *Unit, opts ...grpc.CallOption) (*GenericReply, error)
@@ -1646,6 +1647,15 @@ func (c *registryClient) GetUnit(ctx context.Context, in *UnitName, opts ...grpc
 func (c *registryClient) GetUnits(ctx context.Context, in *UnitFilter, opts ...grpc.CallOption) (*Units, error) {
 	out := new(Units)
 	err := grpc.Invoke(ctx, "/rpc.Registry/GetUnits", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *registryClient) GetUnitState(ctx context.Context, in *UnitName, opts ...grpc.CallOption) (*UnitState, error) {
+	out := new(UnitState)
+	err := grpc.Invoke(ctx, "/rpc.Registry/GetUnitState", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1794,6 +1804,7 @@ type RegistryServer interface {
 	GetUnit(context.Context, *UnitName) (*MaybeUnit, error)
 	GetUnits(context.Context, *UnitFilter) (*Units, error)
 	// global status <= pretty much like list-unit-files
+	GetUnitState(context.Context, *UnitName) (*UnitState, error)
 	GetUnitStates(context.Context, *UnitStateFilter) (*UnitStates, error)
 	ClearUnitHeartbeat(context.Context, *UnitName) (*GenericReply, error)
 	CreateUnit(context.Context, *Unit) (*GenericReply, error)
@@ -1856,6 +1867,18 @@ func _Registry_GetUnits_Handler(srv interface{}, ctx context.Context, dec func(i
 		return nil, err
 	}
 	out, err := srv.(RegistryServer).GetUnits(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func _Registry_GetUnitState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(UnitName)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(RegistryServer).GetUnitState(ctx, in)
 	if err != nil {
 		return nil, err
 	}
@@ -2034,6 +2057,10 @@ var _Registry_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetUnits",
 			Handler:    _Registry_GetUnits_Handler,
+		},
+		{
+			MethodName: "GetUnitState",
+			Handler:    _Registry_GetUnitState_Handler,
 		},
 		{
 			MethodName: "GetUnitStates",

--- a/protobuf/fleet.proto
+++ b/protobuf/fleet.proto
@@ -15,6 +15,7 @@ service Registry {
 	rpc GetUnit(UnitName) returns (MaybeUnit);
 	rpc GetUnits(UnitFilter) returns (Units); // => global status ?
 	// global status <= pretty much like list-unit-files
+	rpc GetUnitState(UnitName) returns (UnitState);
 	rpc GetUnitStates(UnitStateFilter) returns (UnitStates);
 	rpc ClearUnitHeartbeat(UnitName) returns (GenericReply);
 	rpc CreateUnit(Unit) returns (GenericReply);

--- a/registry/interface.go
+++ b/registry/interface.go
@@ -49,6 +49,7 @@ type UnitRegistry interface {
 	ScheduledUnit(name string) (*job.ScheduledUnit, error)
 	Unit(name string) (*job.Unit, error)
 	Units() ([]job.Unit, error)
+	UnitState(name string) (*unit.UnitState, error)
 	UnitStates() ([]*unit.UnitState, error)
 }
 

--- a/registry/rpc/registrymux.go
+++ b/registry/rpc/registrymux.go
@@ -314,6 +314,10 @@ func (r *RegistryMux) Units() ([]job.Unit, error) {
 	return r.getRegistry().Units()
 }
 
+func (r *RegistryMux) UnitState(name string) (*unit.UnitState, error) {
+	return r.getRegistry().UnitState(name)
+}
+
 func (r *RegistryMux) UnitStates() ([]*unit.UnitState, error) {
 	return r.getRegistry().UnitStates()
 }

--- a/registry/rpc/rpcregistry.go
+++ b/registry/rpc/rpcregistry.go
@@ -338,6 +338,26 @@ func (r *RPCRegistry) Units() ([]job.Unit, error) {
 	return jobUnits, nil
 }
 
+func (r *RPCRegistry) UnitState(unitName string) (*unit.UnitState, error) {
+	if DebugRPCRegistry {
+		defer debug.Exit_(debug.Enter_(unitName))
+	}
+
+	state, err := r.getClient().GetUnitState(r.ctx(), &pb.UnitName{unitName})
+	if err != nil {
+		return nil, err
+	}
+
+	return &unit.UnitState{
+		UnitName:    state.Name,
+		MachineID:   state.MachineID,
+		UnitHash:    state.Hash,
+		LoadState:   state.LoadState,
+		ActiveState: state.ActiveState,
+		SubState:    state.SubState,
+	}, nil
+}
+
 func (r *RPCRegistry) UnitStates() ([]*unit.UnitState, error) {
 	if DebugRPCRegistry {
 		defer debug.Exit_(debug.Enter_())

--- a/registry/rpc/rpcserver.go
+++ b/registry/rpc/rpcserver.go
@@ -195,6 +195,16 @@ func (s *rpcserver) GetUnits(ctx context.Context, filter *pb.UnitFilter) (*pb.Un
 	return &pb.Units{Units: units}, nil
 }
 
+func (s *rpcserver) GetUnitState(ctx context.Context, name *pb.UnitName) (*pb.UnitState, error) {
+	if debugRPCServer {
+		defer debug.Exit_(debug.Enter_(name.Name))
+	}
+
+	state := s.localRegistry.UnitState(name.Name)
+
+	return state, nil
+}
+
 func (s *rpcserver) GetUnitStates(ctx context.Context, filter *pb.UnitStateFilter) (*pb.UnitStates, error) {
 	if debugRPCServer {
 		defer debug.Exit_(debug.Enter_())

--- a/schema/v1-gen.go
+++ b/schema/v1-gen.go
@@ -236,6 +236,78 @@ func (c *MachinesListCall) Do() (*MachinePage, error) {
 
 }
 
+// method id "fleet.UnitState.Get":
+
+type UnitStateGetCall struct {
+	s        *Service
+	unitName string
+	opt_     map[string]interface{}
+}
+
+// Get: Retrieve a page of a single UnitState object.
+func (r *UnitStateService) Get(unitName string) *UnitStateGetCall {
+	c := &UnitStateGetCall{s: r.s, opt_: make(map[string]interface{})}
+	c.unitName = unitName
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *UnitStateGetCall) Fields(s ...googleapi.Field) *UnitStateGetCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *UnitStateGetCall) Do() (*UnitState, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "state/{unitName}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"unitName": c.unitName,
+	})
+	req.Header.Set("User-Agent", "google-api-go-client/0.5")
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *UnitState
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieve a page of a single UnitState object.",
+	//   "httpMethod": "GET",
+	//   "id": "fleet.UnitState.Get",
+	//   "parameterOrder": [
+	//     "unitName"
+	//   ],
+	//   "parameters": {
+	//     "unitName": {
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "state/{unitName}",
+	//   "response": {
+	//     "$ref": "UnitState"
+	//   }
+	// }
+
+}
+
 // method id "fleet.UnitState.List":
 
 type UnitStateListCall struct {

--- a/schema/v1-json.go
+++ b/schema/v1-json.go
@@ -276,6 +276,25 @@ const DiscoveryJSON = `{
     },
     "UnitState": {
       "methods": {
+        "Get": {
+          "id": "fleet.UnitState.Get",
+          "description": "Retrieve a page of a single UnitState object.",
+          "httpMethod": "GET",
+          "path": "state/{unitName}",
+          "parameters": {
+            "unitName": {
+              "type": "string",
+              "location": "path",
+              "required": true
+            }
+          },
+          "parameterOrder": [
+            "unitName"
+          ],
+          "response": {
+            "$ref": "UnitState"
+          }
+        },
         "List": {
           "id": "fleet.UnitState.List",
           "description": "Retrieve a page of UnitState objects.",

--- a/schema/v1.json
+++ b/schema/v1.json
@@ -255,6 +255,25 @@
     },
     "UnitState": {
       "methods": {
+        "Get": {
+          "id": "fleet.UnitState.Get",
+          "description": "Retrieve a page of a single UnitState object.",
+          "httpMethod": "GET",
+          "path": "state/{unitName}",
+          "parameters": {
+            "unitName": {
+              "type": "string",
+              "location": "path",
+              "required": true
+            }
+          },
+          "parameterOrder": [
+            "unitName"
+          ],
+          "response": {
+            "$ref": "UnitState"
+          }
+        },
         "List": {
           "id": "fleet.UnitState.List",
           "description": "Retrieve a page of UnitState objects.",


### PR DESCRIPTION
- api: support `GET` method for `stateResource`
- schema: introduce `Get` method for `UnitState`
- client: introduce `UnitState()` for API interface
- protobuf: define `GetUnitState()` for registryClient and registryServer
- registry: introduce `UnitState()` for `etcdRegistry` and `RPCRegistry`
- fleetctl: replace `cAPI.UnitStates()` with `.UnitState()`
- registry: add new unit tests for `GetUnitState()` and relevant ones
- fleetctl: periodically check for systemd states using `waitForState`
- fleetctl: make use of `waitForState` also in `assertUnitState()`

Fixes https://github.com/coreos/fleet/issues/1675
