### PR TITLE
fleetd,main: make github.com/coreos/fleet go-getable

### DIFF
--- a/build
+++ b/build
@@ -20,7 +20,7 @@ fi
 
 if [ ${GOOS} = "linux" ]; then
   echo "Building fleetd..."
-  CGO_ENABLED=0 go build -o bin/fleetd -a -installsuffix netgo -ldflags "${GLDFLAGS}" ${REPO_PATH}/fleetd
+  CGO_ENABLED=0 go build -o bin/fleetd -a -installsuffix netgo -ldflags "${GLDFLAGS}" ${REPO_PATH}
 else
   echo "Not on Linux - skipping fleetd build"
 fi

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package fleetd
 
 import (
 	"encoding/json"
@@ -39,7 +39,7 @@ const (
 	FleetdDescription = "fleetd is the server component of fleet, a simple orchestration system for scheduling systemd units in a cluster."
 )
 
-func main() {
+func Main() {
 	userset := flag.NewFlagSet("fleet", flag.ExitOnError)
 	printVersion := userset.Bool("version", false, "Print the version and exit")
 	cfgPath := userset.String("config", "", fmt.Sprintf("Path to config file. Fleet will look for a config at %s by default.", DefaultConfigFile))

--- a/main.go
+++ b/main.go
@@ -1,0 +1,29 @@
+// Copyright 2016 The fleet Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main is a simple wrapper of the real fleet entrypoint package
+// (located at github.com/coreos/fleet/fleetd) to ensure that fleet is still
+// "go getable"; e.g. `go get github.com/coreos/fleet` works as expected and
+// builds a binary in $GOBIN/fleetd
+//
+// This package should NOT be extended or modified in any way; to modify the
+// fleetd binary, work in the `github.com/coreos/fleet/fleetd` package.
+//
+package main
+
+import "github.com/coreos/fleet/fleetd"
+
+func main() {
+	fleetd.Main()
+}


### PR DESCRIPTION
So far it hasn't been possible to do `"go get github.com/coreos/fleet"` because there was no main.go in the top source directory. Create main.go, a simple wrapper for fleetd to make it _"go-getable"_.

This is a preparation for https://github.com/coreos/fleet/issues/1665, as `goaci` requires a go-getable package.