### PR TITLE
registry,fleetctl: fix bugs regarding shadowed error variables

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -833,18 +833,19 @@ func lazyCreateUnits(cCmd *cobra.Command, args []string) error {
 // Returns true if the contents of the file matches the unit one, false
 // otherwise; and any error encountered.
 func matchLocalFileAndUnit(file string, su *schema.Unit) (bool, error) {
-	result := false
 	a := schema.MapSchemaUnitOptionsToUnitFile(su.Options)
 
 	_, err := os.Stat(file)
-	if err == nil {
-		b, err := getUnitFromFile(file)
-		if err == nil {
-			result = unit.MatchUnitFiles(a, b)
-		}
+	if err != nil {
+		return false, err
 	}
 
-	return result, err
+	b, err := getUnitFromFile(file)
+	if err != nil {
+		return false, err
+	}
+
+	return unit.MatchUnitFiles(a, b), nil
 }
 
 // isLocalUnitDifferent compares a Unit on the file system with a one

--- a/registry/job.go
+++ b/registry/job.go
@@ -312,7 +312,7 @@ func (r *EtcdRegistry) DestroyUnit(name string) error {
 }
 
 // CreateUnit attempts to store a Unit and its associated unit file in the registry
-func (r *EtcdRegistry) CreateUnit(u *job.Unit) (err error) {
+func (r *EtcdRegistry) CreateUnit(u *job.Unit) error {
 	if err := r.storeOrGetUnitFile(u.Unit); err != nil {
 		return err
 	}
@@ -323,7 +323,7 @@ func (r *EtcdRegistry) CreateUnit(u *job.Unit) (err error) {
 	}
 	val, err := marshal(jm)
 	if err != nil {
-		return
+		return err
 	}
 
 	opts := &etcd.SetOptions{
@@ -335,7 +335,7 @@ func (r *EtcdRegistry) CreateUnit(u *job.Unit) (err error) {
 	key := r.prefixed(jobPrefix, u.Name, "object")
 	_, err = r.kAPI.Set(context.Background(), key, val, opts)
 	if err != nil {
-		return
+		return err
 	}
 
 	return r.SetUnitTargetState(u.Name, u.TargetState)


### PR DESCRIPTION
* registry: make `CreateUnit()` explicitly return error

: When `marshal()` returns a non-nil error `'err'`, which shadows the pre-defined `'err'`, we should explicitly return the second error returned from `marshal()`. Otherwise it will always return `nil`. To fix other potential errors, let's just return `err` explicitly. This was discovered by running "go tool vet":

```
$ go tool vet --shadow ./registry
registry/job.go:316: declaration of "err" shadows declaration at registry/job.go:315
```

* fleetctl: fix wrong error value from `matchLocalFileAndUnit()`

: In `matchLocalFileAndUnit()`, if `os.Stat()` returns nil and `getUnitFromFile()` returns non-nil error, then in the end `matchLocalFileAndUnit()` will return `(false, nil)`. That's not the expected result. It should have returned the second error that came from `getUnitFromFile()`. To avoid further potential bugs, let's follow the idiomatic coding style: first check "err != nil", and fail-fast. This issue was discovered by running "go tool vet".
