### PR TITLE
functional: introduce build tags all and dummytest

### DIFF
--- a/functional/client_test.go
+++ b/functional/client_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (

--- a/functional/cluster_test.go
+++ b/functional/cluster_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (

--- a/functional/connectivity-loss_test.go
+++ b/functional/connectivity-loss_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (

--- a/functional/dummy_test.go
+++ b/functional/dummy_test.go
@@ -1,0 +1,47 @@
+// Copyright 2016 The fleet Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build dummytest !all
+
+package functional
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/coreos/fleet/functional/platform"
+)
+
+// TestDummy sets up a functional test environment, but does nothing,
+// just waits forever.
+func TestDummy(t *testing.T) {
+	cluster, err := platform.NewNspawnCluster("smoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cluster.Destroy(t)
+
+	m, err := cluster.CreateMember()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = cluster.WaitForNMachines(m, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(math.MaxInt32 * time.Second)
+}

--- a/functional/fleetctl_test.go
+++ b/functional/fleetctl_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (

--- a/functional/metadata_test.go
+++ b/functional/metadata_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (

--- a/functional/node_test.go
+++ b/functional/node_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (

--- a/functional/scheduling_test.go
+++ b/functional/scheduling_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (

--- a/functional/server_test.go
+++ b/functional/server_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (

--- a/functional/shutdown_test.go
+++ b/functional/shutdown_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (

--- a/functional/systemd_test.go
+++ b/functional/systemd_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (

--- a/functional/test
+++ b/functional/test
@@ -74,15 +74,33 @@ if [ ! -x "bin/fleetd" ] || \
   ./build
 fi
 
+# Parameters to be passed to "go test" must contain either "--tags=all" for
+# normal tests, or "--tags=dummytest" for a dummy test that just sets up
+# test clusters, without running any tests. As "go test" does not accept
+# multiple "--tags" options, we need to parse the option to pass the option
+# only once.
+INPUT_PARAMS="$@"
+if [[ ${INPUT_PARAMS} =~ "-tags"[+([:space:])=]"dummy" ]]; then
+  TEST_PARAMS="-v ${INPUT_PARAMS}"
+else
+  INPUT_PARAMS="${INPUT_PARAMS##?(-)-tags[+([:space:])=]+([[:alnum:]])}"
+  INPUT_PARAMS="${INPUT_PARAMS%%?(-)-tags[+([:space:])=]+([[:alnum:]])}"
+  TEST_PARAMS="-v --tags=all ${INPUT_PARAMS}"
+fi
+
 # Phase 1: run tests with gRPC disabled
 export FLEETD_TEST_ENV="enable_grpc=false"
-go test github.com/coreos/fleet/functional -ldflags "${GLDFLAGS}" -v "$@" 2>&1 | sed -u -r "s/^(---\s+(:?PASS|SKIP|FAIL):\s+Test[^\(]*)/\\1(fleet.conf=\[$FLEETD_TEST_ENV\]) /g;s/^(=== RUN\s+Test.*)/\1 (fleet.conf=\[$FLEETD_TEST_ENV\])/g" | tee -a functional/functional-tests.log
+go test github.com/coreos/fleet/functional --ldflags "${GLDFLAGS}" ${TEST_PARAMS} 2>&1 | \
+  sed -u -r "s/^(---\s+(:?PASS|SKIP|FAIL):\s+Test[^\(]*)/\\1(fleet.conf=\[$FLEETD_TEST_ENV\]) /g;s/^(=== RUN\s+Test.*)/\1 (fleet.conf=\[$FLEETD_TEST_ENV\])/g" | \
+  tee -a functional/functional-tests.log
 
 TESTS_RETURN_CODE_1=${PIPESTATUS[0]}
 
 # Phase 2: run tests with gRPC enabled
 export FLEETD_TEST_ENV="enable_grpc=true"
-go test github.com/coreos/fleet/functional -ldflags "${GLDFLAGS}" -v "$@" 2>&1 | sed -u -r "s/^(---\s+(:?PASS|SKIP|FAIL):\s+Test[^\(]*)/\\1(fleet.conf=\[$FLEETD_TEST_ENV\]) /g;s/^(=== RUN\s+Test.*)/\1 (fleet.conf=\[$FLEETD_TEST_ENV\])/g" | tee -a functional/functional-tests.log
+go test github.com/coreos/fleet/functional --ldflags "${GLDFLAGS}" ${TEST_PARAMS} 2>&1 | \
+  sed -u -r "s/^(---\s+(:?PASS|SKIP|FAIL):\s+Test[^\(]*)/\\1(fleet.conf=\[$FLEETD_TEST_ENV\]) /g;s/^(=== RUN\s+Test.*)/\1 (fleet.conf=\[$FLEETD_TEST_ENV\])/g" | \
+  tee -a functional/functional-tests.log
 
 TESTS_RETURN_CODE_2=${PIPESTATUS[0]}
 

--- a/functional/tunnel_test.go
+++ b/functional/tunnel_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build all !dummytest
+
 package functional
 
 import (


### PR DESCRIPTION
For each source file for functional tests, define build tags, `"all"` and `"dummytest"`. Only one of the two tags must be enabled. Accordingly change functional/test script too.

Also define `TestDummy()` that only sets up test clusters, without running any tests. This test might be useful for manual debugging.