### PR TITLE
Documentation: fix a broken weblink to scripts/build-aci

### DIFF
--- a/Documentation/rkt_guide.md
+++ b/Documentation/rkt_guide.md
@@ -42,5 +42,5 @@ Restart=always
 RestartSec=10s
 ```
 
-[build-aci]: /build-aci
+[build-aci]: /scripts/build-aci
 [deployment-and-configuration]: deployment-and-configuration.md


### PR DESCRIPTION
Fix weblink to build-aci to
https://github.com/coreos/fleet/blob/master/scripts/build-aci.
This was a side-effect of moving the script to the scripts directory.