### PR TITLE
registry/rpc: re-enable error handling after NewSystemdUnitManage

### DIFF
--- a/ssh/known_hosts_test.go
+++ b/ssh/known_hosts_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"runtime"
 	"strconv"
 	"syscall"
 	"testing"
@@ -165,7 +166,13 @@ func TestWrongHostKeyFile(t *testing.T) {
 	// If run as root, drop privileges temporarily
 	if id := syscall.Geteuid(); id == 0 {
 		if err := syscall.Setuid(12345); err != nil {
-			t.Fatalf("error setting uid: %v", err)
+			if runtime.GOOS == "linux" {
+				// On Linux syscall.Setuid is not supported, so we should not fail
+				// the test, but just skip for now. - dpark 20161021
+				t.Skipf("error setting uid: %v", err)
+			} else {
+				t.Fatalf("error setting uid: %v", err)
+			}
 		}
 		defer syscall.Setuid(id)
 	}


### PR DESCRIPTION
Run `TestRegistryMuxUnitManagement()` only when user's euid is 0 and systemd is available at run-time. Such a distinction is necessary for avoiding test failures, especially when unit tests run on travis CI, where systemd is not available. With those checks, we can re-enable error handling after calling `systemd.NewSystemdUnitManager()`.

Besides fix also a hidden bug in `TestWrongHostKeyFile()` to skip the test on Linux if euid is 0. On Linux `syscall.Setuid()` is not supported in go. So running unit tests with root privileges fails when calling Setuid.