### PR TITLE
agent: allow HasConflict() to handle multiple values defined in Conflicts

### DIFF
--- a/agent/reconcile_test.go
+++ b/agent/reconcile_test.go
@@ -387,6 +387,30 @@ func TestAbleToRun(t *testing.T) {
 			want: job.JobActionUnschedule,
 		},
 
+		// conflicts found
+		{
+			dState: &AgentState{
+				MState: &machine.MachineState{ID: "123"},
+				Units: map[string]*job.Unit{
+					"ping.service": &job.Unit{Name: "ping.service"},
+				},
+			},
+			job:  newTestJobWithXFleetValues(t, "Conflicts=pong.service\nConflicts=ping.service"),
+			want: job.JobActionUnschedule,
+		},
+
+		// conflicts found
+		{
+			dState: &AgentState{
+				MState: &machine.MachineState{ID: "123"},
+				Units: map[string]*job.Unit{
+					"ping.service": &job.Unit{Name: "ping.service"},
+				},
+			},
+			job:  newTestJobWithXFleetValues(t, "Conflicts=pong.service ping.service"),
+			want: job.JobActionUnschedule,
+		},
+
 		// no replaces found
 		{
 			dState: &AgentState{

--- a/agent/state_test.go
+++ b/agent/state_test.go
@@ -82,6 +82,86 @@ func TestHasConflicts(t *testing.T) {
 			want:     true,
 			conflict: "bar.service",
 		},
+
+		// existing job has conflict with new job,
+		// one of multiple conflicts defined in a single line
+		{
+			cState: &AgentState{
+				MState: &machine.MachineState{ID: "XXX"},
+				Units: map[string]*job.Unit{
+					"bar.service": &job.Unit{
+						Name: "bar.service",
+						Unit: fleetUnit(t, "Conflicts=foo.service bar.service"),
+					},
+				},
+			},
+			job: &job.Job{
+				Name: "foo.service",
+				Unit: unit.UnitFile{},
+			},
+			want:     true,
+			conflict: "bar.service",
+		},
+
+		// existing job has conflict with new job,
+		// one of multiple conflicts over multiple lines
+		{
+			cState: &AgentState{
+				MState: &machine.MachineState{ID: "XXX"},
+				Units: map[string]*job.Unit{
+					"bar.service": &job.Unit{
+						Name: "bar.service",
+						Unit: fleetUnit(t, "Conflicts=foo.service\nConflicts=bar.service"),
+					},
+				},
+			},
+			job: &job.Job{
+				Name: "foo.service",
+				Unit: unit.UnitFile{},
+			},
+			want:     true,
+			conflict: "bar.service",
+		},
+
+		// new job has conflict with existing job,
+		// one of multiple conflicts defined in a single line
+		{
+			cState: &AgentState{
+				MState: &machine.MachineState{ID: "XXX"},
+				Units: map[string]*job.Unit{
+					"bar.service": &job.Unit{
+						Name: "bar.service",
+						Unit: unit.UnitFile{},
+					},
+				},
+			},
+			job: &job.Job{
+				Name: "foo.service",
+				Unit: fleetUnit(t, "Conflicts=foo.service bar.service"),
+			},
+			want:     true,
+			conflict: "bar.service",
+		},
+
+		// new job has conflict with existing job,
+		// one of multiple conflicts over multiple lines
+		{
+			cState: &AgentState{
+				MState: &machine.MachineState{ID: "XXX"},
+				Units: map[string]*job.Unit{
+					"bar.service": &job.Unit{
+						Name: "bar.service",
+						Unit: unit.UnitFile{},
+					},
+				},
+			},
+			job: &job.Job{
+				Name: "foo.service",
+				Unit: fleetUnit(t, "Conflicts=foo.service\nConflicts=bar.service"),
+			},
+			want:     true,
+			conflict: "bar.service",
+		},
 	}
 
 	for i, tt := range tests {

--- a/functional/fixtures/units/conflict.multiple.0.service
+++ b/functional/fixtures/units/conflict.multiple.0.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Test Unit
+
+[Service]
+ExecStart=/bin/bash -c "while true; do echo Hello, World!; sleep 1; done"
+
+[X-Fleet]
+Conflicts=conflict.2.service conflict.1.service conflict.0.service

--- a/functional/fixtures/units/conflict.multiple.1.service
+++ b/functional/fixtures/units/conflict.multiple.1.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Test Unit
+
+[Service]
+ExecStart=/bin/bash -c "while true; do echo Hello, World!; sleep 1; done"
+
+[X-Fleet]
+Conflicts=conflict.2.service conflict.1.service conflict.0.service

--- a/functional/fixtures/units/conflict.multiple.2.service
+++ b/functional/fixtures/units/conflict.multiple.2.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Test Unit
+
+[Service]
+ExecStart=/bin/bash -c "while true; do echo Hello, World!; sleep 1; done"
+
+[X-Fleet]
+Conflicts=conflict.2.service
+Conflicts=conflict.1.service
+Conflicts=conflict.0.service

--- a/job/job.go
+++ b/job/job.go
@@ -220,8 +220,13 @@ func (j *Job) ValidateRequirements() error {
 // machine as this Job.
 func (j *Job) Conflicts() []string {
 	conflicts := make([]string, 0)
-	conflicts = append(conflicts, j.requirements()[deprecatedXPrefix+fleetConflicts]...)
-	conflicts = append(conflicts, j.requirements()[fleetConflicts]...)
+
+	ldConflicts := splitCombine(j.requirements()[deprecatedXPrefix+fleetConflicts])
+	conflicts = append(conflicts, ldConflicts...)
+
+	dConflicts := splitCombine(j.requirements()[fleetConflicts])
+	conflicts = append(conflicts, dConflicts...)
+
 	return conflicts
 }
 
@@ -331,4 +336,15 @@ func unitPrintf(s string, nu unit.UnitNameInfo) (out string) {
 func isTruthyValue(s string) bool {
 	chl := strings.ToLower(s)
 	return chl == "true" || chl == "yes" || chl == "1" || chl == "on" || chl == "t"
+}
+
+// splitCombine retrieves each word from an input string slice, to put each
+// one again into a single slice.
+func splitCombine(inStrs []string) []string {
+	outStrs := make([]string, 0)
+	for _, str := range inStrs {
+		inStrs := strings.Fields(str)
+		outStrs = append(outStrs, inStrs...)
+	}
+	return outStrs
 }

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -77,6 +77,21 @@ Description=Testing
 [X-Fleet]
 Conflicts=*bar*
 `, []string{"*bar*"}},
+		{``, []string{}},
+		{`[Unit]
+Description=Testing
+
+[X-Fleet]
+Conflicts=*bar* *foo*
+`, []string{"*bar*", "*foo*"}},
+		{``, []string{}},
+		{`[Unit]
+Description=Testing
+
+[X-Fleet]
+Conflicts=*bar*
+Conflicts=*foo*
+`, []string{"*bar*", "*foo*"}},
 	}
 	for i, tt := range testCases {
 		j := NewJob("echo.service", *newUnit(t, tt.contents))


### PR DESCRIPTION
So far when parsing values defined in the `Conflicts` option, it hasn't taken multiple values into account. So let's allow `j.Conflicts()` to parse multiple values, splitting with white-space delimiters into a slice of each string.

In `AgentState.HasConflict()`, split a common part for checking if a unit belongs to a Conflicts list, into a new helper `hasStringInSlice()` Also return a slice of conflicted strings, instead of a single string. Doing that, `HasConflict()` can be more readable.

Also extend unit tests and functional tests.

Fixes https://github.com/coreos/fleet/issues/1245
