### PR TITLE
fleetd: allow users to turn off force flag for systemd.LinkUnitFiles()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	UnitsDirectory          string
 	SystemdUser             bool
 	AuthorizedKeysFile      string
+	SystemdLinkUnitForce    bool
 }
 
 func (c *Config) Capabilities() machine.Capabilities {

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -96,6 +96,7 @@ func Main() {
 	cfgset.Bool("disable_watches", false, "Disable the use of etcd watches. Increases scheduling latency")
 	cfgset.Bool("verify_units", false, "DEPRECATED - This option is ignored")
 	cfgset.String("authorized_keys_file", "", "DEPRECATED - This option is ignored")
+	cfgset.Bool("systemd_link_unit_force", false, "When true, turn on force flag for LinkUnitFiles)")
 
 	globalconf.Register("", cfgset)
 	cfg, err := getConfig(cfgset, *cfgPath)
@@ -237,6 +238,7 @@ func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error
 		SystemdUser:             (*flagset.Lookup("systemd_user")).Value.(flag.Getter).Get().(bool),
 		TokenLimit:              (*flagset.Lookup("token_limit")).Value.(flag.Getter).Get().(int),
 		AuthorizedKeysFile:      (*flagset.Lookup("authorized_keys_file")).Value.(flag.Getter).Get().(string),
+		SystemdLinkUnitForce:    (*flagset.Lookup("systemd_link_unit_force")).Value.(flag.Getter).Get().(bool),
 	}
 
 	if cfg.VerifyUnits {

--- a/functional/systemd_test.go
+++ b/functional/systemd_test.go
@@ -35,7 +35,7 @@ func TestSystemdUnitFlow(t *testing.T) {
 	}
 	defer os.RemoveAll(uDir)
 
-	mgr, err := systemd.NewSystemdUnitManager(uDir, false)
+	mgr, err := systemd.NewSystemdUnitManager(uDir, false, false)
 	if err != nil {
 		t.Fatalf("Failed initializing SystemdUnitManager: %v", err)
 	}

--- a/registry/rpc/registrymux_test.go
+++ b/registry/rpc/registrymux_test.go
@@ -94,7 +94,7 @@ func TestRegistryMuxUnitManagement(t *testing.T) {
 		PublicIP: "127.0.0.1",
 		Metadata: make(map[string]string, 0),
 	}
-	mgr, err := systemd.NewSystemdUnitManager(uDir, false)
+	mgr, err := systemd.NewSystemdUnitManager(uDir, false, false)
 	if err != nil {
 		// NOTE: ideally we should fail with t.Fatalf(), but then it would always
 		// fail on travis CI, because apparently systemd dbus socket is not

--- a/server/server.go
+++ b/server/server.go
@@ -76,7 +76,7 @@ func New(cfg config.Config, listeners []net.Listener) (*Server, error) {
 		return nil, err
 	}
 
-	mgr, err := systemd.NewSystemdUnitManager(cfg.UnitsDirectory, cfg.SystemdUser)
+	mgr, err := systemd.NewSystemdUnitManager(cfg.UnitsDirectory, cfg.SystemdUser, cfg.SystemdLinkUnitForce)
 	if err != nil {
 		return nil, err
 	}

--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -31,12 +31,13 @@ import (
 type systemdUnitManager struct {
 	systemd  *dbus.Conn
 	unitsDir string
+	luForce  bool
 
 	hashes map[string]unit.Hash
 	mutex  sync.RWMutex
 }
 
-func NewSystemdUnitManager(uDir string, systemdUser bool) (*systemdUnitManager, error) {
+func NewSystemdUnitManager(uDir string, systemdUser bool, systemdLUForce bool) (*systemdUnitManager, error) {
 	var systemd *dbus.Conn
 	var err error
 	if systemdUser {
@@ -60,6 +61,7 @@ func NewSystemdUnitManager(uDir string, systemdUser bool) (*systemdUnitManager, 
 	mgr := systemdUnitManager{
 		systemd:  systemd,
 		unitsDir: uDir,
+		luForce:  systemdLUForce,
 		hashes:   hashes,
 		mutex:    sync.RWMutex{},
 	}
@@ -265,7 +267,7 @@ func (m *systemdUnitManager) writeUnit(name string, contents string) error {
 		return err
 	}
 
-	_, err = m.systemd.LinkUnitFiles([]string{ufPath}, true, true)
+	_, err = m.systemd.LinkUnitFiles([]string{ufPath}, true, m.luForce)
 	return err
 }
 


### PR DESCRIPTION
So far `systemd.LinkUnitFiles()` has been called with the force option turned on. That was one of the reasons of performance issues.

Let's introduce an option `systemd_link_unit_force`, false by default. Users can set the option in `fleetd.conf`. That option will be passed directly to `systemd.LinkUnitFiles()`.

/cc @hectorj2f 
Fixes https://github.com/coreos/fleet/issues/1694