### PR TITLE
agent,engine: fix bugs in rescheduling for replaced units

### DIFF
--- a/agent/state.go
+++ b/agent/state.go
@@ -156,3 +156,11 @@ func (as *AgentState) AbleToRun(j *job.Job) (jobAction job.JobAction, errstr str
 
 	return job.JobActionSchedule, ""
 }
+
+func (as *AgentState) GetReplacedUnit(j *job.Job) (string, error) {
+	cExists, replaced := as.hasReplace(j.Name, j.Replaces())
+	if !cExists {
+		return "", fmt.Errorf("cannot find units to be replaced for Unit(%s)", j.Name)
+	}
+	return replaced, nil
+}

--- a/agent/state.go
+++ b/agent/state.go
@@ -124,15 +124,15 @@ func globMatches(pattern, target string) bool {
 //   - Agent must have all required Peers of the Job scheduled locally (if any)
 //   - Job must not conflict with any other Units scheduled to the agent
 //   - Job must specially handle replaced units to be rescheduled
-func (as *AgentState) AbleToRun(j *job.Job) (bool, string) {
+func (as *AgentState) AbleToRun(j *job.Job) (jobAction job.JobAction, errstr string) {
 	if tgt, ok := j.RequiredTarget(); ok && !as.MState.MatchID(tgt) {
-		return false, fmt.Sprintf("agent ID %q does not match required %q", as.MState.ID, tgt)
+		return job.JobActionUnschedule, fmt.Sprintf("agent ID %q does not match required %q", as.MState.ID, tgt)
 	}
 
 	metadata := j.RequiredTargetMetadata()
 	if len(metadata) != 0 {
 		if !machine.HasMetadata(as.MState, metadata) {
-			return false, "local Machine metadata insufficient"
+			return job.JobActionUnschedule, "local Machine metadata insufficient"
 		}
 	}
 
@@ -140,20 +140,19 @@ func (as *AgentState) AbleToRun(j *job.Job) (bool, string) {
 	if len(peers) != 0 {
 		for _, peer := range peers {
 			if !as.unitScheduled(peer) {
-				return false, fmt.Sprintf("required peer Unit(%s) is not scheduled locally", peer)
+				return job.JobActionUnschedule, fmt.Sprintf("required peer Unit(%s) is not scheduled locally", peer)
 			}
 		}
 	}
 
 	if cExists, cJobName := as.HasConflict(j.Name, j.Conflicts()); cExists {
-		return false, fmt.Sprintf("found conflict with locally-scheduled Unit(%s)", cJobName)
+		return job.JobActionUnschedule, fmt.Sprintf("found conflict with locally-scheduled Unit(%s)", cJobName)
 	}
 
-	// Handle Replace option specially, by returning a special string
-	// "jobreschedule" as reason.
-	if cExists, _ := as.hasReplace(j.Name, j.Replaces()); cExists {
-		return false, job.JobReschedule
+	// Handle Replace option specially for rescheduling the unit
+	if cExists, cJobName := as.hasReplace(j.Name, j.Replaces()); cExists {
+		return job.JobActionReschedule, fmt.Sprintf("found replace with locally-scheduled Unit(%s)", cJobName)
 	}
 
-	return true, ""
+	return job.JobActionSchedule, ""
 }

--- a/engine/scheduler.go
+++ b/engine/scheduler.go
@@ -41,7 +41,7 @@ func (lls *leastLoadedScheduler) Decide(clust *clusterState, j *job.Job) (*decis
 
 	var target *agent.AgentState
 	for _, as := range agents {
-		if able, _ := as.AbleToRun(j); !able {
+		if act, _ := as.AbleToRun(j); act != job.JobActionSchedule {
 			continue
 		}
 

--- a/engine/scheduler.go
+++ b/engine/scheduler.go
@@ -28,6 +28,7 @@ type decision struct {
 
 type Scheduler interface {
 	Decide(*clusterState, *job.Job) (*decision, error)
+	DecideReschedule(*clusterState, *job.Job) (*decision, error)
 }
 
 type leastLoadedScheduler struct{}
@@ -41,7 +42,7 @@ func (lls *leastLoadedScheduler) Decide(clust *clusterState, j *job.Job) (*decis
 
 	var target *agent.AgentState
 	for _, as := range agents {
-		if act, _ := as.AbleToRun(j); act != job.JobActionSchedule {
+		if act, _ := as.AbleToRun(j); act == job.JobActionUnschedule {
 			continue
 		}
 
@@ -51,6 +52,42 @@ func (lls *leastLoadedScheduler) Decide(clust *clusterState, j *job.Job) (*decis
 	}
 
 	if target == nil {
+		return nil, fmt.Errorf("no agents able to run job")
+	}
+
+	dec := decision{
+		machineID: target.MState.ID,
+	}
+
+	return &dec, nil
+}
+
+// DecideReschedule() decides scheduling in a much simpler way than
+// Decide(). It just tries to find out another free machine to be scheduled,
+// except for the current target machine. It does not have to run
+// as.AbleToRun(), because its job action must have been already decided
+// before getting into the function.
+func (lls *leastLoadedScheduler) DecideReschedule(clust *clusterState, j *job.Job) (*decision, error) {
+	agents := lls.sortedAgents(clust)
+
+	if len(agents) == 0 {
+		return nil, fmt.Errorf("zero agents available")
+	}
+
+	found := false
+	var target *agent.AgentState
+	for _, as := range agents {
+		if as.MState.ID == j.TargetMachineID {
+			continue
+		}
+
+		as := as
+		target = as
+		found = true
+		break
+	}
+
+	if !found {
 		return nil, fmt.Errorf("no agents able to run job")
 	}
 

--- a/functional/fixtures/units/replace-kick0.service
+++ b/functional/fixtures/units/replace-kick0.service
@@ -3,3 +3,6 @@ Description=Test Unit
 
 [Service]
 ExecStart=/bin/bash -c "while true; do echo Hello, World!; sleep 1; done"
+
+[X-Fleet]
+Replaces=replace.0.service

--- a/functional/fixtures/units/replace.2.service
+++ b/functional/fixtures/units/replace.2.service
@@ -3,3 +3,6 @@ Description=Test Unit
 
 [Service]
 ExecStart=/bin/bash -c "while true; do echo Hello, World!; sleep 1; done"
+
+[X-Fleet]
+MachineOf=replace.1.service

--- a/job/job.go
+++ b/job/job.go
@@ -23,13 +23,16 @@ import (
 )
 
 type JobState string
+type JobAction string
 
 const (
 	JobStateInactive = JobState("inactive")
 	JobStateLoaded   = JobState("loaded")
 	JobStateLaunched = JobState("launched")
 
-	JobReschedule = "jobreschedule"
+	JobActionSchedule   = JobAction("job_action_schedule")
+	JobActionUnschedule = JobAction("job_action_unschedule")
+	JobActionReschedule = JobAction("job_action_reschedule")
 )
 
 // fleet-specific unit file requirement keys.


### PR DESCRIPTION
So far in engine reconciler, `decide()` returns a bool variable to determine whether it's possible to schedule or not. Reschedule was not handled in a proper way.

So let's create a new tri-state for `job.JobAction`, i.e. `JobActionSchedule`, `JobActionUnschedule`, and `JobActionReschedule`. And return the tri-state variable instead of bool. That way `AbleToRun()` can check return values from `HasConflict()` and `HasReplace()` in a correct manner.

With that, we can fix bugs in rescheduling for replaced units. While the `'Replaces'` option has been supported since https://github.com/coreos/fleet/pull/1572, the engine didn't actually unschedule units to be replaced. It was a bug.

So let's implement `GetReplacedUnit()` to expose the replaced unit from `AgentState` to the engine reconciler. And make the engine reconciler unschedule the replaced unit, and schedule the current unit. The engine scheduler's decision structure needs to also track if the unit needs to be rescheduled, to be used by the scheduling path.
