### PR TITLE
functional: fix error from message change from systemctl status

### DIFF
--- a/functional/platform/cluster.go
+++ b/functional/platform/cluster.go
@@ -32,6 +32,7 @@ type Cluster interface {
 	ReplaceMember(Member) (Member, error)
 	Members() []Member
 	MemberCommand(Member, ...string) (string, error)
+	MemberCommandStderr(Member, ...string) (string, string, error)
 	Destroy(t *testing.T) error
 
 	// client operations


### PR DESCRIPTION
Since systemd v231, `TestNodeShutdown` fails with the following message.

```
--- FAIL: TestNodeShutdown (fleet.conf=[enable_grpc=false]) (8.98s)
        node_test.go:83: Unit hello.service not reported as inactive:
```

It's because of behavioral change of `"systemctl status"`. Until systemd v230, `"systemctl status hello.service"` has printed

```
Loaded: not-found (Reason: No such file or directory)
Active: inactive (dead)
```

to stdout, when hello.service is not active. So the functional test `TestNodeShutdown` has expected a string `"Active: inactive"` in the message from stdout.

Since systemd v231, however, the output string has become

```
Unit hello.service could not be found
```
And it's printed to stderr, instead of stdout.

As `MemberCommand()` doesn't return stderr at all, we need to make it return stderr too. Changing prototype of `MemberCommand()` however requires a lot of changes all over functional tests. So let's add another helper `MemberCommandStderr()`, a distinct helper that returns both stdout and stderr. Then we can change only `TestNodeShutdown()`
without touching other tests.

In the long run, we need to change `MemberCommand()` directly, removing `MemberCommandStderr()`.

Fixes https://github.com/coreos/fleet/issues/1699