### PR TITLE
functional: reduce number of tests and total running time

### DIFF
--- a/functional/machines_test.go
+++ b/functional/machines_test.go
@@ -90,25 +90,11 @@ func TestMachinesList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	testMachinesListBadNextPageToken(t, m)
 }
 
-func TestMachinesListBadNextPageToken(t *testing.T) {
-	cluster, err := platform.NewNspawnCluster("smoke")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cluster.Destroy(t)
-
-	m, err := cluster.CreateMember()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = cluster.WaitForNMachines(m, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+func testMachinesListBadNextPageToken(t *testing.T, m platform.Member) {
 	// Send an invalid GET request, should return failure
 	resp, err := getHTTPResponse("GET", m.Endpoint()+"/fleet/v1/machines?nextPageToken=EwBMLg==", "")
 	if err != nil {
@@ -239,29 +225,11 @@ func TestMachinesPatchAddModify(t *testing.T) {
 			}
 		}
 	}
+
+	testMachinesPatchDelete(t, m0, m1)
 }
 
-func TestMachinesPatchDelete(t *testing.T) {
-	cluster, err := platform.NewNspawnCluster("smoke")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cluster.Destroy(t)
-
-	m0, err := cluster.CreateMember()
-	if err != nil {
-		t.Fatal(err)
-	}
-	m1, err := cluster.CreateMember()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = cluster.WaitForNMachines(m0, 2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+func testMachinesPatchDelete(t *testing.T, m0 platform.Member, m1 platform.Member) {
 	sm0 := &fxSchemaMachine{
 		Id: m0.ID(),
 		Metadata: map[string]string{

--- a/functional/metadata_test.go
+++ b/functional/metadata_test.go
@@ -86,7 +86,7 @@ func TestTemplatesWithSpecifiersInMetadata(t *testing.T) {
 		}
 	}
 
-	if stdout, stderr, err := cluster.Fleetctl(m0, "start", "--block-attempts=20", "fixtures/units/metadata@invalid.service"); err == nil {
+	if stdout, stderr, err := cluster.Fleetctl(m0, "start", "--block-attempts=5", "fixtures/units/metadata@invalid.service"); err == nil {
 		t.Fatalf("metadata@invalid unit should not be scheduled: \nstdout: %s\nstderr: %s", stdout, stderr)
 	}
 }

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -72,10 +72,14 @@ func TestUnitRunnable(t *testing.T) {
 	}
 }
 
-// TestUnitSubmit checks if a unit becomes submitted and destroyed successfully.
-// First it submits a unit, and destroys the unit, verifies it's destroyed,
-// finally submits the unit again.
-func TestUnitSubmit(t *testing.T) {
+// TestUnitLaunch runs 3 tests: submit, load and start
+// - checks whether a command "fleetctl submit hello.service" works or not.
+// - checks whether a command "fleetctl load hello.service" works or not.
+// - checks whether a command "fleetctl start hello.service" works or not.
+// Each one also checks if a unit becomes destroyed successfully.
+// For example, first it submits a unit, and destroys the unit, verifies
+// it's destroyed, finally submits the unit again.
+func TestUnitLaunch(t *testing.T) {
 	cluster, err := platform.NewNspawnCluster("smoke")
 	if err != nil {
 		t.Fatal(err)
@@ -94,72 +98,25 @@ func TestUnitSubmit(t *testing.T) {
 	if err := unitStartCommon(cluster, m, "submit", 2); err != nil {
 		t.Fatal(err)
 	}
-}
-
-// TestUnitLoad checks if a unit becomes loaded and unloaded successfully.
-// First it load a unit, and unloads the unit, verifies it's unloaded,
-// finally loads the unit again.
-func TestUnitLoad(t *testing.T) {
-	cluster, err := platform.NewNspawnCluster("smoke")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cluster.Destroy(t)
-
-	m, err := cluster.CreateMember()
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = cluster.WaitForNMachines(m, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	if err := unitStartCommon(cluster, m, "load", 2); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func TestUnitStart(t *testing.T) {
-	cluster, err := platform.NewNspawnCluster("smoke")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cluster.Destroy(t)
-
-	m, err := cluster.CreateMember()
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = cluster.WaitForNMachines(m, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	if err := unitStartCommon(cluster, m, "start", 1); err != nil {
 		t.Fatal(err)
 	}
 }
 
-// TestUnitSubmitReplace() tests whether a command "fleetctl submit --replace
-// hello.service" works or not.
-func TestUnitSubmitReplace(t *testing.T) {
+// TestUnitLaunchReplace() runs 3 tests: submit, load, and start.
+// - checks whether a command "fleetctl submit --replace hello.service" works or not.
+// - checks whether a command "fleetctl load --replace hello.service" works or not.
+// - checks whether a command "fleetctl start --replace hello.service" works or not.
+func TestUnitLaunchReplace(t *testing.T) {
 	if err := replaceUnitCommon(t, "submit", 2); err != nil {
 		t.Fatal(err)
 	}
-}
-
-// TestUnitLoadReplace() tests whether a command "fleetctl load --replace
-// hello.service" works or not.
-func TestUnitLoadReplace(t *testing.T) {
 	if err := replaceUnitCommon(t, "load", 2); err != nil {
 		t.Fatal(err)
 	}
-}
-
-// TestUnitStartReplace() tests whether a command "fleetctl start --replace
-// hello.service" works or not.
-func TestUnitStartReplace(t *testing.T) {
 	if err := replaceUnitCommon(t, "start", 1); err != nil {
 		t.Fatal(err)
 	}

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -91,7 +91,7 @@ func TestUnitSubmit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := unitStartCommon(cluster, m, "submit", 9); err != nil {
+	if err := unitStartCommon(cluster, m, "submit", 2); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -115,7 +115,7 @@ func TestUnitLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := unitStartCommon(cluster, m, "load", 6); err != nil {
+	if err := unitStartCommon(cluster, m, "load", 2); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -136,7 +136,7 @@ func TestUnitStart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := unitStartCommon(cluster, m, "start", 3); err != nil {
+	if err := unitStartCommon(cluster, m, "start", 1); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -144,7 +144,7 @@ func TestUnitStart(t *testing.T) {
 // TestUnitSubmitReplace() tests whether a command "fleetctl submit --replace
 // hello.service" works or not.
 func TestUnitSubmitReplace(t *testing.T) {
-	if err := replaceUnitCommon(t, "submit", 9); err != nil {
+	if err := replaceUnitCommon(t, "submit", 2); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -152,7 +152,7 @@ func TestUnitSubmitReplace(t *testing.T) {
 // TestUnitLoadReplace() tests whether a command "fleetctl load --replace
 // hello.service" works or not.
 func TestUnitLoadReplace(t *testing.T) {
-	if err := replaceUnitCommon(t, "load", 6); err != nil {
+	if err := replaceUnitCommon(t, "load", 2); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -160,7 +160,7 @@ func TestUnitLoadReplace(t *testing.T) {
 // TestUnitStartReplace() tests whether a command "fleetctl start --replace
 // hello.service" works or not.
 func TestUnitStartReplace(t *testing.T) {
-	if err := replaceUnitCommon(t, "start", 3); err != nil {
+	if err := replaceUnitCommon(t, "start", 1); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Functional test seems to have a limitation of 40 tests in total. When the number of tests becomes more than 40, no more cluster member can be created, so that test ends up with hanging mysteriously. To avoid that, let's reduce number of tests, mainly for dynamic metadata tests as well as unit action tests. It's just squashing similar tests.

As go test natively has an upper limit of 600sec in total for all tests, we should reduce total running time. So let's reduce number of units to be tested in the unit state tests, and reduce maximum block attempts for the metadata template test. This will fix the failure on semaphoreci, which has suddenly appeared since the dynamic metadata tests. This should make tests work for now. In the long run, it would be necessary to be able to tune the timeout.
