### PR TITLE
functional: close DBUS connections after running systemd commands

### DIFF
--- a/functional/platform/nspawn.go
+++ b/functional/platform/nspawn.go
@@ -681,6 +681,7 @@ func (nc *nspawnCluster) systemdReload() error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 	conn.Reload()
 	return nil
 }
@@ -690,6 +691,7 @@ func (nc *nspawnCluster) systemd(unitName, exec string) error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 
 	props := []dbus.Property{
 		dbus.PropExecStart(strings.Split(exec, " "), false),


### PR DESCRIPTION
As described in https://github.com/coreos/fleet/pull/1704, functional test has a bug hitting an upper limit of ~40 tests in total. That's actually an issue of DBUS connections remaining opened even after nspawn containers got successfully terminated. That's why the number of unix sockets grows up to 256.

```
$ netstat -nap | grep /var/run/dbus/system_bus_socket | wc -l
256
```

From that moment on, functional test hangs mysteriously. Sometimes users could see errors like `"The maximum number of active connections for UID 0 has been reached."`

Its reason is that every DBUS connection was never closed. The more tests we add, the more stale DBUS connections we have. This bug has existed since the beginning.

Fix it by adding `conn.Close()` after running systemd commands.