### PR TITLE
scripts: add scripts for building Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+
+ADD fleetd /usr/local/bin/
+ADD fleetctl /usr/local/bin/
+
+ARG FLEET_IMG_VER
+ENV FLEET_IMG_VER ${FLEET_IMG_VER:-v0.13}
+RUN echo $FLEET_IMG_VER
+
+# Define default command.
+CMD ["/usr/local/bin/fleetd"]

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -e
+
+VER=$1
+PROJ="fleet"
+
+if [ -z "$1" ]; then
+	echo "Usage: ${0} VERSION" >> /dev/stderr
+	exit 255
+fi
+
+set -u
+
+function setup_env {
+	local proj=${1}
+	local ver=${2}
+
+	if [ ! -d ${proj} ]; then
+		git clone https://github.com/coreos/${proj}
+	fi
+
+	pushd ${proj} >/dev/null
+		git checkout master
+		git fetch --all
+		git reset --hard origin/master
+		git checkout $ver
+	popd >/dev/null
+}
+
+
+function package {
+	local target=${1}
+	local srcdir="${2}/bin"
+
+	local ccdir="${srcdir}/${GOOS}_${GOARCH}"
+	if [ -d ${ccdir} ]; then
+		srcdir=${ccdir}
+	fi
+	local ext=""
+	for bin in fleetd fleetctl; do
+		cp ${srcdir}/${bin} ${target}/${bin}${ext}
+	done
+
+	cp fleet/README.md ${target}/README.md
+}
+
+function main {
+	mkdir -p release
+	cd release
+	setup_env ${PROJ} ${VER}
+
+	for os in darwin linux; do
+		export GOOS=${os}
+		export GOARCH="amd64"
+
+		pushd fleet >/dev/null
+			GO_LDFLAGS="-s" ./build
+		popd >/dev/null
+
+		TARGET="fleet-${VER}-${GOOS}-${GOARCH}"
+		mkdir -p ${TARGET}
+		package ${TARGET} ${PROJ}
+
+		if [ ${GOOS} == "linux" ]; then
+			tar cfz ${TARGET}.tar.gz ${TARGET}
+			echo "Wrote release/${TARGET}.tar.gz"
+		else
+			zip -qr ${TARGET}.zip ${TARGET}
+			echo "Wrote release/${TARGET}.zip"
+		fi
+	done
+}
+
+main

--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Build a docker image to be published to quay.io.
+# Run with a version parameter:
+#
+#  $ ./scripts/build-docker v0.13
+#
+# or just run without the version number, then it will simply take the current version.
+#
+#  $ ./scripts/build-docker
+
+VERSION=${1}
+if [ -z "$VERSION" ]; then
+	VERSION=$(git describe)
+	if [ -z "$VERSION" ]; then
+		VERSION="latest"
+	fi
+fi
+
+BINARYDIR=${BINARYDIR:-release/fleet-${VERSION}-linux-amd64}
+BUILDDIR=${BUILDDIR:-release}
+
+IMAGEDIR=${BUILDDIR}/image-docker
+
+mkdir -p ${IMAGEDIR} ${BINARYDIR}
+cp ${BINARYDIR}/fleetd ${BINARYDIR}/fleetctl ${IMAGEDIR}
+
+cp ./Dockerfile ${IMAGEDIR}/Dockerfile
+
+docker build -t quay.io/coreos/fleet:${VERSION} --build-arg FLEET_IMG_VER=${VERSION} ${IMAGEDIR}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Build all release binaries and images to directory ./release.
+# Run from repository root.
+#
+set -e
+
+VERSION=$1
+if [ -z "${VERSION}" ]; then
+	echo "Usage: ${0} VERSION" >> /dev/stderr
+	exit 255
+fi
+
+if ! command -v acbuild >/dev/null; then
+    echo "cannot find acbuild"
+    exit 1
+fi
+
+if ! command -v docker >/dev/null; then
+    echo "cannot find docker"
+    exit 1
+fi
+
+FLEET_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+# build-aci is located in the top src directory until v0.13.0,
+# while it's under ./scripts/ since v1.0.0.
+BUILD_ACI="./scripts/build-aci"
+if [ ! -x "${BUILD_ACI}" ]; then
+	BUILD_ACI="./build-aci"
+fi
+
+pushd ${FLEET_ROOT} >/dev/null
+	echo Building fleet binaries...
+	./scripts/build-binary ${VERSION}
+	echo Building aci image...
+	BINARYDIR=release/fleet-${VERSION}-linux-amd64 BUILDDIR=release ${BUILD_ACI} ${VERSION}
+	echo Building docker image...
+	BINARYDIR=release/fleet-${VERSION}-linux-amd64 BUILDDIR=release ./scripts/build-docker ${VERSION}
+popd >/dev/null


### PR DESCRIPTION
Add Dockerfile as well as new scripts, to be able to build Docker images to be uploaded to `quay.io/coreos/fleet`. Structure under scripts directory is similar to that of etcd.

See also https://github.com/coreos/fleet/issues/1705.