### PR TITLE
Revert workaround for reducing tests

### DIFF
--- a/functional/machines_test.go
+++ b/functional/machines_test.go
@@ -90,11 +90,25 @@ func TestMachinesList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	testMachinesListBadNextPageToken(t, m)
 }
 
-func testMachinesListBadNextPageToken(t *testing.T, m platform.Member) {
+func TestMachinesListBadNextPageToken(t *testing.T) {
+	cluster, err := platform.NewNspawnCluster("smoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cluster.Destroy(t)
+
+	m, err := cluster.CreateMember()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = cluster.WaitForNMachines(m, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// Send an invalid GET request, should return failure
 	resp, err := getHTTPResponse("GET", m.Endpoint()+"/fleet/v1/machines?nextPageToken=EwBMLg==", "")
 	if err != nil {
@@ -225,11 +239,29 @@ func TestMachinesPatchAddModify(t *testing.T) {
 			}
 		}
 	}
-
-	testMachinesPatchDelete(t, m0, m1)
 }
 
-func testMachinesPatchDelete(t *testing.T, m0 platform.Member, m1 platform.Member) {
+func TestMachinesPatchDelete(t *testing.T) {
+	cluster, err := platform.NewNspawnCluster("smoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cluster.Destroy(t)
+
+	m0, err := cluster.CreateMember()
+	if err != nil {
+		t.Fatal(err)
+	}
+	m1, err := cluster.CreateMember()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = cluster.WaitForNMachines(m0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	sm0 := &fxSchemaMachine{
 		Id: m0.ID(),
 		Metadata: map[string]string{

--- a/functional/metadata_test.go
+++ b/functional/metadata_test.go
@@ -86,7 +86,7 @@ func TestTemplatesWithSpecifiersInMetadata(t *testing.T) {
 		}
 	}
 
-	if stdout, stderr, err := cluster.Fleetctl(m0, "start", "--block-attempts=5", "fixtures/units/metadata@invalid.service"); err == nil {
+	if stdout, stderr, err := cluster.Fleetctl(m0, "start", "--block-attempts=20", "fixtures/units/metadata@invalid.service"); err == nil {
 		t.Fatalf("metadata@invalid unit should not be scheduled: \nstdout: %s\nstderr: %s", stdout, stderr)
 	}
 }

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -72,14 +72,10 @@ func TestUnitRunnable(t *testing.T) {
 	}
 }
 
-// TestUnitLaunch runs 3 tests: submit, load and start
-// - checks whether a command "fleetctl submit hello.service" works or not.
-// - checks whether a command "fleetctl load hello.service" works or not.
-// - checks whether a command "fleetctl start hello.service" works or not.
-// Each one also checks if a unit becomes destroyed successfully.
-// For example, first it submits a unit, and destroys the unit, verifies
-// it's destroyed, finally submits the unit again.
-func TestUnitLaunch(t *testing.T) {
+// TestUnitSubmit checks if a unit becomes submitted and destroyed successfully.
+// First it submits a unit, and destroys the unit, verifies it's destroyed,
+// finally submits the unit again.
+func TestUnitSubmit(t *testing.T) {
 	cluster, err := platform.NewNspawnCluster("smoke")
 	if err != nil {
 		t.Fatal(err)
@@ -95,29 +91,76 @@ func TestUnitLaunch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := unitStartCommon(cluster, m, "submit", 2); err != nil {
-		t.Fatal(err)
-	}
-	if err := unitStartCommon(cluster, m, "load", 2); err != nil {
-		t.Fatal(err)
-	}
-	if err := unitStartCommon(cluster, m, "start", 1); err != nil {
+	if err := unitStartCommon(cluster, m, "submit", 9); err != nil {
 		t.Fatal(err)
 	}
 }
 
-// TestUnitLaunchReplace() runs 3 tests: submit, load, and start.
-// - checks whether a command "fleetctl submit --replace hello.service" works or not.
-// - checks whether a command "fleetctl load --replace hello.service" works or not.
-// - checks whether a command "fleetctl start --replace hello.service" works or not.
-func TestUnitLaunchReplace(t *testing.T) {
-	if err := replaceUnitCommon(t, "submit", 2); err != nil {
+// TestUnitLoad checks if a unit becomes loaded and unloaded successfully.
+// First it load a unit, and unloads the unit, verifies it's unloaded,
+// finally loads the unit again.
+func TestUnitLoad(t *testing.T) {
+	cluster, err := platform.NewNspawnCluster("smoke")
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := replaceUnitCommon(t, "load", 2); err != nil {
+	defer cluster.Destroy(t)
+
+	m, err := cluster.CreateMember()
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := replaceUnitCommon(t, "start", 1); err != nil {
+	_, err = cluster.WaitForNMachines(m, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := unitStartCommon(cluster, m, "load", 6); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnitStart(t *testing.T) {
+	cluster, err := platform.NewNspawnCluster("smoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cluster.Destroy(t)
+
+	m, err := cluster.CreateMember()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cluster.WaitForNMachines(m, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := unitStartCommon(cluster, m, "start", 3); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUnitSubmitReplace() tests whether a command "fleetctl submit --replace
+// hello.service" works or not.
+func TestUnitSubmitReplace(t *testing.T) {
+	if err := replaceUnitCommon(t, "submit", 9); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUnitLoadReplace() tests whether a command "fleetctl load --replace
+// hello.service" works or not.
+func TestUnitLoadReplace(t *testing.T) {
+	if err := replaceUnitCommon(t, "load", 6); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUnitStartReplace() tests whether a command "fleetctl start --replace
+// hello.service" works or not.
+func TestUnitStartReplace(t *testing.T) {
+	if err := replaceUnitCommon(t, "start", 3); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This reverts commit 0f8467201adc16abe33d0f007ccafc81b5bd5858, and commit f81c3b2e9ea2df2f232c17367291e0b29ee87f0d.
So it reverts https://github.com/coreos/fleet/pull/1704.