### PR TITLE
travis,functional: change golang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: go
 matrix:
   include:
-    - go: 1.5.4
+    - go: 1.5.x
       env: GO15VENDOREXPERIMENT=1
-    - go: 1.6.3
-    - go: 1.7.1
+    - go: 1.6.x
+    - go: 1.7.x
     - go: tip
   allow_failures:
     - go: tip

--- a/functional/provision/install_go.sh
+++ b/functional/provision/install_go.sh
@@ -6,7 +6,7 @@ HOME=$(getent passwd "${USER_ID}" | cut -d: -f6)
 export GOROOT=${HOME}/go
 export PATH=${HOME}/go/bin:${PATH}
 
-gover=1.7.1
+gover=1.7.3
 gotar=go${gover}.linux-amd64.tar.gz
 if [ ! -f ${HOME}/${gotar} ]; then
   # Remove unfinished archive when you press Ctrl+C


### PR DESCRIPTION
For travis, let's use the standard latest version of each stable golang tree. For example, 1.7.x == 1.7.3, 1.6.x == 1.6.3, and 1.5.x == 1.5.4. Doing that, we are able to avoid bumping the minor version every time.

For functional tests, upgrade go from 1.7.1 to 1.7.3.