### PR TITLE
fleetctl: increase default sleep time from 2 to 4 seconds

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -64,7 +64,7 @@ recommended to upgrade fleetctl to prevent incompatibility issues.
 	clientDriverEtcd = "etcd"
 
 	defaultEndpoint  = "unix:///var/run/fleet.sock"
-	defaultSleepTime = 2000 * time.Millisecond
+	defaultSleepTime = 4000 * time.Millisecond
 )
 
 var (

--- a/functional/metadata_test.go
+++ b/functional/metadata_test.go
@@ -86,7 +86,7 @@ func TestTemplatesWithSpecifiersInMetadata(t *testing.T) {
 		}
 	}
 
-	if stdout, stderr, err := cluster.Fleetctl(m0, "start", "--block-attempts=20", "fixtures/units/metadata@invalid.service"); err == nil {
+	if stdout, stderr, err := cluster.Fleetctl(m0, "start", "--block-attempts=10", "fixtures/units/metadata@invalid.service"); err == nil {
 		t.Fatalf("metadata@invalid unit should not be scheduled: \nstdout: %s\nstderr: %s", stdout, stderr)
 	}
 }

--- a/functional/unit_action_test.go
+++ b/functional/unit_action_test.go
@@ -91,7 +91,7 @@ func TestUnitSubmit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := unitStartCommon(cluster, m, "submit", 9); err != nil {
+	if err := unitStartCommon(cluster, m, "submit", 2); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -115,7 +115,7 @@ func TestUnitLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := unitStartCommon(cluster, m, "load", 6); err != nil {
+	if err := unitStartCommon(cluster, m, "load", 2); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -136,7 +136,7 @@ func TestUnitStart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := unitStartCommon(cluster, m, "start", 3); err != nil {
+	if err := unitStartCommon(cluster, m, "start", 2); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -144,7 +144,7 @@ func TestUnitStart(t *testing.T) {
 // TestUnitSubmitReplace() tests whether a command "fleetctl submit --replace
 // hello.service" works or not.
 func TestUnitSubmitReplace(t *testing.T) {
-	if err := replaceUnitCommon(t, "submit", 9); err != nil {
+	if err := replaceUnitCommon(t, "submit", 2); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -152,7 +152,7 @@ func TestUnitSubmitReplace(t *testing.T) {
 // TestUnitLoadReplace() tests whether a command "fleetctl load --replace
 // hello.service" works or not.
 func TestUnitLoadReplace(t *testing.T) {
-	if err := replaceUnitCommon(t, "load", 6); err != nil {
+	if err := replaceUnitCommon(t, "load", 2); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -160,7 +160,7 @@ func TestUnitLoadReplace(t *testing.T) {
 // TestUnitStartReplace() tests whether a command "fleetctl start --replace
 // hello.service" works or not.
 func TestUnitStartReplace(t *testing.T) {
-	if err := replaceUnitCommon(t, "start", 3); err != nil {
+	if err := replaceUnitCommon(t, "start", 2); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
As fleetctl start sometimes needs to wait up to 4 seconds until systemd active states get confirmed, we need to increase the `defaultSleepTime` from 2 to 4 seconds. Otherwise, a simple `"fleetctl start`" could sometimes fail with timeout.

Also reduce total running time of all tests, to avoid crash of functional tests resulted by the global timeout 600 secs.