### PR TITLE
fleetctl: remove unnecessary error messages

### DIFF
--- a/fleetctl/fleetctl.go
+++ b/fleetctl/fleetctl.go
@@ -1059,9 +1059,8 @@ func assertUnitState(name string, js job.JobState, out io.Writer) bool {
 		fmt.Fprintln(out, msg)
 		return nil
 	}
-	timeout, err := waitForState(fetchUnitState)
+	_, err := waitForState(fetchUnitState)
 	if err != nil {
-		log.Errorf("Failed to find unit %s within %v, err: %v", name, timeout, err)
 		return false
 	}
 
@@ -1237,13 +1236,13 @@ func waitForState(stateCheckFunc func() error) (time.Duration, error) {
 	for {
 		select {
 		case <-alarm:
-			return timeout, fmt.Errorf("Failed to fetch systemd active states within %v", timeout)
+			return timeout, fmt.Errorf("Failed to fetch states within %v", timeout)
 		case <-ticker:
 			err := stateCheckFunc()
 			if err == nil {
 				return timeout, nil
 			}
-			log.Debug("Retrying assertion of systemd active states. err: %v", err)
+			log.Debugf("Retrying assertion of states. err: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Even when `waitForState()` does not return correct states in defaultSleepTime, `"fleetctl start/stop"` works just fine, because `checkUnitState()` already waits until units got populated. So let's remove the unnecessary error message.

Use also `Debugf()` instead of `Debug()`.
Change also error messages into general ones, as it might be used in any cases for fetching unit states.